### PR TITLE
Add setter to user property on request object

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -169,6 +169,15 @@ class Request(object):
             self._user, self._auth = self._authenticate()
         return self._user
 
+    @user.setter
+    def user(self, value):
+         """
+         Sets the user on the current request. This is necessary to maintain
+         compatilbility with django.contrib.auth where the user proprety is
+         set in the login and logout functions.
+         """
+         self._user = value
+
     @property
     def auth(self):
         """


### PR DESCRIPTION
This change adds a setter to the user property on the request object.

This allows standard django login / logout to be used as discussed here:

https://groups.google.com/d/topic/django-rest-framework/f65BjbQfEjI/discussion
