### PR TITLE
Ensure duplicate "page" parameters are not created

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -679,7 +679,7 @@ class PaginatorMixin(object):
         Constructs a url used for getting the next/previous urls
         """
         url = URLObject.parse(self.request.get_full_path())
-        url = url.add_query_param('page', page_number)
+        url = url.set_query_param('page', page_number)
 
         limit = self.get_limit()
         if limit != self.limit:

--- a/djangorestframework/tests/mixins.py
+++ b/djangorestframework/tests/mixins.py
@@ -280,3 +280,12 @@ class TestPagination(TestCase):
         self.assertTrue('foo=bar' in content['next'])
         self.assertTrue('another=something' in content['next'])
         self.assertTrue('page=2' in content['next'])
+
+    def test_duplicate_parameters_are_not_created(self):
+        """ Regression: ensure duplicate "page" parameters are not added to
+        paginated URLs. So page 1 should contain ?page=2, not ?page=1&page=2 """
+        request = self.req.get('/paginator/?page=1')
+        response = MockPaginatorView.as_view()(request)
+        content = json.loads(response.content)
+        self.assertTrue('page=2' in content['next'])
+        self.assertFalse('page=1' in content['next'])


### PR DESCRIPTION
Previously, URLObject.add_query_param was used to generate
next/previous page links in PaginatorMixin. This resulted
in (for example) page 2's "next" link having the params:

   ?page=2&page=3

Instead, URLObject.set_query_param should be used to replace
the current value of the "page" parameter.
