### PR TITLE
Replace get_static_prefix template tag with static

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -1,6 +1,6 @@
 {% load url from future %}
 {% load rest_framework %}
-{% load static %}
+{% load staticfiles %}
 <!DOCTYPE html>
 <html>
     <head>
@@ -14,10 +14,10 @@
         <title>{% block title %}Django REST framework{% endblock %}</title>
 
         {% block style %}
-        <link rel="stylesheet" type="text/css" href="{% get_static_prefix %}rest_framework/css/bootstrap.min.css"/>
-        <link rel="stylesheet" type="text/css" href="{% get_static_prefix %}rest_framework/css/bootstrap-tweaks.css"/>
-        <link rel="stylesheet" type="text/css" href='{% get_static_prefix %}rest_framework/css/prettify.css'/>
-        <link rel="stylesheet" type="text/css" href='{% get_static_prefix %}rest_framework/css/default.css'/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/prettify.css" %}"/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/default.css" %}"/>
         {% endblock %}
 
     {% endblock %}
@@ -195,10 +195,10 @@
     {% endblock %}
 
     {% block script %}
-    <script src="{% get_static_prefix %}rest_framework/js/jquery-1.8.1-min.js"></script>
-    <script src="{% get_static_prefix %}rest_framework/js/bootstrap.min.js"></script>
-    <script src="{% get_static_prefix %}rest_framework/js/prettify-min.js"></script>
-    <script src="{% get_static_prefix %}rest_framework/js/default.js"></script>
+    <script src="{% static "rest_framework/js/jquery-1.8.1-min.js" %}"></script>
+    <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
+    <script src="{% static "rest_framework/js/prettify-min.js" %}"></script>
+    <script src="{% static "rest_framework/js/default.js" %}"></script>
     {% endblock %}
   </body>
 </html>

--- a/rest_framework/templates/rest_framework/login.html
+++ b/rest_framework/templates/rest_framework/login.html
@@ -1,11 +1,11 @@
 {% load url from future %}
-{% load static %}
+{% load staticfiles %}
 <html>
 
     <head>
-        <link rel="stylesheet" type="text/css" href="{% get_static_prefix %}rest_framework/css/bootstrap.min.css"/>
-        <link rel="stylesheet" type="text/css" href="{% get_static_prefix %}rest_framework/css/bootstrap-tweaks.css"/>
-        <link rel="stylesheet" type="text/css" href='{% get_static_prefix %}rest_framework/css/default.css'/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/default.css" %}"/>
     </head>
 
     <body class="container">


### PR DESCRIPTION
When we use a custom static files storage backend (e.g. django-storages), we get wrong URLs for static files in html view templates because `get_static_prefix` template tag just returns value of `STATIC_URL` setting. To fix that we should use `static` template tag which [builds the URL for the given relative path by using the configured STATICFILES_STORAGE storage.](https://docs.djangoproject.com/en/1.4/howto/static-files/#with-a-template-tag)
