### PR TITLE
Fix serialization of reverse relationships

### DIFF
--- a/rest_framework/tests/models.py
+++ b/rest_framework/tests/models.py
@@ -92,6 +92,17 @@ class Comment(RESTFrameworkModel):
     content = models.CharField(max_length=200)
     created = models.DateTimeField(auto_now_add=True)
 
+
 class ActionItem(RESTFrameworkModel):
     title = models.CharField(max_length=200)
     done = models.BooleanField(default=False)
+
+
+# Models for reverse relations
+class BlogPost(RESTFrameworkModel):
+    title = models.CharField(max_length=100)
+
+
+class BlogPostComment(RESTFrameworkModel):
+    text = models.TextField()
+    blog_post = models.ForeignKey(BlogPost)

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -302,3 +302,32 @@ class CallableDefaultValueTests(TestCase):
         self.assertEquals(len(self.objects.all()), 1)
         self.assertEquals(instance.pk, 1)
         self.assertEquals(instance.text, 'overridden')
+
+
+class ManyRelatedTests(TestCase):
+    def setUp(self):
+
+        class BlogPostCommentSerializer(serializers.Serializer):
+            text = serializers.CharField()
+
+        class BlogPostSerializer(serializers.Serializer):
+            title = serializers.CharField()
+            comments = BlogPostCommentSerializer(source='blogpostcomment_set')
+
+        self.serializer_class = BlogPostSerializer
+
+    def test_reverse_relations(self):
+        post = BlogPost.objects.create(title="Test blog post")
+        post.blogpostcomment_set.create(text="I hate this blog post")
+        post.blogpostcomment_set.create(text="I love this blog post")
+
+        serializer = self.serializer_class(instance=post)
+        expected = {
+            'title': 'Test blog post',
+            'comments': [
+                {'text': 'I hate this blog post'},
+                {'text': 'I love this blog post'}
+            ]
+        }
+
+        self.assertEqual(serializer.data, expected)


### PR DESCRIPTION
Previously, reverse relations were not handled correctly by serializers. This now duck types the relation to assume that anything with a simple callable called `all` should be iterated over.
