### PR TITLE
Have Serializer.serialize take a generic **kwargs dict, and BaseResource serialize take a request.

### DIFF
--- a/djangorestframework/resources.py
+++ b/djangorestframework/resources.py
@@ -15,7 +15,7 @@ class BaseResource(Serializer):
     exclude = None
 
     def __init__(self, view=None, depth=None, stack=[], **kwargs):
-        super(BaseResource, self).__init__(depth, stack, **kwargs)
+        super(BaseResource, self).__init__(depth, stack, view=view, **kwargs)
         self.view = view
         self.request = getattr(view, 'request', None)
 

--- a/djangorestframework/serializer.py
+++ b/djangorestframework/serializer.py
@@ -106,6 +106,7 @@ class Serializer(object):
         if depth is not None:
             self.depth = depth
         self.stack = stack
+        self.kwargs = kwargs
 
     def get_fields(self, obj):
         fields = self.fields
@@ -188,8 +189,8 @@ class Serializer(object):
             stack = self.stack[:]
             stack.append(obj)
 
-        return related_serializer(depth=depth, stack=stack).serialize(
-            obj, **kwargs)
+        return related_serializer(depth=depth, stack=stack,
+                                  **self.kwargs).serialize(obj, **kwargs)
 
     def serialize_max_depth(self, obj):
         """


### PR DESCRIPTION
The `Serializer` class seems like it should not be tied to a request object.  OTOH, a `Resource` class should.  So, make the `serialize` method on `Serializer` take a generic keyword argument dictionary, which `serialize_model` then passes on to related serializers.

Also, pass the kwargs from `Serializer.__init__` into any related serializers, so that resources have access to the view all the way down.  Addresses issue #214.
