### PR TITLE
change the key name "field-errors" to "field_errors".

### DIFF
--- a/djangorestframework/resources.py
+++ b/djangorestframework/resources.py
@@ -173,7 +173,7 @@ class FormResource(Resource):
                 field_errors[key] = [u'This field does not exist.']
 
             if field_errors:
-                detail[u'field-errors'] = field_errors
+                detail[u'field_errors'] = field_errors
 
         # Return HTTP 400 response (BAD REQUEST)
         raise ErrorResponse(400, detail)


### PR DESCRIPTION
"-" is not allowed as a part of key name in some language such as "Javascript".
javascript cannot handle JSON which returned by djangorestframework when form validation failed
So it may be a bad idea to use "-" in key name.
