### PR TITLE
Added test for None found while resolving the source attribute...

### DIFF
--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -785,6 +785,23 @@ class RelatedTraversalTest(TestCase):
 
         self.assertEqual(serializer.data, expected)
 
+    def test_nested_traversal_with_none(self):
+
+        from rest_framework.tests.models import NullableForeignKeySource
+        instance = NullableForeignKeySource.objects.create(name='Source with null FK')
+
+        class NullableSourceSerializer(serializers.Serializer):
+            target_name = serializers.Field(source='target.name')
+
+        serializer = NullableSourceSerializer(instance=instance)
+
+        expected = {
+            'name': 'Source with null FK',
+            'target_name': None,
+        }
+
+        self.assertEqual(serializer.data, expected)
+
 
 class SerializerMethodFieldTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
...of a field.

My suggestion in the test was to return None if any component in the source path is None, though if that should be customizable, we can change or expand the test.
