### PR TITLE
#94 : Add AttributeError when markdown.blockprocessors doesn't exists

### DIFF
--- a/djangorestframework/compat.py
+++ b/djangorestframework/compat.py
@@ -371,6 +371,34 @@ else:
 try:
     import markdown
 
+    class CustomSetextHeaderProcessor(markdown.blockprocessors.BlockProcessor):
+        """
+        Class for markdown < 2.1
+
+        Override `markdown`'s :class:`SetextHeaderProcessor`, so that ==== headers are <h2> and ---- heade
+
+        We use <h1> for the resource name.
+        """
+        import re
+        # Detect Setext-style header. Must be first 2 lines of block.
+        RE = re.compile(r'^.*?\n[=-]{3,}', re.MULTILINE)
+
+        def test(self, parent, block):
+            return bool(self.RE.match(block))
+
+        def run(self, parent, blocks):
+            lines = blocks.pop(0).split('\n')
+            # Determine level. ``=`` is 1 and ``-`` is 2.
+            if lines[1].startswith('='):
+                level = 2
+            else:
+                level = 3
+            h = markdown.etree.SubElement(parent, 'h%d' % level)
+            h.text = lines[0].strip()
+            if len(lines) > 2:
+                # Block contains additional lines. Add to  master blocks for later.
+                blocks.insert(0, '\n'.join(lines[2:]))
+
     def apply_markdown(text):
         """
         Simple wrapper around :func:`markdown.markdown` to set the base level
@@ -381,35 +409,6 @@ try:
         safe_mode = False,
 
         if markdown.version_info < (2, 1):
-            class CustomSetextHeaderProcessor(markdown.blockprocessors.BlockProcessor):
-                """
-                Class for markdown < 2.1
-            
-                Override `markdown`'s :class:`SetextHeaderProcessor`, so that ==== headers are <h2> and ---- heade
-            
-                We use <h1> for the resource name.
-                """
-                import re
-                # Detect Setext-style header. Must be first 2 lines of block.
-                RE = re.compile(r'^.*?\n[=-]{3,}', re.MULTILINE)
-            
-                def test(self, parent, block):
-                    return bool(self.RE.match(block))
-            
-                def run(self, parent, blocks):
-                    lines = blocks.pop(0).split('\n')
-                    # Determine level. ``=`` is 1 and ``-`` is 2.
-                    if lines[1].startswith('='):
-                        level = 2
-                    else:
-                        level = 3
-                    h = markdown.etree.SubElement(parent, 'h%d' % level)
-                    h.text = lines[0].strip()
-                    if len(lines) > 2:
-                        # Block contains additional lines. Add to  master blocks for later.
-                        blocks.insert(0, '\n'.join(lines[2:]))
-            
-            
             output_format = markdown.DEFAULT_OUTPUT_FORMAT
 
             md = markdown.Markdown(extensions=markdown.load_extensions(extensions),
@@ -420,7 +419,7 @@ try:
             md = markdown.Markdown(extensions=extensions, safe_mode=safe_mode)
         return md.convert(text)
 
-except ImportError:
+except (ImportError, AttributeError):
     apply_markdown = None
 
 # Yaml is optional


### PR DESCRIPTION
On markdown v.1.7 with Python 2.6 I've got module doesn't have blockprocessors attribute.
I think the minimum is that markdown got deactivate in that case.
