### PR TITLE
One-to-one writable, nested serializer support

### DIFF
--- a/rest_framework/tests/nesting.py
+++ b/rest_framework/tests/nesting.py
@@ -106,7 +106,7 @@ class NestedOneToOneTests(TestCase):
         self.assertEquals(serializer.data, expected)
 
     def test_one_to_one_delete(self):
-        data = {'id': 3, 'name': u'target-3', 'target_source': {'_delete': True, 'id': 3, 'name': u'target-source-3', 'source': {'id': 3, 'name': u'source-3'}}}
+        data = {'id': 3, 'name': u'target-3', 'target_source': None}
         instance = OneToOneTarget.objects.get(pk=3)
         serializer = OneToOneTargetSerializer(instance, data=data)
         self.assertTrue(serializer.is_valid())


### PR DESCRIPTION
Adds writable nested serializer support for reverse one-to-one relations.  These changes include #553 as it was necessary for the tests to pass.  Once #553 is merged I'll update the diff here.
