### PR TITLE
missing rest_framework templatetags for statics in login template

### DIFF
--- a/rest_framework/templates/rest_framework/login.html
+++ b/rest_framework/templates/rest_framework/login.html
@@ -1,4 +1,5 @@
 {% load url from future %}
+{% load rest_framework %}
 <html>
 
     <head>


### PR DESCRIPTION
"static" tag is not defined in login.html template.
