### PR TITLE
Pass request to related serializers

### DIFF
--- a/djangorestframework/serializer.py
+++ b/djangorestframework/serializer.py
@@ -179,7 +179,8 @@ class Serializer(object):
             stack = self.stack[:]
             stack.append(obj)
 
-        return related_serializer(depth=depth, stack=stack).serialize(obj)
+        return related_serializer(depth=depth, stack=stack).serialize(
+            obj, request=self.request)
 
     def serialize_max_depth(self, obj):
         """
@@ -253,10 +254,14 @@ class Serializer(object):
         """
         return smart_unicode(obj, strings_only=True)
 
-    def serialize(self, obj):
+    def serialize(self, obj, request=None):
         """
         Convert any object into a serializable representation.
         """
+
+        # Request from related serializer.
+        if request is not None:
+            self.request = request
 
         if isinstance(obj, (dict, models.Model)):
             # Model instances & dictionaries


### PR DESCRIPTION
Related serializers may need access to the request to properly serialize
a child resource.  For example, reverse() in djangorestframework.reverse
uses request if available to return an absolute URL.  While the parent
resource has access to the request to generate the absolute URL, the
child resource does not.

A colleague discovered that child resources of a resource were not generating an absolute URL. It was due to not having the request to pass to DRF's reverse() which calls request.build_absolute_uri() if request is present.

This patch fixes the issue by passing the request to related serializers since they are separate objects that do not inherit the request.

This replaces pull request #218.
