### PR TITLE
Making sure the assert does not fail  when required=False, read_only=True

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -133,7 +133,7 @@ class WritableField(Field):
         if required is None:
             self.required = not(read_only)
         else:
-            assert not read_only, "Cannot set required=True and read_only=True"
+            assert not (read_only and required), "Cannot set required=True and read_only=True"
             self.required = required
 
         messages = {}


### PR DESCRIPTION
Currently when you pass in required=False and read_only=True , you erroneously get an error  saying ""Cannot set required=True and read_only=True" . This is because the assert is only checking for the read_only field in the else clause and assumes required is True in this clause but the if check is only for None and so it'll fail when the required is set to False and read_only is set to True. By making this assert explicitly check the complete condition, this case of required=False, read_only=True is handled.
