### PR TITLE
URLObject v2.0.0 changed its API

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -685,7 +685,7 @@ class PaginatorMixin(object):
         """
         Constructs a url used for getting the next/previous urls
         """
-        url = URLObject.parse(self.request.get_full_path())
+        url = URLObject(self.request.get_full_path())
         url = url.set_query_param('page', page_number)
 
         limit = self.get_limit()

--- a/djangorestframework/templatetags/add_query_param.py
+++ b/djangorestframework/templatetags/add_query_param.py
@@ -4,8 +4,7 @@ register = Library()
 
 
 def add_query_param(url, param):
-    (key, sep, val) = param.partition('=')
-    return unicode(URLObject.parse(url) & (key, val))
+    return unicode(URLObject(url).with_query(param))
 
 
 register.filter('add_query_param', add_query_param)


### PR DESCRIPTION
URLObject v2.0.0 removed parse() from its API.  These are changes I made to get it to work.  
