### PR TITLE
Better naming for properties on views, requests and responses

### DIFF
--- a/djangorestframework/renderers.py
+++ b/djangorestframework/renderers.py
@@ -216,7 +216,7 @@ class DocumentingTemplateRenderer(BaseRenderer):
         """
 
         # Find the first valid renderer and render the content. (Don't use another documenting renderer.)
-        renderers = [renderer for renderer in view.renderers
+        renderers = [renderer for renderer in view.renderer_classes
                      if not issubclass(renderer, DocumentingTemplateRenderer)]
         if not renderers:
             return '[No renderers were found]'

--- a/djangorestframework/request.py
+++ b/djangorestframework/request.py
@@ -37,9 +37,9 @@ class Request(object):
 
     Kwargs:
         - request(HttpRequest). The original request instance.
-        - parsers(list/tuple). The parsers to use for parsing the
+        - parsers_classes(list/tuple). The parsers to use for parsing the
           request content.
-        - authentications(list/tuple). The authentications used to try
+        - authentication_classes(list/tuple). The authentications used to try
           authenticating the request's user.
     """
 
@@ -47,10 +47,10 @@ class Request(object):
     _CONTENT_PARAM = api_settings.FORM_CONTENT_OVERRIDE
     _CONTENTTYPE_PARAM = api_settings.FORM_CONTENTTYPE_OVERRIDE
 
-    def __init__(self, request, parsers=None, authentication=None):
+    def __init__(self, request, parser_classes=None, authentication_classes=None):
         self._request = request
-        self.parsers = parsers or ()
-        self.authentication = authentication or ()
+        self.parser_classes = parser_classes or ()
+        self.authentication_classes = authentication_classes or ()
         self._data = Empty
         self._files = Empty
         self._method = Empty
@@ -61,13 +61,13 @@ class Request(object):
         """
         Instantiates and returns the list of parsers the request will use.
         """
-        return [parser() for parser in self.parsers]
+        return [parser() for parser in self.parser_classes]
 
     def get_authentications(self):
         """
         Instantiates and returns the list of parsers the request will use.
         """
-        return [authentication() for authentication in self.authentication]
+        return [authentication() for authentication in self.authentication_classes]
 
     @property
     def method(self):

--- a/djangorestframework/tests/authentication.py
+++ b/djangorestframework/tests/authentication.py
@@ -23,7 +23,7 @@ class MockView(APIView):
     def put(self, request):
         return HttpResponse({'a': 1, 'b': 2, 'c': 3})
 
