### PR TITLE
using 'pk' in fields throws KeyError

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -201,7 +201,7 @@ Open the file `snippets/serializers.py` again, and edit the `SnippetSerializer` 
     class SnippetSerializer(serializers.ModelSerializer):
         class Meta:
             model = Snippet
-            fields = ('pk', 'title', 'code', 'linenos', 'language', 'style')
+            fields = ('id', 'title', 'code', 'linenos', 'language', 'style')
 
 
 


### PR DESCRIPTION
I've been following the tutorial step-by-step (using sqlite and
the same project structure, etc). I cannot for the life of me make 'pk'
be accepted as a valid field for Meta.fields of ModelSerializer...
'id' on the other hand seems to work very well.
