### PR TITLE
Allow the data to be overridden by subclasses

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -83,7 +83,7 @@ class UpdateModelMixin(object):
     Update a model instance.
     Should be mixed in with `SingleObjectBaseView`.
     """
-    def update(self, request, *args, **kwargs):
+    def update(self, request, data=None, *args, **kwargs):
         try:
             self.object = self.get_object()
             created = False
@@ -91,7 +91,10 @@ class UpdateModelMixin(object):
             self.object = None
             created = True
 
-        serializer = self.get_serializer(self.object, data=request.DATA, files=request.FILES)
+        if data is None:
+            data = request.DATA
+
+        serializer = self.get_serializer(self.object, data=data, files=request.FILES)
 
         if serializer.is_valid():
             self.pre_save(serializer.object)


### PR DESCRIPTION
This is useful in cases like per-user objects, where objects a user creates are automatically owned by them. The user's ListCreateAPIView subclass can simply override create(), copy the request.DATA, add the request.user to the data, and then use super() to call the parent class with the overridden data.
