### PR TITLE
Make default field check safe for boolean values

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -393,7 +393,7 @@ class ModelSerializer(Serializer):
         except KeyError:
             ret = ModelField(model_field=model_field)
 
-        if model_field.default:
+        if model_field.default is not None:
             ret.required = False
 
         return ret

--- a/rest_framework/tests/models.py
+++ b/rest_framework/tests/models.py
@@ -91,3 +91,7 @@ class Comment(RESTFrameworkModel):
     email = models.EmailField()
     content = models.CharField(max_length=200)
     created = models.DateTimeField(auto_now_add=True)
+
+class ActionItem(RESTFrameworkModel):
+    title = models.CharField(max_length=200)
+    done = models.BooleanField(default=False)

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -28,6 +28,10 @@ class CommentSerializer(serializers.Serializer):
         return instance
 
 
+class ActionItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ActionItem
+
 class BasicTests(TestCase):
     def setUp(self):
         self.comment = Comment(
@@ -81,7 +85,9 @@ class ValidationTests(TestCase):
             'email': 'tom@example.com',
             'content': 'x' * 1001,
             'created': datetime.datetime(2012, 1, 1)
-        }
+        }         
+        self.actionitem = ActionItem('Some to do item',
+        )
 
     def test_create(self):
         serializer = CommentSerializer(self.data)
@@ -101,6 +107,17 @@ class ValidationTests(TestCase):
         serializer = CommentSerializer(data, instance=self.comment)
         self.assertEquals(serializer.is_valid(), False)
         self.assertEquals(serializer.errors, {'email': [u'This field is required.']})
+
+    def test_missing_bool_with_default(self):
+        """Make sure that a boolean value with a 'False' value is not
+        mistaken for not having a default."""
+        data = {
+            'title':'Some action item',
+            #No 'done' value.
+        }
+        serializer = ActionItemSerializer(data, instance=self.actionitem)
+        self.assertEquals(serializer.is_valid(), True)
+        self.assertEquals(serializer.errors, {})
 
 
 class MetadataTests(TestCase):


### PR DESCRIPTION
Without this patch, setting the default value of a Boolean field will result in making that field required.

I've also added a test to catch a regression.
