### PR TITLE
Fix bug with relative/real path

### DIFF
--- a/mkdocs.py
+++ b/mkdocs.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import sys
 
-root_dir = os.path.abspath(os.path.split(__file__)[0])
+root_dir = os.path.abspath(os.path.dirname(__file__))
 docs_dir = os.path.join(root_dir, 'docs')
 html_dir = os.path.join(root_dir, 'html')
 
@@ -60,7 +60,8 @@ for (dirpath, dirnames, filenames) in os.walk(docs_dir):
 
         content = markdown.markdown(text, ['headerid'])
 
-        build_dir = os.path.join(html_dir, dirpath.partition(docs_dir)[2].lstrip("/"))
+        category_dir = dirpath.replace(docs_dir, '').lstrip(os.path.sep)
+        build_dir = os.path.join(html_dir, category_dir)
         build_file = os.path.join(build_dir, filename[:-3] + '.html')
 
         if not os.path.exists(build_dir):


### PR DESCRIPTION
It fix a little bug with documentation generation : 

```
% python mkdocs.py  
Traceback (most recent call last):
    File "mkdocs.py", line 67, in <module>
        os.makedirs(build_dir)
    File "/usr/lib/python2.7/os.py", line 157, in makedirs
        mkdir(name, mode)
OSError: [Errno 13] Permission denied: '/tutorial'
```
