### PR TITLE
ManyPrimaryKeyRelatedField now supports create for one-to-many rel

### DIFF
--- a/rest_framework/tests/models.py
+++ b/rest_framework/tests/models.py
@@ -149,6 +149,11 @@ class BlogPostComment(RESTFrameworkModel):
     blog_post = models.ForeignKey(BlogPost)
 
 
+class BlogPostRelatedComment(RESTFrameworkModel):
+    text = models.TextField()
+    blog_post = models.ForeignKey(BlogPost, related_name="comments")
+
+
 class Album(RESTFrameworkModel):
     title = models.CharField(max_length=100, unique=True)
 


### PR DESCRIPTION
In the current release if you are using the field type "ManyPrimaryKeyRelatedField" you cannot create a model unless you flip the "read_only" bit on. In the event that you actually need to create a model with this related data it blew up.
