### PR TITLE
support utf8 description

### DIFF
--- a/djangorestframework/views.py
+++ b/djangorestframework/views.py
@@ -156,6 +156,9 @@ class View(ResourceMixin, RequestMixin, ResponseMixin, AuthMixin, DjangoView):
 
         description = _remove_leading_indent(description)
 
+        if not isinstance(description, unicode):
+            description = description.decode('UTF-8')
+
         if html:
             return self.markup_description(description)
         return description


### PR DESCRIPTION
if use chinese as api description, will get error: 

```
Exception Value:    

'ascii' codec can't decode byte 0xe8 in position 0: ordinal not in range(128). -- Note: Markdown only accepts unicode input!Exception Value:    

```

test code here:

``` python
from djangorestframework.view import View
from djangorestframework.resources import ModelResource

class ApiListView(View):
    """这里提供所有已完成api的入口链接，方便测试与调试使用"""
    ......
class Collects(ModelResource):
    """应用程序评论"""
    ......
```

my branch fixed the bug, now support utf8 description, so user can write description use Chinese, Japanese or Korea。
