### PR TITLE
Fix Script Prefix Issues

### DIFF
--- a/djangorestframework/templates/renderer.html
+++ b/djangorestframework/templates/renderer.html
@@ -13,15 +13,14 @@
      </style>
      <link rel="stylesheet" type="text/css" href='{{ADMIN_MEDIA_PREFIX}}css/base.css'/>
      <link rel="stylesheet" type="text/css" href='{{ADMIN_MEDIA_PREFIX}}css/forms.css'/>
-     <link rel="shortcut icon" href="/media/img/favicon.ico" type="image/x-icon" />
-    <title>Yipit's RESTful Framework - {{ name }}</title>
+    <title>Django REST framework - {{ name }}</title>
   </head>
   <body>
   <div id="container">
   
 	<div id="header">
 		<div id="branding">
-		  <h1 id="site-name"><a href='http://django-rest-framework.org'>Yipit's RESTful Framework</a> <span class="version"> v {{ version }}</span></h1>
+		  <h1 id="site-name"><a href='http://django-rest-framework.org'>Django REST framework</a> <span class="version"> v {{ version }}</span></h1>
 		</div>
 		<div id="user-tools">
 		  {% if user.is_active %}Welcome, {{ user }}.{% if logout_url %} <a href='{{ logout_url }}'>Log out</a>{% endif %}{% else %}Anonymous {% if login_url %}<a href='{{ login_url }}'>Log in</a>{% endif %}{% endif %}


### PR DESCRIPTION
This fixes issue #76(https://github.com/tomchristie/django-rest-framework/issues/76)

There may be a better solution to eliminate the use of set_script_prefix entirely, but this works.
