### PR TITLE
Pass along the context to the object_serializer in BasePaginationSeriali...

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -62,7 +62,8 @@ class BasePaginationSerializer(serializers.Serializer):
         super(BasePaginationSerializer, self).__init__(*args, **kwargs)
         results_field = self.results_field
         object_serializer = self.opts.object_serializer_class
-        self.fields[results_field] = object_serializer(source='object_list')
+        self.fields[results_field] = object_serializer(source='object_list',
+                                                       context=self.context)
 
     def to_native(self, obj):
         """


### PR DESCRIPTION
This little change passes the BasePaginationSerializer's context to the constructor of the object_serializer_class used for the 'results' field. 

I came across the need to pass the context along in order to get absolute URLs in the serialization of the paginated objects.
