### PR TITLE
Support URL namespaces.

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -403,7 +403,7 @@ class HyperlinkedRelatedField(RelatedField):
         except:
             raise ValidationError(self.error_messages['no_match'])
 
-        if match.url_name != self.view_name:
+        if match.view_name != self.view_name:
             raise ValidationError(self.error_messages['incorrect_match'])
 
         pk = match.kwargs.get(self.pk_url_kwarg, None)


### PR DESCRIPTION
My API urls are deployed under a django URL namespace - this largely works fine - I override `_default_url_name` to include the namespace and all the reversing works to render the urls properly. However the resolving of urls fails as we're checking against the non-namespaced version.

It would be ideal to be able to just set 'namespace' somehow and everything just work, but this is close enough.

Not sure how to go about testing this change...
