### PR TITLE
Prevent the touchstart event propagation on the dropdown menus in the navbar

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -118,7 +118,7 @@
       if (location.hash) shiftWindow();
       window.addEventListener("hashchange", shiftWindow);
 
-      $('.dropdown-menu').click(function(event) {
+      $('.dropdown-menu').on('click touchstart', function(event) {
         event.stopPropagation();
       });
     </script>


### PR DESCRIPTION
This allows the dropdowns to be used on a touch device.
