### PR TITLE
#314 Fix for manytomany field being required in the payload even though ...

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -256,6 +256,9 @@ class ManyRelatedMixin(object):
         return [self.to_native(item) for item in value.all()]
 
     def field_from_native(self, data, field_name, into):
+        if self.readonly:
+            return
+            
         try:
             # Form data
             value = data.getlist(self.source or field_name)

--- a/rest_framework/tests/models.py
+++ b/rest_framework/tests/models.py
@@ -62,7 +62,12 @@ class CallableDefaultValueModel(RESTFrameworkModel):
 
 class ManyToManyModel(RESTFrameworkModel):
     rel = models.ManyToManyField(Anchor)
+    
 
+class ReadOnlyManyToManyModel(RESTFrameworkModel):
+    text = models.CharField(max_length=100, default='anchor')
+    rel = models.ManyToManyField(Anchor)
+       
 # Models to test generic relations
 
 


### PR DESCRIPTION
...the field is specified as readonly in the serializer
