### PR TITLE
bugfix for failed multipart parse

### DIFF
--- a/djangorestframework/parsers.py
+++ b/djangorestframework/parsers.py
@@ -13,6 +13,7 @@ We need a method to be able to:
 
 from django.http import QueryDict
 from django.http.multipartparser import MultiPartParser as DjangoMultiPartParser
+from django.http.multipartparser import MultiPartParserError
 from django.utils import simplejson as json
 from djangorestframework import status
 from djangorestframework.response import ErrorResponse
@@ -135,6 +136,10 @@ class MultiPartParser(BaseParser):
         `files` will be a :class:`QueryDict` containing all the form files.
         """
         upload_handlers = self.view.request._get_upload_handlers()
-        django_parser = DjangoMultiPartParser(self.view.request.META, stream, upload_handlers)
+        try:
+            django_parser = DjangoMultiPartParser(self.view.request.META, stream, upload_handlers)
+        except MultiPartParserError, exc:
+            raise ErrorResponse(status.HTTP_400_BAD_REQUEST,
+                                {'detail': 'multipart parse error - %s' % unicode(exc)})
         return django_parser.parse()
 


### PR DESCRIPTION
Hi, just selecting Content-Type "multipart/form-data" and leaving Content empty in the POST part of the form for an HTML view and then pushing the "POST" button results in a HTTP 500 status error as django shows a traceback. This simple patch returns 400 BAD REQUEST rather than Django traceback/500 error on failed multipart parse.

-Andrew
