### PR TITLE
Add exception handling to the XML parser

### DIFF
--- a/djangorestframework/compat.py
+++ b/djangorestframework/compat.py
@@ -465,3 +465,9 @@ except:
     from django.core.urlresolvers import reverse
     from django.utils.functional import lazy
     reverse_lazy = lazy(reverse, str)
+
+# xml.etree.parse only throws ParseError for python >= 2.7
+try:
+    from xml.etree import ParseError as ETParseError
+except ImportError: # python < 2.7
+    ETParseError = None


### PR DESCRIPTION
The XML parser now catches the exceptions that might be thrown by xml.etree.parse()
