### PR TITLE
The automatic breadcrumbs don't work when WSGIScriptAlias isn't "/"

### DIFF
--- a/djangorestframework/renderers.py
+++ b/djangorestframework/renderers.py
@@ -329,7 +329,7 @@ class DocumentingTemplateRenderer(BaseRenderer):
         name = self.get_name()
         description = self.get_description()
 
-        breadcrumb_list = get_breadcrumbs(self.view.request.path)
+        breadcrumb_list = get_breadcrumbs(self.view.request.path_info)
 
         template = loader.get_template(self.template)
         context = RequestContext(self.view.request, {


### PR DESCRIPTION
As per https://code.djangoproject.com/ticket/10328, the Django-relative part of the URL is stored in the requests "path_info" attribute, while the "path" attribute also includes the WSGIScriptAlias portion.

The breadcrumb generator is currently using the wrong one, and hence all of the calls to "resolve()" fail with a 404 and no breadcrumbs are reported.
