### PR TITLE
Added virtualenv-generated directories to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,10 @@ dist/
 *.egg-info/
 MANIFEST
 
+bin/
+include/
+lib/
+local/
+
 !.gitignore
 !.travis.yml


### PR DESCRIPTION
I've installed djangorestframework in a virtualenv for isolated testing. For that I need to ignore the virtualenv-generated directories.
