### PR TITLE
Return dictionaries as is

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -91,7 +91,7 @@ class Field(object):
         elif hasattr(value, '__iter__') and not isinstance(value, (dict, basestring)):
             return [self.to_native(item) for item in value]
         elif isinstance(value, dict):
-            return dict((k, self.to_native(v)) for k, v in value.items())
+            return dict(map(self.to_native, (k, v)) for k, v in value.items())
         return smart_unicode(value)
 
     def attributes(self):


### PR DESCRIPTION
Okay so I've got the following model:

```
class Model(models.Model):
    @property
    def props(self):
        return {
            'foo': 'bar',
            'foo_bar': {
                'f': 1,
                'o': 2,
            },
        }

class Serializer(serializers.ModelSerializer):
    props = serializers.Field(source='props')

    class Meta:
        fields = ('props', )
```

What `fields.Field.to_native` currently does is to return a string representation of the dictionary like this: `"{'foo_bar': {'foo': 1, 'bar': 2}, 'foo': 'bar'}"`. I've changed the default to what I think is a more sensible behavior, returning dictionaries as is (it recursively applies to_native on keys and values of the dict like is currently done with values of other iterables).
