### PR TITLE
Only set the script_prefix if the prefix isn't already a full URL.

### DIFF
--- a/djangorestframework/views.py
+++ b/djangorestframework/views.py
@@ -115,8 +115,9 @@ class View(ResourceMixin, RequestMixin, ResponseMixin, AuthMixin, DjangoView):
 
         # Calls to 'reverse' will not be fully qualified unless we set the scheme/host/port here.
         orig_prefix = get_script_prefix()
-        prefix = '%s://%s' % (request.is_secure() and 'https' or 'http', request.get_host())
-        set_script_prefix(prefix + orig_prefix)
+        if not (orig_prefix.startswith('http:') or orig_prefix.startswith('https:')):
+            prefix = '%s://%s' % (request.is_secure() and 'https' or 'http', request.get_host())
+            set_script_prefix(prefix + orig_prefix)
 
         try:
             self.initial(request, *args, **kwargs)


### PR DESCRIPTION
I was running into a problem in some tests against code written on top of django-rest-framework.  I kept getting URLs from reverse that looked like `'http://testserverhttp://testserver/api/activities'`.  I traced the issue back to the code in this patch.  At some point the script prefix was set to `'http://testserver/'`, and that was being appended to `'http://testserver'` resulting in `'http://testserverhttp://testserver/'` as the new prefix and causing a bunch of 404s.
