### PR TITLE
Return choices as unicode and not string

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -100,7 +100,7 @@ class JSONPRenderer(JSONRenderer):
         callback = self.get_callback(renderer_context)
         json = super(JSONPRenderer, self).render(data, accepted_media_type,
                                                  renderer_context)
-        return "%s(%s);" % (callback, json)
+        return u"%s(%s);" % (callback, json)
 
 
 class XMLRenderer(BaseRenderer):
@@ -306,7 +306,7 @@ class BrowsableAPIRenderer(BaseRenderer):
                 if getattr(widget, 'choices', None):
                     choices = widget.choices
                     if any([ident != desc for (ident, desc) in choices]):
-                        choices = [(ident, "%s (%s)" % (desc, ident))
+                        choices = [(ident, u"%s (%s)" % (desc, ident))
                                    for (ident, desc) in choices]
                     widget.choices = choices
                 kwargs['widget'] = widget


### PR DESCRIPTION
Browseable API fails to render `ugettext_lazy` objects as choice description.
This seems to happen because `serializer_to_form` fields attempts to coerce the choices descr. to string.

Since current Django version runs on Python 2.7 I suggest returning it as Unicode (i.e: `u'translation'`), plus Python 3.3 should now support the `u''` syntax. I've also taken the liberty of doing this for `jsonp` renderer.

P.s: It seems wise to do this in all modules (you never know when unicode strings might appear).