-MockView.authentication += (TokenAuthentication,)
+MockView.authentication_classes += (TokenAuthentication,)
 
 urlpatterns = patterns('',
     (r'^$', MockView.as_view()),

--- a/djangorestframework/tests/renderers.py
+++ b/djangorestframework/tests/renderers.py
@@ -51,7 +51,7 @@ class RendererB(BaseRenderer):
 
 
 class MockView(APIView):
-    renderers = (RendererA, RendererB)
+    renderer_classes = (RendererA, RendererB)
 
     def get(self, request, **kwargs):
         response = Response(DUMMYCONTENT, status=DUMMYSTATUS)
@@ -65,23 +65,23 @@ class MockGETView(APIView):
 
 
 class HTMLView(APIView):
-    renderers = (DocumentingHTMLRenderer, )
+    renderer_classes = (DocumentingHTMLRenderer, )
 
     def get(self, request, **kwargs):
         return Response('text')
 
 
 class HTMLView1(APIView):
-    renderers = (DocumentingHTMLRenderer, JSONRenderer)
+    renderer_classes = (DocumentingHTMLRenderer, JSONRenderer)
 
     def get(self, request, **kwargs):
         return Response('text')
 
 urlpatterns = patterns('',
-    url(r'^.*\.(?P<format>.+)$', MockView.as_view(renderers=[RendererA, RendererB])),
-    url(r'^$', MockView.as_view(renderers=[RendererA, RendererB])),
-    url(r'^jsonp/jsonrenderer$', MockGETView.as_view(renderers=[JSONRenderer, JSONPRenderer])),
-    url(r'^jsonp/nojsonrenderer$', MockGETView.as_view(renderers=[JSONPRenderer])),
+    url(r'^.*\.(?P<format>.+)$', MockView.as_view(renderer_classes=[RendererA, RendererB])),
+    url(r'^$', MockView.as_view(renderer_classes=[RendererA, RendererB])),
+    url(r'^jsonp/jsonrenderer$', MockGETView.as_view(renderer_classes=[JSONRenderer, JSONPRenderer])),
+    url(r'^jsonp/nojsonrenderer$', MockGETView.as_view(renderer_classes=[JSONPRenderer])),
     url(r'^html$', HTMLView.as_view()),
     url(r'^html1$', HTMLView1.as_view()),
     url(r'^api', include('djangorestframework.urls', namespace='djangorestframework'))

--- a/djangorestframework/tests/request.py
+++ b/djangorestframework/tests/request.py
@@ -217,7 +217,7 @@ class TestContentParsing(TestCase):
 
 
 class MockView(APIView):
-    authentication = (SessionAuthentication,)
+    authentication_classes = (SessionAuthentication,)
 
     def post(self, request):
         if request.POST.get('example') is not None:

--- a/djangorestframework/views.py
+++ b/djangorestframework/views.py
@@ -54,9 +54,9 @@ def _camelcase_to_spaces(content):
 
 
 class APIView(_View):
-    renderers = api_settings.DEFAULT_RENDERERS
-    parsers = api_settings.DEFAULT_PARSERS
-    authentication = api_settings.DEFAULT_AUTHENTICATION
+    renderer_classes = api_settings.DEFAULT_RENDERERS
+    parser_classes = api_settings.DEFAULT_PARSERS
+    authentication_classes = api_settings.DEFAULT_AUTHENTICATION
     throttle_classes = api_settings.DEFAULT_THROTTLES
     permission_classes = api_settings.DEFAULT_PERMISSIONS
 
@@ -139,35 +139,35 @@ class APIView(_View):
         """
         Return a list of all the media types that this view can parse.
         """
-        return [parser.media_type for parser in self.parsers]
+        return [parser.media_type for parser in self.parser_classes]
 
     @property
     def _default_parser(self):
         """
         Return the view's default parser class.
         """
-        return self.parsers[0]
+        return self.parser_classes[0]
 
     @property
     def _rendered_media_types(self):
         """
         Return an list of all the media types that this response can render.
         """
-        return [renderer.media_type for renderer in self.renderers]
+        return [renderer.media_type for renderer in self.renderer_classes]
 
     @property
     def _rendered_formats(self):
         """
         Return a list of all the formats that this response can render.
         """
-        return [renderer.format for renderer in self.renderers]
+        return [renderer.format for renderer in self.renderer_classes]
 
     @property
     def _default_renderer(self):
         """
         Return the response's default renderer class.
         """
-        return self.renderers[0]
+        return self.renderer_classes[0]
 
     def get_permissions(self):
         """
@@ -201,7 +201,7 @@ class APIView(_View):
         """
         Returns the initial request object.
         """
-        return Request(request, parsers=self.parsers, authentication=self.authentication)
+        return Request(request, parser_classes=self.parser_classes, authentication_classes=self.authentication_classes)
 
     def finalize_response(self, request, response, *args, **kwargs):
         """
@@ -210,7 +210,7 @@ class APIView(_View):
         if isinstance(response, Response):
             response.view = self
             response.request = request
-            response.renderers = self.renderers
+            response.renderer_classes = self.renderer_classes
             if api_settings.FORMAT_SUFFIX_KWARG:
                 response.format = kwargs.get(api_settings.FORMAT_SUFFIX_KWARG, None)
 


### PR DESCRIPTION
`renderers` is now `renderer_classes`
`parsers` is now `parser_classes`
`authentication` is now `authentication_classes`

Seems to be a more consistent and more clear way of naming things.

May still need some work - for example, views have `_default_parser`, `_default_renderer` etc, which should probably be `_default_parser_class`, `_default_renderer_class` and so on. But these may be going away at some point soon anyway..
