### PR TITLE
Add better date / datetime validation

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -189,6 +189,8 @@ Corresponds to `django.db.models.fields.DateField`
 
 Uses `DATE_INPUT_FORMATS` to validate date.
 
+Optionally takes `format` as parameter to replace the matching pattern.
+
 ## DateTimeField
 
 A date and time representation.
@@ -196,6 +198,8 @@ A date and time representation.
 Corresponds to `django.db.models.fields.DateTimeField`
 
 Uses `DATETIME_INPUT_FORMATS` to validate date_time.
+
+Optionally takes `format` as parameter to replace the matching pattern.
 
 When using `ModelSerializer` or `HyperlinkedModelSerializer`, note that any model fields with `auto_now=True` or `auto_now_add=True` will use serializer fields that are `read_only=True` by default.
 

--- a/rest_framework/tests/fields.py
+++ b/rest_framework/tests/fields.py
@@ -2,8 +2,10 @@
 General serializer field tests.
 """
 
+import django
 from django.db import models
 from django.test import TestCase
+from django.utils import unittest
 from rest_framework import serializers
 
 
@@ -16,6 +18,16 @@ class CharPrimaryKeyModel(models.Model):
     id = models.CharField(max_length=20, primary_key=True)
 
 
+class DateObject(object):
+    def __init__(self, date):
+        self.date = date
+
+
+class DateTimeObject(object):
+    def __init__(self, date_time):
+        self.date_time = date_time
+
+
 class TimestampedModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = TimestampedModel
@@ -24,6 +36,46 @@ class TimestampedModelSerializer(serializers.ModelSerializer):
 class CharPrimaryKeyModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = CharPrimaryKeyModel
+
+
+class DateObjectSerializer(serializers.Serializer):
+    date = serializers.DateField()
+
+    def restore_object(self, attrs, instance=None):
+        if instance is not None:
+            instance.date = attrs['date']
+            return instance
+        return DateObject(**attrs)
+
+
+class DateObjectCustomFormatSerializer(serializers.Serializer):
+    date = serializers.DateField(format=("%Y", "%Y -- %m"))
+
+    def restore_object(self, attrs, instance=None):
+        if instance is not None:
+            instance.date = attrs['date']
+            return instance
+        return DateObject(**attrs)
+
+
+class DateTimeObjectSerializer(serializers.Serializer):
+    date_time = serializers.DateTimeField()
+
+    def restore_object(self, attrs, instance=None):
+        if instance is not None:
+            instance.date_time = attrs['date_time']
+            return instance
+        return DateTimeObject(**attrs)
+
+
+class DateTimeObjectCustomFormatSerializer(serializers.Serializer):
+    date_time = serializers.DateTimeField(format=("%Y", "%Y %H:%M"))
+
+    def restore_object(self, attrs, instance=None):
+        if instance is not None:
+            instance.date_time = attrs['date_time']
+            return instance
+        return DateTimeObject(**attrs)
 
 
 class ReadOnlyFieldTests(TestCase):
@@ -47,3 +99,133 @@ class ReadOnlyFieldTests(TestCase):
         """
         serializer = CharPrimaryKeyModelSerializer()
         self.assertEquals(serializer.fields['id'].read_only, False)
