### PR TITLE
Fixed AttributeError in ModelSerializer.save when ModelSerializer.restore_object is overwritten

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -458,7 +458,7 @@ class ModelSerializer(Serializer):
         """
         self.object.save()
 
-        if self.m2m_data and save_m2m:
+        if getattr(self, 'm2m_data', None) and save_m2m:
             for accessor_name, object_list in self.m2m_data.items():
                 setattr(self.object, accessor_name, object_list)
             self.m2m_data = {}


### PR DESCRIPTION
I encountered this issue as I was overwritting a serializer's restore_object without explicitly setting self.m2m_data. Calling save() then failed as the default implementation of save did require self.m2m_data to be set.

Btw: great work!!!
