### PR TITLE
Implements Accept headers from IE in the case describe in Issue 215

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -274,7 +274,8 @@ class ResponseMixin(object):
             accept_list = [request.GET.get(self._ACCEPT_QUERY_PARAM)]
         elif (self._IGNORE_IE_ACCEPT_HEADER and
               'HTTP_USER_AGENT' in request.META and
-              MSIE_USER_AGENT_REGEX.match(request.META['HTTP_USER_AGENT'])):
+              MSIE_USER_AGENT_REGEX.match(request.META['HTTP_USER_AGENT']) and
+              request.META.get('HTTP_X_REQUESTED_WITH', '') != 'XMLHttpRequest'):
             # Ignore MSIE's broken accept behavior and do something sensible instead
             accept_list = ['text/html', '*/*']
         elif 'HTTP_ACCEPT' in request.META:

--- a/djangorestframework/tests/accept.py
+++ b/djangorestframework/tests/accept.py
@@ -50,6 +50,16 @@ class UserAgentMungingTest(TestCase):
             resp = self.view(req)
             self.assertEqual(resp['Content-Type'], 'text/html')
 
+    def test_dont_munge_msie_with_x_requested_with_header(self):
+        """Send MSIE user agent strings, and an X-Requested-With header, and
+        ensure that we get a JSON response if we set a */* Accept header."""
+        for user_agent in (MSIE_9_USER_AGENT,
+                           MSIE_8_USER_AGENT,
+                           MSIE_7_USER_AGENT):
+            req = self.req.get('/', HTTP_ACCEPT='*/*', HTTP_USER_AGENT=user_agent, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+            resp = self.view(req)
+            self.assertEqual(resp['Content-Type'], 'application/json')
+
     def test_dont_rewrite_msie_accept_header(self):
         """Turn off _IGNORE_IE_ACCEPT_HEADER, send MSIE user agent strings and ensure
         that we get a JSON response if we set a */* accept header."""


### PR DESCRIPTION
See details in https://github.com/tomchristie/django-rest-framework/issues/215 and https://groups.google.com/d/topic/django-rest-framework/5roG-E4bqBE/discussion

I've also included a test for this condition.
