### PR TITLE
Include instance in stack when serializing

### DIFF
--- a/djangorestframework/serializer.py
+++ b/djangorestframework/serializer.py
@@ -210,6 +210,9 @@ class Serializer(object):
         Given a model instance or dict, serialize it to a dict..
         """
         data = {}
+        # Append the instance itself to the stack so that you never iterate
+        # back into the first object.
+        self.stack.append(instance)
 
         fields = self.get_fields(instance)
 


### PR DESCRIPTION
Without this patch the base object will be recursed back into with each
related object at least once.
## 

Not sure if this makes the cut, but I've found it useful in the same case as my previous bug/pull request.
