### PR TITLE
ModelViews don't correctly validate Resources whose models have unique fields.

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -491,17 +491,17 @@ class ReadModelMixin(object):
         try:
             if args:
                 # If we have any none kwargs then assume the last represents the primrary key
-                instance = model.objects.get(pk=args[-1], **kwargs)
+                self.model_instance = model.objects.get(pk=args[-1], **kwargs)
             else:
                 # Otherwise assume the kwargs uniquely identify the model
                 filtered_keywords = kwargs.copy()
                 if BaseRenderer._FORMAT_QUERY_PARAM in filtered_keywords:
                     del filtered_keywords[BaseRenderer._FORMAT_QUERY_PARAM]
-                instance = model.objects.get(**filtered_keywords)
+                self.model_instance = model.objects.get(**filtered_keywords)
         except model.DoesNotExist:
             raise ErrorResponse(status.HTTP_404_NOT_FOUND)
 
-        return instance
+        return self.model_instance
 
 
 class CreateModelMixin(object):
@@ -540,19 +540,19 @@ class UpdateModelMixin(object):
         try:
             if args:
                 # If we have any none kwargs then assume the last represents the primrary key
-                instance = model.objects.get(pk=args[-1], **kwargs)
+                self.model_instance = model.objects.get(pk=args[-1], **kwargs)
             else:
                 # Otherwise assume the kwargs uniquely identify the model
-                instance = model.objects.get(**kwargs)
+                self.model_instance = model.objects.get(**kwargs)
 
             for (key, val) in self.CONTENT.items():
-                setattr(instance, key, val)
+                setattr(self.model_instance, key, val)
         except model.DoesNotExist:
-            instance = model(**self.CONTENT)
-            instance.save()
+            self.model_instance = model(**self.CONTENT)
+            self.model_instance.save()
 
-        instance.save()
-        return instance
+        self.model_instance.save()
+        return self.model_instance
 
 
 class DeleteModelMixin(object):


### PR DESCRIPTION
With this patch ModelViews can have Resources whose models have unique fields.

ReadModelMixin and UpdateModelMixin store model instance as a property. This allows ModelResource to bind the ModelForm using the model instance making the form validate the input data against the model instance and not a brand new instance. When the latter happened and the model used unique fields, the form validation failed whenever a PUT was maintaining the previous value of the unique field.

Example to reproduce:

```
class Movie(models.Model):
    name = models.CharField(max_length=200)
    imdb_id = models.CharField(max_length=32, blank=True, unique=True, null=True)

class MovieResource(ModelResource):
    model = Movie
    fields = ('name', 'imdb_id', 'url')
    ordering = ('name',)

urlpatterns = patterns('',
    url(r'^movies/$', ListOrCreateModelView.as_view(resource=MovieResource), name='movies'),
    url(r'^movies/(?P<id>[0-9]+)/$', InstanceModelView.as_view(resource=MovieResource)),
)

$ curl -X POST --data 'name=movie&imdb_id=1' http://localhost:8000/movies  
201 Created

$ curl -X PUT --data 'name=movie&imdb_id=1' http://localhost:8000/movies/1  
400 Bad Request
```
