### PR TITLE
context doesn't get applied to the 2nd level of nested serializers

### DIFF
--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -769,8 +769,6 @@ class DepthTest(TestCase):
 class NestedSerializerContextTests(TestCase):
 
     def test_nested_serializer_context(self):
-        class AlbumCollection(object):
-            albums = None
 
         class PhotoSerializer(serializers.ModelSerializer):
             class Meta:
@@ -797,15 +795,24 @@ class NestedSerializerContextTests(TestCase):
                     raise RuntimeError("context isn't getting passed into 1st level nested serializer")
                 return "success"
 
+        class AlbumCollection(object):
+            albums = None
+
         class AlbumCollectionSerializer(serializers.Serializer):
-            albums = AlbumSerializer(source="albums", )
+            albums = AlbumSerializer(source="albums")
+
         album1 = Album.objects.create(title="album 1")
-        album1.photo_set.add(Photo(description="Dog"), Photo(description="Cat"))
+        album1.photo_set.add(
+            Photo.objects.create(description="Bigfoot"),
+            Photo.objects.create(description="Unicorn"))
         album2 = Album.objects.create(title="album 2")
-        album2.photo_set.add(Photo(description="Yeti"), Photo(description="Sasquatch"), Photo(description="Bigfoot"))
+        album2.photo_set.add(
+            Photo.objects.create(description="Yeti"),
+            Photo.objects.create(description="Sasquatch"))
         album_collection = AlbumCollection()
         album_collection.albums = [album1, album2]
 
+        #the test.  (will raise RuntimeError if context doesn't get passed correctly to the nested Serializers)
         data = AlbumCollectionSerializer(album_collection, context={'context_item': 'album context'}).data
 
 


### PR DESCRIPTION
I've written a failing test that mirrors a problem I'm having in some of my code.   Basically, context passed in to a root serializer doesn't get applied to the 2nd level of nested serializers.  This seemed to work before (2.1.2) but my code broke in the update to 2.1.8.  

Please let me know whether the problem is that I'm using the framework incorrectly or if this is actually an issue.  If it is an issue, and someone can point me in the right direction to a fix, I'd be happy to to attempt and submit a patch.  

I wasn't  familiar with how to reference a failing test in my own fork to a new issue here.  Doing a pull request may be the wrong protocol; if so, please let me know the right way to do it.

(thankfully the workaround for this bug is pretty simple, just check self.context and set it to self.root.context if its empty)
