### PR TITLE
Unexpected exception when creating an instance with missing M2M data

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -351,8 +351,13 @@ class ManyRelatedMixin(object):
         except:
             # Non-form data
             value = data.get(self.source or field_name)
-        if value == [''] or value is None:
-            value = []
+        else:
+            if value == ['']:
+                value = []
+
+        if value is None and self.required:
+            raise ValidationError("Field '%s' is required" % field_name)
+
         into[field_name] = [self.from_native(item) for item in value]
 
 

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -340,11 +340,7 @@ class ManyToManyTests(TestCase):
         """
         data = {}
         serializer = self.serializer_class(data=data)
-        self.assertEqual(serializer.is_valid(), True)
-        instance = serializer.save()
-        self.assertEquals(len(ManyToManyModel.objects.all()), 2)
-        self.assertEquals(instance.pk, 2)
-        self.assertEquals(list(instance.rel.all()), [])
+        self.assertEqual(serializer.is_valid(), False)
 
     def test_create_empty_relationship_flat_data(self):
         """


### PR DESCRIPTION
You get `'NoneType' object is not iterable` exception instead of `{"user": ["Invalid pk 'None' - object does not exist."]}`  _(or similar)_ reponse if you try to create a new instance without M2M field data.

This is a test case to reproduce that exception.
