### PR TITLE
{% static %} template tag for Django 1.5

### DIFF
--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -23,7 +23,7 @@ register = template.Library()
 # conflicts with this rest_framework template tag module.
 
 try:  # Django 1.5+
-    from django.contrib.staticfiles.templatetags import StaticFilesNode
+    from django.contrib.staticfiles.templatetags.staticfiles import StaticFilesNode
 
     @register.tag('static')
     def do_static(parser, token):


### PR DESCRIPTION
Perhaps a rename has happened during the 1.5 development cycle, but the `rest_framework` template tags attempt to import

```
from django.contrib.staticfiles.templatetags import StaticFilesNode
```

the correct import is now

```
from django.contrib.staticfiles.templatetags.staticfiles import StaticFilesNode
```
