### PR TITLE
Don't add unknown field errors if allow_unknown_form_fields is set

### DIFF
--- a/djangorestframework/resources.py
+++ b/djangorestframework/resources.py
@@ -168,9 +168,10 @@ class FormResource(Resource):
                 if not key.startswith('__')
             )
 
-            # Add any unknown field errors
-            for key in unknown_fields:
-                field_errors[key] = [u'This field does not exist.']
+            if not self.allow_unknown_form_fields:
+                # Add any unknown field errors
+                for key in unknown_fields:
+                    field_errors[key] = [u'This field does not exist.']
 
             if field_errors:
                 detail[u'field_errors'] = field_errors


### PR DESCRIPTION
Field errors are confusing and hide other errors if you have allow_unknown_form_fields set and expect those to get passed through.
