### PR TITLE
Rare case where rel attribute of model field is None and DRF tries to return rel.to

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -211,9 +211,9 @@ class ModelField(WritableField):
     def from_native(self, value):
         try:
             rel = self.model_field.rel
+            return rel.to._meta.get_field(rel.field_name).to_python(value)
         except:
             return self.model_field.to_python(value)
-        return rel.to._meta.get_field(rel.field_name).to_python(value)
 
     def field_to_native(self, obj, field_name):
         value = self.model_field._get_val_from_obj(obj)


### PR DESCRIPTION
Just a tiny change (no biggie at all) to fail if the rel.to value is none in DRF2's default ModelField.
