### PR TITLE
Change 'except' for 'except Exception' (Fixes issue #75)

### DIFF
--- a/djangorestframework/renderers.py
+++ b/djangorestframework/renderers.py
@@ -246,14 +246,14 @@ class DocumentingTemplateRenderer(BaseRenderer):
                     form_instance = view.get_bound_form(view.response.cleaned_content, method=method)
                     if form_instance and not form_instance.is_valid():
                         form_instance = None
-                except:
+                except Exception:
                     form_instance = None
 
         # If we still don't have a form instance then try to get an unbound form
         if not form_instance:
             try:
                 form_instance = view.get_bound_form(method=method)
-            except:
+            except Exception:
                 pass
 
         # If we still don't have a form instance then try to get an unbound form which can tunnel arbitrary content types

--- a/djangorestframework/utils/__init__.py
+++ b/djangorestframework/utils/__init__.py
@@ -43,7 +43,7 @@ def url_resolves(url):
     """
     try:
         resolve(url)
-    except:
+    except Exception:
         return False
     return True
 

--- a/djangorestframework/utils/breadcrumbs.py
+++ b/djangorestframework/utils/breadcrumbs.py
@@ -11,7 +11,7 @@ def get_breadcrumbs(url):
 
         try:
             (view, unused_args, unused_kwargs) = resolve(url)
-        except:
+        except Exception:
             pass
         else:
             # Check if this is a REST framework view, and if so add it to the breadcrumbs

--- a/djangorestframework/utils/mediatypes.py
+++ b/djangorestframework/utils/mediatypes.py
@@ -109,7 +109,7 @@ class _MediaType(object):
     #    """
     #    try:
     #        return Decimal(self.params.get('q', '1.0'))
-    #    except:
+    #    except Exception:
     #        return Decimal(0)
 
     #def score(self):

--- a/examples/pygments_api/tests.py
+++ b/examples/pygments_api/tests.py
@@ -18,7 +18,7 @@ class TestPygmentsExample(TestCase):
     def tearDown(self):
         try:
             shutil.rmtree(self.temp_dir)
-        except:
+        except Exception:
             pass
         
     def test_get_to_root(self):


### PR DESCRIPTION
Change bare `except` statements for `except Exception` ones, to precent catching of SystemExit, KeyboardInterrupt, GeneratorExit and BaseException
