### PR TITLE
cleanup MultipleObjectBaseView remains

### DIFF
--- a/docs/tutorial/3-class-based-views.md
+++ b/docs/tutorial/3-class-based-views.md
@@ -92,7 +92,7 @@ Let's take a look at how we can compose our views by using the mixin classes.
 
     class SnippetList(mixins.ListModelMixin,
                       mixins.CreateModelMixin,
-                      generics.MultipleObjectBaseView):
+                      generics.MultipleObjectAPIView):
         model = Snippet
         serializer_class = SnippetSerializer
 
@@ -102,7 +102,7 @@ Let's take a look at how we can compose our views by using the mixin classes.
         def post(self, request, *args, **kwargs):
             return self.create(request, *args, **kwargs)
 
-We'll take a moment to examine exactly what's happening here - We're building our view using `MultipleObjectBaseView`, and adding in `ListModelMixin` and `CreateModelMixin`.
+We'll take a moment to examine exactly what's happening here - We're building our view using `MultipleObjectAPIView`, and adding in `ListModelMixin` and `CreateModelMixin`.
 
 The base class provides the core functionality, and the mixin classes provide the `.list()` and `.create()` actions.  We're then explicitly binding the `get` and `post` methods to the appropriate actions.  Simple enough stuff so far.
 

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -29,7 +29,7 @@ class CreateModelMixin(object):
 class ListModelMixin(object):
     """
     List a queryset.
-    Should be mixed in with `MultipleObjectBaseView`.
+    Should be mixed in with `MultipleObjectAPIView`.
     """
     empty_error = u"Empty list and '%(class_name)s.allow_empty' is False."
 


### PR DESCRIPTION
since `MultipleObjectBaseView` was renamed `MultipleObjectAPIView`, it stands to reason to complete the renaming in docs and comments as well.
