### PR TITLE
Test case: overriding restore_object on a ModelSerializer causes the validation for model fields to be skipped

### DIFF
--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -54,6 +54,19 @@ class ActionItemSerializer(serializers.ModelSerializer):
         model = ActionItem
 
 
+class ActionItemUpdateSerializer(serializers.ModelSerializer):
+
+    def restore_object(self, data, instance=None):
+        if instance is None:
+            return ActionItem(**data)
+        for key, val in data.items():
+            setattr(instance, key, val)
+        return instance
+
+    class Meta:
+        model = ActionItem
+
+
 class PersonSerializer(serializers.ModelSerializer):
     info = serializers.Field(source='info')
 
@@ -299,6 +312,15 @@ class ValidationTests(TestCase):
         serializer = ActionItemSerializer(data=data)
         self.assertEquals(serializer.is_valid(), False)
         self.assertEquals(serializer.errors, {'title': [u'Ensure this value has at most 200 characters (it has 201).']})
+
+    def test_modelserializer_update_max_length_exceeded(self):
+        data = {
+            'title': 'x' * 201,
+        }
+        serializer = ActionItemUpdateSerializer(data=data)
+        self.assertEquals(serializer.is_valid(), False)
+        self.assertEquals(serializer.errors, {'title': [u'Ensure this value has at most 200 characters (it has 201).']})
+
 
     def test_default_modelfield_max_length_exceeded(self):
         data = {


### PR DESCRIPTION
Implementing a `ModelSerializer` with an overriden `restore_object` method causes that serializer to skip the validation for model fields. Validation without `restore_object` on the `ModelSerializer` subclass works just fine.

This error was introduced between 2.1.6 and 2.1.7 (I tested individual versions), but I cannot find the source of the error.

The pull request contains a simple test case for this scenario: A `ModelSerializer` with an override for `restore_object`, taken from other Serializers in the test case file. No fix is attached.