+
+
+class DateValidationTest(TestCase):
+    def test_valid_default_date_input_formats(self):
+        serializer = DateObjectSerializer(data={'date': '1984-07-31'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': '07/31/1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': '07/31/84'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': 'Jul 31 1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': 'Jul 31, 1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': '31 Jul 1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': '31 Jul 1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': 'July 31 1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': 'July 31, 1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': '31 July 1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectSerializer(data={'date': '31 July, 1984'})
+        self.assertTrue(serializer.is_valid())
+
+    def test_valid_custom_date_input_formats(self):
+        serializer = DateObjectCustomFormatSerializer(data={'date': '1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateObjectCustomFormatSerializer(data={'date': '1984 -- 07'})
+        self.assertTrue(serializer.is_valid())
+
+    def test_wrong_default_date_input_format(self):
+        serializer = DateObjectSerializer(data={'date': 'something wrong'})
+        self.assertFalse(serializer.is_valid())
+        self.assertEquals(serializer.errors, {'date': [u'Date has wrong format. Use one of these formats instead: '
+                                                       u'YYYY-MM-DD; MM/DD/YYYY; MM/DD/YY; [Jan through Dec] DD YYYY; '
+                                                       u'[Jan through Dec] DD, YYYY; DD [Jan through Dec] YYYY; '
+                                                       u'DD [Jan through Dec], YYYY; [January through December] DD YYYY; '
+                                                       u'[January through December] DD, YYYY; DD [January through December] YYYY; '
+                                                       u'DD [January through December], YYYY']})
+
+    def test_wrong_custom_date_input_format(self):
+        serializer = DateObjectCustomFormatSerializer(data={'date': '07/31/1984'})
+        self.assertFalse(serializer.is_valid())
+        self.assertEquals(serializer.errors, {'date': [u'Date has wrong format. Use one of these formats instead: YYYY; YYYY -- MM']})
+
+
+class DateTimeValidationTest(TestCase):
+    def test_valid_default_date_time_input_formats(self):
+        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31 04:31:59'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31 04:31'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984 04:31:59'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984 04:31'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84 04:31:59'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84 04:31'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84'})
+        self.assertTrue(serializer.is_valid())
+
+    @unittest.skipUnless(django.VERSION >= (1, 4), "django < 1.4 don't have microseconds in default settings")
+    def test_valid_default_date_time_input_formats_for_django_gte_1_4(self):
+        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31 04:31:59.123456'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984 04:31:59.123456'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84 04:31:59.123456'})
+        self.assertTrue(serializer.is_valid())
+
+    def test_valid_custom_date_time_input_formats(self):
+        serializer = DateTimeObjectCustomFormatSerializer(data={'date_time': '1984'})
+        self.assertTrue(serializer.is_valid())
+
+        serializer = DateTimeObjectCustomFormatSerializer(data={'date_time': '1984 04:31'})
+        self.assertTrue(serializer.is_valid())
+
+    @unittest.skipUnless(django.VERSION >= (1, 4), "django < 1.4 don't have microseconds in default settings")
+    def test_wrong_default_date_time_input_format_for_django_gte_1_4(self):
+        serializer = DateTimeObjectSerializer(data={'date_time': 'something wrong'})
+        self.assertFalse(serializer.is_valid())
+        self.assertEquals(serializer.errors, {'date_time': [u'Datetime has wrong format. Use one of these formats instead: '
+                                                            u'YYYY-MM-DD HH:MM:SS; YYYY-MM-DD HH:MM:SS.uuuuuu; YYYY-MM-DD HH:MM; '
+                                                            u'YYYY-MM-DD; MM/DD/YYYY HH:MM:SS; MM/DD/YYYY HH:MM:SS.uuuuuu; '
+                                                            u'MM/DD/YYYY HH:MM; MM/DD/YYYY; MM/DD/YY HH:MM:SS; '
+                                                            u'MM/DD/YY HH:MM:SS.uuuuuu; MM/DD/YY HH:MM; MM/DD/YY']})
+
+    @unittest.skipUnless(django.VERSION < (1, 4), "django >= 1.4 have microseconds in default settings")
+    def test_wrong_default_date_time_input_format_for_django_lt_1_4(self):
+        serializer = DateTimeObjectSerializer(data={'date_time': 'something wrong'})
+        self.assertFalse(serializer.is_valid())
+        self.assertEquals(serializer.errors, {'date_time': [u'Datetime has wrong format. Use one of these formats instead:'
+                                                            u' YYYY-MM-DD HH:MM:SS; YYYY-MM-DD HH:MM; YYYY-MM-DD; '
+                                                            u'MM/DD/YYYY HH:MM:SS; MM/DD/YYYY HH:MM; MM/DD/YYYY; '
+                                                            u'MM/DD/YY HH:MM:SS; MM/DD/YY HH:MM; MM/DD/YY']})
+
+    def test_wrong_custom_date_time_input_format(self):
+        serializer = DateTimeObjectCustomFormatSerializer(data={'date_time': '07/31/84 04:31'})
+        self.assertFalse(serializer.is_valid())
+        self.assertEquals(serializer.errors, {'date_time': [u'Datetime has wrong format. Use one of these formats instead: YYYY; YYYY HH:MM']})

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -1,8 +1,6 @@
 import datetime
 import pickle
-import django
 from django.test import TestCase
-from django.utils import unittest
 from rest_framework import serializers
 from rest_framework.tests.models import (HasPositiveIntegerAsChoice, Album, ActionItem, Anchor, BasicModel,
     BlankFieldModel, BlogPost, Book, CallableDefaultValueModel, DefaultValueModel,
@@ -41,36 +39,6 @@ class CommentSerializer(serializers.Serializer):
         for key, val in data.items():
             setattr(instance, key, val)
         return instance
-
-
-class DateObject(object):
-    def __init__(self, date):
-        self.date = date
-
-
-class DateObjectSerializer(serializers.Serializer):
-    date = serializers.DateField()
-
-    def restore_object(self, attrs, instance=None):
-        if instance is not None:
-            instance.date = attrs['date']
-            return instance
-        return DateObject(**attrs)
-
-
-class DateTimeObject(object):
-    def __init__(self, date_time):
-        self.date_time = date_time
-
-
-class DateTimeObjectSerializer(serializers.Serializer):
-    date_time = serializers.DateTimeField()
-
-    def restore_object(self, attrs, instance=None):
-        if instance is not None:
-            instance.date_time = attrs['date_time']
-            return instance
-        return DateTimeObject(**attrs)
 
 
 class BookSerializer(serializers.ModelSerializer):
@@ -466,113 +434,6 @@ class RegexValidationTest(TestCase):
     def test_create_success(self):
         serializer = BookSerializer(data={'isbn': '1234567890123'})
         self.assertTrue(serializer.is_valid())
-
-
-class DateValidationTest(TestCase):
-    def test_valid_date_input_formats(self):
-        serializer = DateObjectSerializer(data={'date': '1984-07-31'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': '07/31/1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': '07/31/84'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': 'Jul 31 1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': 'Jul 31, 1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': '31 Jul 1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': '31 Jul 1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': 'July 31 1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': 'July 31, 1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': '31 July 1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateObjectSerializer(data={'date': '31 July, 1984'})
-        self.assertTrue(serializer.is_valid())
-
-    def test_wrong_date_input_format(self):
-        serializer = DateObjectSerializer(data={'date': 'something wrong'})
-        self.assertFalse(serializer.is_valid())
-        self.assertEquals(serializer.errors, {'date': [u'Date has wrong format. Use one of these formats instead: '
-                                                       u'YYYY-MM-DD; MM/DD/YYYY; MM/DD/YY; [Jan through Dec] DD YYYY; '
-                                                       u'[Jan through Dec] DD, YYYY; DD [Jan through Dec] YYYY; '
-                                                       u'DD [Jan through Dec], YYYY; [January through December] DD YYYY; '
-                                                       u'[January through December] DD, YYYY; DD [January through December] YYYY; '
-                                                       u'DD [January through December], YYYY']})
-
-
-class DateTimeValidationTest(TestCase):
-    def test_valid_date_time_input_formats(self):
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31 04:31:59'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31 04:31'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984 04:31:59'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984 04:31'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84 04:31:59'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84 04:31'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84'})
-        self.assertTrue(serializer.is_valid())
-
-    @unittest.skipUnless(django.VERSION >= (1, 4), "django < 1.4 don't have microseconds in default settings")
-    def test_valid_date_time_input_formats_2(self):
-        serializer = DateTimeObjectSerializer(data={'date_time': '1984-07-31 04:31:59.123456'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/1984 04:31:59.123456'})
-        self.assertTrue(serializer.is_valid())
-
-        serializer = DateTimeObjectSerializer(data={'date_time': '07/31/84 04:31:59.123456'})
-        self.assertTrue(serializer.is_valid())
-
-    @unittest.skipUnless(django.VERSION >= (1, 4), "django < 1.4 don't have microseconds in default settings")
-    def test_wrong_date_time_input_format(self):
-        serializer = DateTimeObjectSerializer(data={'date_time': 'something wrong'})
-        self.assertFalse(serializer.is_valid())
-        self.assertEquals(serializer.errors, {'date_time': [u'Datetime has wrong format. Use one of these formats instead: '
-                                                            u'YYYY-MM-DD HH:MM:SS; YYYY-MM-DD HH:MM:SS.uuuuuu; YYYY-MM-DD HH:MM; '
-                                                            u'YYYY-MM-DD; MM/DD/YYYY HH:MM:SS; MM/DD/YYYY HH:MM:SS.uuuuuu; '
-                                                            u'MM/DD/YYYY HH:MM; MM/DD/YYYY; MM/DD/YY HH:MM:SS; '
-                                                            u'MM/DD/YY HH:MM:SS.uuuuuu; MM/DD/YY HH:MM; MM/DD/YY']})
-
-    @unittest.skipUnless(django.VERSION < (1, 4), "django >= 1.4 have microseconds in default settings")
-    def test_wrong_date_time_input_format_2(self):
-        serializer = DateTimeObjectSerializer(data={'date_time': 'something wrong'})
-        self.assertFalse(serializer.is_valid())
-        self.assertEquals(serializer.errors, {'date_time': [u'Datetime has wrong format. Use one of these formats instead:'
-                                                            u' YYYY-MM-DD HH:MM:SS; YYYY-MM-DD HH:MM; YYYY-MM-DD; '
-                                                            u'MM/DD/YYYY HH:MM:SS; MM/DD/YYYY HH:MM; MM/DD/YYYY; '
-                                                            u'MM/DD/YY HH:MM:SS; MM/DD/YY HH:MM; MM/DD/YY']})
 
 
 class MetadataTests(TestCase):

--- a/rest_framework/utils/dates.py
+++ b/rest_framework/utils/dates.py
@@ -1,0 +1,14 @@
+def get_readable_date_format(date_format):
+    mapping = [("%Y", "YYYY"),
+               ("%y", "YY"),
+               ("%m", "MM"),
+               ("%b", "[Jan through Dec]"),
+               ("%B", "[January through December]"),
+               ("%d", "DD"),
+               ("%H", "HH"),
+               ("%M", "MM"),
+               ("%S", "SS"),
+               ("%f", "uuuuuu")]
+    for k, v in mapping:
+        date_format = date_format.replace(k, v)
+    return date_format


### PR DESCRIPTION
it's now possible to use different time formats with datefield and datetimefield. 
you can also use custom validation formats (when altering / overriding date_input_formats or datetime_input_formats setting)
also the error message is dynamically in respect of the settings.
summary: no static stuff any more
