### PR TITLE
Modify 415 error content

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -181,7 +181,7 @@ class RequestMixin(object):
                 return parser.parse(stream)
 
         raise ErrorResponse(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                            {'error': 'Unsupported media type in request \'%s\'.' % 
+                            {'detail': 'Unsupported media type in request \'%s\'.' % 
                             content_type})
 
     @property


### PR DESCRIPTION
Modified mixins.py to make sure that the 415 error returns its error in the 'detail' key instead of in the 'error' key (for consistency with all other errors).
