### PR TITLE
Resource ownership

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -527,6 +527,16 @@ class ModelMixin(object):
         """
         return self.get_queryset().get(**kwargs)
 
+    def get_owner(self):
+        """
+        Returns the model instance's owner, if any.
+
+        The owner is retrieved by calling the .get_owner() function on the model instance, if implemented. 
+        """
+        try:
+            return self.model_instance.get_owner()
+        except: pass
+
     @property
     def model_instance(self):
         """

--- a/djangorestframework/permissions.py
+++ b/djangorestframework/permissions.py
@@ -13,7 +13,7 @@ __all__ = (
     'BasePermission',
     'FullAnonAccess',
     'IsAuthenticated',
-    'IsModelInstanceOwnerOrIsAnonReadOnly',
+    'IsResourceOwnerOrIsAnonReadOnly',
     'IsAdminUser',
     'IsUserOrIsAnonReadOnly',
     'PerUserThrottling',
@@ -78,12 +78,9 @@ class IsAdminUser(BasePermission):
             raise _403_FORBIDDEN_RESPONSE
 
 
-class IsModelInstanceOwnerOrIsAnonReadOnly(BasePermission):
+class IsResourceOwnerOrIsAnonReadOnly(BasePermission):
     """
-    The request is authenticated as the owner of the model instance, or is a read-only request.
-
-    In order to determine the owner, the model has to provide a .get_owner() function that
-    returns the owner, otherwise the permission will be denied. 
+    The request is authenticated as the owner of the resource, or is a read-only request.
     """
 
     def check_permission(self, user):
@@ -94,10 +91,8 @@ class IsModelInstanceOwnerOrIsAnonReadOnly(BasePermission):
         if not user.is_authenticated():
             raise _403_FORBIDDEN_RESPONSE
 
-        try:
-            if self.view.model_instance.get_owner() == user:
-                return
-        except: pass
+        if self.view.get_owner() == user:
+            return
 
         raise _403_FORBIDDEN_RESPONSE
 

--- a/djangorestframework/resources.py
+++ b/djangorestframework/resources.py
@@ -32,6 +32,12 @@ class BaseResource(Serializer):
         """
         return self.serialize(obj)
 
+    def get_owner(self):
+        """
+        Returns a Django User instance as the owner of the resource, if any.
+        """
+        return None
+
 
 class Resource(BaseResource):
     """


### PR DESCRIPTION
Instead of loading the ModelMixin's model_instance in the .get() .put() and .delete() functions, I moved it to a lazy (hits the DB only once) model_instance property. Then it can be called elsewhere, and earlier, such as the auth/permission phase, where the ability of accessing the model instance data can provide more granular checks.

As a first step (I'm preparing the implementation for OAuth 2.0) I've added a IsModelInstanceOwnerOrIsAnonReadOnly permission, which only allows write access to the model instance's owner (assuming the model implements a .get_owner() function). Based on this, we can implement a resource/instance authorization system between resource owners.
