### PR TITLE
ModelMixin should use a resource instance to get the queryset

### DIFF
--- a/djangorestframework/mixins.py
+++ b/djangorestframework/mixins.py
@@ -514,8 +514,8 @@ class ModelMixin(object):
         """
         Return the queryset for this view.
         """
-        return getattr(self.resource, 'queryset',
-                       self.resource.model.objects.all())
+        return getattr(self._resource, 'queryset',
+                       self._resource.model.objects.all())
 
     def get_ordering(self):
         """

--- a/djangorestframework/tests/mixins.py
+++ b/djangorestframework/tests/mixins.py
@@ -29,6 +29,7 @@ class TestModelRead(TestModelsTestCase):
         request = self.req.get('/groups')
         mixin = ReadModelMixin()
         mixin.resource = GroupResource
+        mixin._resource = GroupResource(mixin)
 
         response = mixin.get(request, id=group.id)
         self.assertEquals(group.name, response.name)
@@ -40,6 +41,7 @@ class TestModelRead(TestModelsTestCase):
         request = self.req.get('/groups')
         mixin = ReadModelMixin()
         mixin.resource = GroupResource
+        mixin._resource = GroupResource(mixin)
 
         self.assertRaises(ErrorResponse, mixin.get, request, id=12345)
 


### PR DESCRIPTION
This is a small change that makes it possible to use a queryset that is customized to the resource instance that is specific to the current view instance.
