### PR TITLE
Custom field context when pagination is used

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -62,7 +62,7 @@ class BasePaginationSerializer(serializers.Serializer):
         super(BasePaginationSerializer, self).__init__(*args, **kwargs)
         results_field = self.results_field
         object_serializer = self.opts.object_serializer_class
-        self.fields[results_field] = object_serializer(source='object_list')
+        self.fields[results_field] = object_serializer(source='object_list', **kwargs)
 
     def to_native(self, obj):
         """


### PR DESCRIPTION
It is partially connected with #497 issue and stopped working in 2.1.5.
When pagination is used context was not passed to serializer_class.
