### PR TITLE
get_excluded_fieldnames() should respect Meta options' ability to be eit...

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -132,9 +132,9 @@ class BaseSerializer(Field):
         Returns the fieldnames that should not be validated.
         """
         excluded_fields = list(self.opts.exclude)
-        for field in self.fields.keys() + self.get_default_fields().keys():
-            if self.opts.fields:
-                if field not in self.opts.fields + self.opts.exclude:
+        if self.opts.fields:
+            for field in self.fields.keys() + self.get_default_fields().keys():
+                if field not in list(self.opts.fields) + excluded_fields:
                     excluded_fields.append(field)
         return excluded_fields
 

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -66,6 +66,7 @@ class AlbumsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Album
+        fields = ['title']  # lists are also valid options
 
 
 class BasicTests(TestCase):
@@ -282,9 +283,11 @@ class ValidationTests(TestCase):
         self.assertEquals(serializer.is_valid(), False)
         self.assertEquals(serializer.errors, {'info': [u'Ensure this value has at most 12 characters (it has 13).']})
 
+
+class ModelValidationTests(TestCase):
     def test_validate_unique(self):
         """
-        Just check if serializers.ModelSerializer.perform_model_validation() handles unique checks via .full_clean()
+        Just check if serializers.ModelSerializer handles unique checks via .full_clean()
         """
         serializer = AlbumsSerializer(data={'title': 'a'})
         serializer.is_valid()


### PR DESCRIPTION
...her a tuple or list. Fixes #490.

Refactored `if self.opt.fields` out of the for loop.
Updated and cleaned up the validation-tests.
