### PR TITLE
Failing test case test_with_content_type_args

### DIFF
--- a/djangorestframework/tests/renderers.py
+++ b/djangorestframework/tests/renderers.py
@@ -172,7 +172,7 @@ class RendererIntegrationTests(TestCase):
         self.assertEquals(resp.status_code, DUMMYSTATUS)
 
 _flat_repr = '{"foo": ["bar", "baz"]}'
-_indented_repr = '{\n  "foo": [\n    "bar", \n    "baz"\n  ]\n}'
+_indented_repr = '{\n  "foo": [\n    "bar",\n    "baz"\n  ]\n}'
 
 
 class JSONRendererTests(TestCase):


### PR DESCRIPTION
Looks like whitespace error. Does this test case fail for you without this patch?
