### PR TITLE
Small change to setup.py, "pip installable" directly from the repository now.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ]
 )
 
-import os, shutil
-shutil.rmtree(os.path.join(os.path.dirname(__file__), 'djangorestframework.egg-info'), True)
+#import os, shutil
+#shutil.rmtree(os.path.join(os.path.dirname(__file__), 'djangorestframework.egg-info'), True)
 
 


### PR DESCRIPTION
I'm starting to use this project, and have the habit of installing it directly from github using pip, what was not possible due to the cleanup which was made at the end of setup.py.

I'm looking forward to collaborate in this project, as it is promising to be very useful to me. Is there any points in particular where you feel some work is needed?
