### PR TITLE
Resource's get_bound_form() populates instance's form on GET

### DIFF
--- a/djangorestframework/resources.py
+++ b/djangorestframework/resources.py
@@ -311,7 +311,7 @@ class ModelResource(FormResource):
         # Instantiate the ModelForm as appropriate
         form_kwargs = {'data': data, 'files': files}
          # Bound to an existing model instance
-        if issubclass(form, forms.ModelForm) and if hasattr(self.view, 'model_instance'): form_kwargs['instance'] = self.view.model_instance
+        if issubclass(form, forms.ModelForm) and hasattr(self.view, 'model_instance'): form_kwargs['instance'] = self.view.model_instance
 
         return form(**form_kwargs)
 


### PR DESCRIPTION
Simplified the argument's logic when `.get_bound_form()` returns the new `Form` by building a `**form_kwargs` dict, as `Form` accepts `file` or `data` arguments set to `None` by default: https://code.djangoproject.com/browser/django/trunk/django/forms/forms.py#L75

Declare model's instance in the `Form` if present, and not only if `data` or `file` are declared, then the form is populated with the instance's data on GET, much more convenient when editing, IMHO.
