### PR TITLE
Changed user.is_staff() to user.is_staff

### DIFF
--- a/djangorestframework/permissions.py
+++ b/djangorestframework/permissions.py
@@ -73,7 +73,7 @@ class IsAdminUser(BasePermission):
     """
 
     def check_permission(self, user):
-        if not user.is_staff():
+        if not user.is_staff:
             raise _403_FORBIDDEN_RESPONSE
 
 


### PR DESCRIPTION
Previous code was causing "Bool is not callable" errors, since is_staff is a field on User, not a function.

https://docs.djangoproject.com/en/dev//topics/auth/#django.contrib.auth.models.User.is_staff
