### PR TITLE
Make the kwargs from the URL available in the request.

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -75,12 +75,13 @@ class Request(object):
     _CONTENTTYPE_PARAM = api_settings.FORM_CONTENTTYPE_OVERRIDE
 
     def __init__(self, request, parsers=None, authenticators=None,
-                 negotiator=None, parser_context=None):
+                 negotiator=None, parser_context=None, kargs = {}):
         self._request = request
         self.parsers = parsers or ()
         self.authenticators = authenticators or ()
         self.negotiator = negotiator or self._default_negotiator()
         self.parser_context = parser_context
+        self.kwargs = kargs
         self._data = Empty
         self._files = Empty
         self._method = Empty

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -275,7 +275,7 @@ class APIView(View):
                        parsers=self.get_parsers(),
                        authenticators=self.get_authenticators(),
                        negotiator=self.get_content_negotiator(),
-                       parser_context=parser_context)
+                       parser_context=parser_context, kargs=kargs)
 
     def initial(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
This makes captures from the urls.py entries available at all points (including during authentication)
