### PR TITLE
Docstring and whitespace fixes.

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -49,12 +49,12 @@ class RequestMixin(object):
     _CONTENTTYPE_PARAM = '_content_type'
     _CONTENT_PARAM = '_content'
 
+    parsers = ()
     """
     The set of request parsers that the view can handle.
 
     Should be a tuple/list of classes as described in the :mod:`parsers` module.
     """
-    parsers = ()
 
     @property
     def method(self):
@@ -226,12 +226,12 @@ class ResponseMixin(object):
     _ACCEPT_QUERY_PARAM = '_accept'        # Allow override of Accept header in URL query params
     _IGNORE_IE_ACCEPT_HEADER = True
 
+    renderers = ()
     """
     The set of response renderers that the view can handle.
 
     Should be a tuple/list of classes as described in the :mod:`renderers` module.
     """
-    renderers = ()
 
 
     # TODO: wrap this behavior around dispatch(), ensuring it works
@@ -339,19 +339,19 @@ class AuthMixin(object):
     Simple :class:`mixin` class to add authentication and permission checking to a :class:`View` class.
     """
 
+    authentication = ()
     """
     The set of authentication types that this view can handle.
 
     Should be a tuple/list of classes as described in the :mod:`authentication` module.
     """
-    authentication = ()
 
+    permissions = ()
     """
     The set of permissions that will be enforced on this view.
 
     Should be a tuple/list of classes as described in the :mod:`permissions` module.
     """
-    permissions = ()
 
 
     @property

--- a/djangorestframework/parsers.py
+++ b/djangorestframework/parsers.py
@@ -171,8 +171,8 @@ class MultiPartParser(BaseParser):
             raise ErrorResponse(status.HTTP_400_BAD_REQUEST,
                                 {'detail': 'multipart parse error - %s' % unicode(exc)})
         return django_parser.parse()
-		
-		
+
+
 class XMLParser(BaseParser):
     """
     XML parser.
@@ -183,7 +183,7 @@ class XMLParser(BaseParser):
     def parse(self, stream):
         """
         Returns a 2-tuple of `(data, files)`.
-		
+
         `data` will simply be a string representing the body of the request.
         `files` will always be `None`.
         """
@@ -218,33 +218,33 @@ class XMLParser(BaseParser):
         """
         Converts the value returned by the XMl parse into the equivalent
         Python type
-        """	
-        if value is None:	
+        """
+        if value is None:
             return value
-			
+
         try:
             return datetime.datetime.strptime(value,'%Y-%m-%d %H:%M:%S')
         except ValueError:
             pass
-			
+
         try:
             return int(value)
         except ValueError:
             pass
-			
+
         try:
             return decimal.Decimal(value)
         except decimal.InvalidOperation:
             pass
-			
+
         return value
 
 
 DEFAULT_PARSERS = ( JSONParser,
                     FormParser,
                     MultiPartParser,
-					XMLParser
-					)
+                    XMLParser
+                    )
 
 if YAMLParser:
     DEFAULT_PARSERS += ( YAMLParser, )

--- a/djangorestframework/tests/accept.py
+++ b/djangorestframework/tests/accept.py
@@ -63,6 +63,3 @@ class UserAgentMungingTest(TestCase):
             resp = self.view(req)
             self.assertEqual(resp['Content-Type'], 'application/json')
 
-
-
-

--- a/djangorestframework/tests/files.py
+++ b/djangorestframework/tests/files.py
@@ -30,7 +30,3 @@ class UploadFilesTests(TestCase):
         response = view(request)
         self.assertEquals(response.content, '{"FILE_CONTENT": "stuff", "FILE_NAME": "stuff.txt"}')
 
-
-
-
-

--- a/djangorestframework/tests/models.py
+++ b/djangorestframework/tests/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import Group
- 
+
 class CustomUser(models.Model):
     """
     A custom user model, which uses a 'through' table for the foreign key
@@ -8,15 +8,15 @@ class CustomUser(models.Model):
     username = models.CharField(max_length=255, unique=True)
     groups = models.ManyToManyField(
         to=Group, blank=True, null=True, through='UserGroupMap'
-    ) 
-        
+    )
+
     @models.permalink
     def get_absolute_url(self):
         return ('custom_user', (), {
             'pk': self.id
-    })        
-             
-        
+    })
+
+
 class UserGroupMap(models.Model):
     user = models.ForeignKey(to=CustomUser)
     group = models.ForeignKey(to=Group)      

--- a/djangorestframework/tests/parsers.py
+++ b/djangorestframework/tests/parsers.py
@@ -172,7 +172,6 @@ class TestXMLParser(TestCase):
             'field_b': 'dasd',	
             'field_c': None,
             'field_d': datetime.datetime(2011, 12, 25, 12, 45, 00)
-			
         }
         self._complex_data_input = StringIO(
             '<?xml version="1.0" encoding="utf-8"?>'

--- a/djangorestframework/utils/__init__.py
+++ b/djangorestframework/utils/__init__.py
@@ -150,10 +150,10 @@ class XMLRenderer():
                 xml.startElement(key, {})
                 self._to_xml(xml, value)
                 xml.endElement(key)
-				
+
         elif data is None:
             # Don't output any value
-            pass				
+            pass
 
         else:
             xml.characters(smart_unicode(data))

--- a/djangorestframework/views.py
+++ b/djangorestframework/views.py
@@ -32,32 +32,32 @@ class View(ResourceMixin, RequestMixin, ResponseMixin, AuthMixin, DjangoView):
     Performs request deserialization, response serialization, authentication and input validation.
     """
 
+    resource = None
     """
     The resource to use when validating requests and filtering responses,
     or `None` to use default behaviour.
     """
-    resource = None
 
+    renderers = renderers.DEFAULT_RENDERERS
     """
     List of renderers the resource can serialize the response with, ordered by preference.
     """
-    renderers = renderers.DEFAULT_RENDERERS
 
+    parsers = parsers.DEFAULT_PARSERS
     """
     List of parsers the resource can parse the request with.
     """
-    parsers = parsers.DEFAULT_PARSERS
 
+    authentication = ( authentication.UserLoggedInAuthentication,
+                       authentication.BasicAuthentication )
     """
     List of all authenticating methods to attempt.
     """
-    authentication = ( authentication.UserLoggedInAuthentication,
-                       authentication.BasicAuthentication )
 
+    permissions = ( permissions.FullAnonAccess, )
     """
     List of all permissions that must be checked.
     """
-    permissions = ( permissions.FullAnonAccess, )
 
     @classmethod
     def as_view(cls, **initkwargs):


### PR DESCRIPTION
Removed tabs, converted CRLF to LF, moved docstrings under (instead of over) intended targets.
