### PR TITLE
Use 401 with Authenticate header, when appropriate

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -86,6 +86,7 @@ class Request(object):
         self._method = Empty
         self._content_type = Empty
         self._stream = Empty
+        self._authenticated = False
 
         if self.parser_context is None:
             self.parser_context = {}
@@ -288,6 +289,7 @@ class Request(object):
         for authenticator in self.authenticators:
             user_auth_tuple = authenticator.authenticate(self)
             if not user_auth_tuple is None:
+                self._authenticated = True
                 return user_auth_tuple
         return self._not_authenticated()
 

--- a/rest_framework/tests/decorators.py
+++ b/rest_framework/tests/decorators.py
@@ -109,7 +109,7 @@ class DecoratorTestCase(TestCase):
 
         request = self.factory.get('/')
         response = view(request)
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_throttle_classes(self):
         class OncePerDayUserThrottle(UserRateThrottle):


### PR DESCRIPTION
This is attempt to fix Issue #187 - 401 v.s. 403 - with your recommendations from the unauthenticated_response branch. 
