### PR TITLE
Update docs/api-guide/pagination.md

### DIFF
--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -96,8 +96,11 @@ You can also set the pagination style on a per-view basis, using the `ListAPIVie
         model = ExampleModel
         paginate_by = 10
         paginate_by_param = 'page_size'
+Note: to override the default pagination settings on a per-view basis, using 'paginate_by = 0' will turn off the pagination for this view
 
 For more complex requirements such as serialization that differs depending on the requested media type you can override the `.get_paginate_by()` and `.get_pagination_serializer_class()` methods.
+
+
 
 ---
 


### PR DESCRIPTION
If you use the default pagination settings, but for a specific view you don't want to have the pagination, it might be handy to know setting paginate_by to 0 will tutn pagination off for this particular view.
