### PR TITLE
add_query_param should preserve previous querystring

### DIFF
--- a/djangorestframework/templatetags/add_query_param.py
+++ b/djangorestframework/templatetags/add_query_param.py
@@ -4,7 +4,7 @@ register = Library()
 
 
 def add_query_param(url, param):
-    return unicode(URLObject(url).with_query(param))
+    return unicode(URLObject(url).add_query_param(*param.split('=')))
 
 
 register.filter('add_query_param', add_query_param)


### PR DESCRIPTION
The way add_query_param works overrides previous querystring, I think it should keep it as the function is named **add**_query_param and as keeping previous querystring is convenient (e.g. containing the current pagination's selection).
