### PR TITLE
Tutorial: fix module name in section 3

### DIFF
--- a/docs/tutorial/3-class-based-views.md
+++ b/docs/tutorial/3-class-based-views.md
@@ -6,8 +6,8 @@ We can also write our API views using class based views, rather than function ba
 
 We'll start by rewriting the root view as a class based view.  All this involves is a little bit of refactoring.
 
-    from snippet.models import Snippet
-    from snippet.serializers import SnippetSerializer
+    from snippets.models import Snippet
+    from snippets.serializers import SnippetSerializer
     from django.http import Http404
     from rest_framework.views import APIView
     from rest_framework.response import Response
@@ -66,7 +66,7 @@ We'll also need to refactor our URLconf slightly now we're using class based vie
 
     from django.conf.urls import patterns, url
     from rest_framework.urlpatterns import format_suffix_patterns
-    from snippetpost import views
+    from snippets import views
 
     urlpatterns = patterns('',
         url(r'^snippets/$', views.SnippetList.as_view()),
@@ -85,8 +85,8 @@ The create/retrieve/update/delete operations that we've been using so far are go
 
 Let's take a look at how we can compose our views by using the mixin classes.
 
-    from snippet.models import Snippet
-    from snippet.serializers import SnippetSerializer
+    from snippets.models import Snippet
+    from snippets.serializers import SnippetSerializer
     from rest_framework import mixins
     from rest_framework import generics
 
@@ -128,8 +128,8 @@ Pretty similar.  This time we're using the `SingleObjectBaseView` class to provi
 
 Using the mixin classes we've rewritten the views to use slightly less code than before, but we can go one step further.  REST framework provides a set of already mixed-in generic views that we can use.
 
-    from snippet.models import Snippet
-    from snippet.serializers import SnippetSerializer
+    from snippets.models import Snippet
+    from snippets.serializers import SnippetSerializer
     from rest_framework import generics
 
 


### PR DESCRIPTION
Again snippet -> snippets, but then it could be simpler (and possibly intended) to rename snippets to snippet in the first section of the tutorial.
