### PR TITLE
A mixin for enabling the use of current request in Resource Form validation

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -729,3 +729,18 @@ class PaginatorMixin(object):
         serialized_page_info['results'] = serialized_object_list
 
         return serialized_page_info
+
+
+############## RequestFormMixin ####################
+
+class RequestFormMixin(object):
+    """
+    If you add this mixin to a form class, the instantiated form will have the `set_request`-method
+    which will be set by any resource using standard form validation, allowing you to use `self.request`
+    in any form clean`-methods.
+    """
+
+    request = None
+
+    def set_request(self, request):
+        self.request = request

--- a/djangorestframework/resources.py
+++ b/djangorestframework/resources.py
@@ -205,6 +205,7 @@ class FormResource(Resource):
         """
         Given some content return a Django form bound to that content.
         If form validation is turned off (:attr:`form` class attribute is :const:`None`) then returns :const:`None`.
+        If the form class uses the `RequestFormMixin` mixin, the request will be set on the form
         """
         form = self.get_form_class(method)
 
@@ -212,9 +213,15 @@ class FormResource(Resource):
             return None
 
         if data is not None or files is not None:
-            return form(data, files)
+            form_instance = form(data, files)
+        else:
+            form_instance = form()
 
-        return form()
+        try:
+            form_instance.set_request(self.view.request)
+        except AttributeError:
+            pass
+        return form_instance
 
 
 


### PR DESCRIPTION
Added a `RequestFormMixin`, which will, if used enable the use of
`self.request` in form clean-methods in the request handling. With basic
test. 

**Edit:** Changed title. See discussion.
