### PR TITLE
Failing Test Case for #606 "Support for Hyperlinked Generic Relationships"

### DIFF
--- a/rest_framework/tests/genericrelations.py
+++ b/rest_framework/tests/genericrelations.py
@@ -1,9 +1,23 @@
 from django.test import TestCase
-from rest_framework import serializers
+from rest_framework import serializers, generics
 from rest_framework.tests.models import *
+from rest_framework.compat import patterns, url
+
+
+class BookmarkDetail(generics.RetrieveAPIView):
+    model = ManyToManyModel
+    serializer_class = serializers.HyperlinkedModelSerializer
+
+
+urlpatterns = patterns('',
+    url(r'^bookmark/(?P<pk>\d+)/$', BookmarkDetail.as_view(), name='bookmarks-detail'),
+)
 
 
 class TestGenericRelations(TestCase):
+
+    urls = 'rest_framework.tests.genericrelations'
+
     def setUp(self):
         bookmark = Bookmark(url='https://www.djangoproject.com/')
         bookmark.save()
@@ -29,5 +43,20 @@ class TestGenericRelations(TestCase):
         expected = {
             'tags': [u'django', u'python'],
             'url': u'https://www.djangoproject.com/'
+        }
+        self.assertEquals(serializer.data, expected)
+
+    def test_hyperlinked_generic_relation(self):
+
+        class BookmarkSerializer(serializers.ModelSerializer):
+            tags = serializers.ManyHyperlinkedRelatedField(source='tags')
+
+            class Meta:
+                model = Bookmark
+                exclude = ('id', 'url')
+
+        serializer = BookmarkSerializer(self.bookmark)
+        expected = {
+            'tags': [u'/bookmark/1/', u'/bookmark/2/']
         }
         self.assertEquals(serializer.data, expected)


### PR DESCRIPTION
Failing test case as mentioned in #606 

Caveats:
- The test is against `ManyHyperlinkedRelatedField` - this suggests the implementation to some degree, which I don't intend. As much as anything else, this is just by way of contrast against the other test in `genericrelations.py`, which uses `ManyRelatedField`.
- If the correct `view_name` is given to the `ManyHyperlinkedRelatedField`
  ('bookmarks-detail'), the test passes, though of course this is only
  because the test relationship is a Bookmark. When it does work,
  the hyperlinks don't contain a protocol or hostname ("http://testserver/..."). I
  assume this is because no real request/response context exists, but I don't have a lot of experience with testing request/response.

I have not specified something via the medium of failing test case before, so any critique is welcome. Also, critique of my shitty Python is fine.
