### PR TITLE
Fixed typo on safe_mode markdown wrapper

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -340,7 +340,7 @@ try:
         """
 
         extensions = ['headerid(level=2)']
-        safe_mode = False,
+        safe_mode = False
         md = markdown.Markdown(extensions=extensions, safe_mode=safe_mode)
         return md.convert(text)
 


### PR DESCRIPTION
Just removed a coma that makes safe_mode be True instead of intended False :)
