### PR TITLE
Failing test case test_with_content_type_args

### DIFF
--- a/djangorestframework/tests/renderers.py
+++ b/djangorestframework/tests/renderers.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf.urls.defaults import patterns, url
 from django.test import TestCase
 
@@ -187,6 +189,8 @@ class JSONRendererTests(TestCase):
         obj = {'foo': ['bar', 'baz']}
         renderer = JSONRenderer(None)
         content = renderer.render(obj, 'application/json')
+        # Fix failing test case which depends on version of JSON library.
+        content = re.sub(' +\n', '\n', content)
         self.assertEquals(content, _flat_repr)
 
     def test_with_content_type_args(self):


### PR DESCRIPTION
This includes a regex to remove trailing whitespace from JSON content. The whitespace is missing from the constant, so this test should pass now regardless of the JSON library version.
