### PR TITLE
Cache all fields per serializer instance

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -135,7 +135,7 @@ class BaseSerializer(Field):
 
         # Add in the default fields
         default_fields = self.get_default_fields()
-        for key, val in self.default_fields.items():
+        for key, val in default_fields.items():
             if key not in ret:
                 ret[key] = val
 


### PR DESCRIPTION
This takes my previous pull request of caching the default_fields, and caches all per Tom's feedback. Please note the changes to the pagination plugin -- this could affect code in the wild.

Using my highly scientific benchmarking, this change takes my serialization of around 2000 items from 0.5 seconds to 0.37 seconds.

Future idea and thought: in a basic configuration of django model serialization, fields aren't dynamically updated and the get_fields method is very much a classmethod, so the field extraction _could_ be done at metaclass.**init** time. This is probably overkill, but could set up fields at startup time, not serializer instantiation time. IMO this is too much magic, but tweaking performance does this sort of thing to you :-)
