### PR TITLE
Fix issue where pk was was being set to a string.

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -105,11 +105,11 @@ class UpdateModelMixin(object):
         """
         # pk and/or slug attributes are implicit in the URL.
         pk = self.kwargs.get(self.pk_url_kwarg, None)
-        try:
-            pk = int(pk)
-        except ValueError:
-            pass
         if pk:
+            try:
+                pk = int(pk)
+            except ValueError:
+                pass
             setattr(obj, 'pk', pk)
 
         slug = self.kwargs.get(self.slug_url_kwarg, None)


### PR DESCRIPTION
We had an issue where update (PUT) requests were returning the id (pk) value of a model as a string instead of an int. All other requests seem to return the id as an int. Because JSON can differentiate strings from ints this change was causing unexpected side effects in our clientside framework. This unexpected behavior seems to be due to the parsing of the pk field from the url kwargs in the UpdateModelMixin. 

While most Django models will probably have id values as ints, I could see an issue where the pk field is not an int and thus the suggested change may not be optimal. With some guidance I'd be happy to help implement a more robust solution, if you think one exists.
