### PR TITLE
Deprecate django.utils.simplejson in favor of Python 2.6's built-in json module

### DIFF
--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -8,11 +8,11 @@ on the request, such as form content or json encoded data.
 from django.http import QueryDict
 from django.http.multipartparser import MultiPartParser as DjangoMultiPartParser
 from django.http.multipartparser import MultiPartParserError
-from django.utils import simplejson as json
 from rest_framework.compat import yaml, ETParseError
 from rest_framework.exceptions import ParseError
 from xml.etree import ElementTree as ET
 from xml.parsers.expat import ExpatError
+import json
 import datetime
 import decimal
 

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -8,10 +8,10 @@ REST framework also provides an HTML renderer the renders the browsable API.
 """
 import copy
 import string
+import json
 from django import forms
 from django.http.multipartparser import parse_header
 from django.template import RequestContext, loader, Template
-from django.utils import simplejson as json
 from rest_framework.compat import yaml
 from rest_framework.exceptions import ConfigurationError
 from rest_framework.settings import api_settings

--- a/rest_framework/tests/authentication.py
+++ b/rest_framework/tests/authentication.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.test import Client, TestCase
-from django.utils import simplejson as json
 
 from rest_framework import permissions
 from rest_framework.authtoken.models import Token
@@ -9,6 +8,7 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.compat import patterns
 from rest_framework.views import APIView
 
+import json
 import base64
 
 

--- a/rest_framework/tests/generics.py
+++ b/rest_framework/tests/generics.py
@@ -1,6 +1,6 @@
+import json
 from django.db import models
 from django.test import TestCase
-from django.utils import simplejson as json
 from rest_framework import generics, serializers, status
 from rest_framework.tests.utils import RequestFactory
 from rest_framework.tests.models import BasicModel, Comment, SlugBasedModel

--- a/rest_framework/tests/hyperlinkedserializers.py
+++ b/rest_framework/tests/hyperlinkedserializers.py
@@ -1,6 +1,6 @@
+import json
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.utils import simplejson as json
 from rest_framework import generics, status, serializers
 from rest_framework.compat import patterns, url
 from rest_framework.tests.models import Anchor, BasicModel, ManyToManyModel, BlogPost, BlogPostComment, Album, Photo, OptionalRelationModel

--- a/rest_framework/tests/request.py
+++ b/rest_framework/tests/request.py
@@ -1,12 +1,12 @@
 """
 Tests for content parsing, and form-overloaded content parsing.
 """
+import json
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import TestCase, Client
 from django.test.client import RequestFactory
-from django.utils import simplejson as json
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.compat import patterns

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -4,7 +4,7 @@ Helper classes for parsers.
 import datetime
 import decimal
 import types
-from django.utils import simplejson as json
+import json
 from django.utils.datastructures import SortedDict
 from rest_framework.compat import timezone
 from rest_framework.serializers import DictWithMetadata, SortedDictWithMetadata


### PR DESCRIPTION
Since `django-rest-framework` doesn't support Python 2.5, we can now rely on the json module being available in Python's standard library.

Django maintainers [recommend](https://docs.djangoproject.com/en/dev/releases/1.5/#system-version-of-simplejson-no-longer-used) to use it from now on.
