### PR TITLE
Fix: Crash when yaml isn't installed.

### DIFF
--- a/djangorestframework/views.py
+++ b/djangorestframework/views.py
@@ -40,13 +40,7 @@ class View(ResourceMixin, RequestMixin, ResponseMixin, AuthMixin, DjangoView):
     """
     List of renderers the resource can serialize the response with, ordered by preference.
     """
-    renderers = ( renderers.JSONRenderer,
-                  renderers.DocumentingHTMLRenderer,
-                  renderers.DocumentingXHTMLRenderer,
-                  renderers.DocumentingPlainTextRenderer,
-                  renderers.XMLRenderer,
-                  renderers.YAMLRenderer )
-    
+    renderers = renderers.DEFAULT_RENDERERS    
     """
     List of parsers the resource can parse the request with.
     """


### PR DESCRIPTION
Hi, 
after merging the latest changes (yaml support) my test app crashed because I didn't have yaml installed in my env.
Here's the fix.

Best
