### PR TITLE
Caching instances

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -695,7 +695,7 @@ class DeleteModelMixin(ModelMixin, InstanceReaderMixin, InstanceWriterMixin):
     Behavior to delete a `model` instance on DELETE requests
     """
     def delete(self, request, *args, **kwargs):
-        self.delete_instance(instance)
+        self.delete_instance()
         return
 
 


### PR DESCRIPTION
This patch does two things:
- Makes sure that the instance for a read or update view can be retrieved without doing additional queries.  This is useful, for example, when checking instance-level permissions.  If a user is authorized to read or edit some but not all instances of a model, it is useful to be able to grab the current instance off of the view from a permission class.
- Abstracts out the logic for creating a model instance, so that UpdateModelMixin views use the same attribute setting logic as CreateModelMixin views.

It implements two new mixin classes:
- `InstanceReaderMixin` -- Assumes a single instance for the view. Caches the instance object on `self`.
- `InstanceWriterMixin` -- Abstracts out the logic for applying many-to-many data to a single instance.

Test are also added for the `UpdateModelMixin` and `DeleteModelMixin` functionality.
