### PR TITLE
Serializer.serialize_model fix

### DIFF
--- a/djangorestframework/serializer.py
+++ b/djangorestframework/serializer.py
@@ -229,21 +229,21 @@ class Serializer(object):
 
         # serialize each required field 
         for fname in fields:
-            if hasattr(self, smart_str(fname)):
-                # check first for a method 'fname' on self first
-                meth = getattr(self, fname)
-                if inspect.ismethod(meth) and len(inspect.getargspec(meth)[0]) == 2:
-                    obj = meth(instance)
-            elif hasattr(instance, '__contains__') and fname in instance:
-                # check for a key 'fname' on the instance
-                obj = instance[fname]
-            elif hasattr(instance, smart_str(fname)):
-                # finally check for an attribute 'fname' on the instance
-                obj = getattr(instance, fname)
-            else:
-                continue
-
             try:
+                if hasattr(self, smart_str(fname)):
+                    # check first for a method 'fname' on self first
+                    meth = getattr(self, fname)
+                    if inspect.ismethod(meth) and len(inspect.getargspec(meth)[0]) == 2:
+                        obj = meth(instance)
+                elif hasattr(instance, '__contains__') and fname in instance:
+                    # check for a key 'fname' on the instance
+                    obj = instance[fname]
+                elif hasattr(instance, smart_str(fname)):
+                    # finally check for an attribute 'fname' on the instance
+                    obj = getattr(instance, fname)
+                else:
+                    continue
+
                 key = self.serialize_key(fname)
                 val = self.serialize_val(fname, obj)
                 data[key] = val


### PR DESCRIPTION
the serialize_model method uses the _SkipField exception to signify which fields should be skipped. This exception doesnt seem to signify an error at all, and is meant for control flow exclusively. In some cases this exception is raised outside of the try block, as it is in the previous version. This version expands the try block to include the entire section processing that field. 
