### PR TITLE
correction for the django-filter integration api-guide documentation

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -102,7 +102,7 @@ If all you need is simple equality-based filtering, you can set a `filter_fields
     class ProductList(generics.ListAPIView):
         model = Product
         serializer_class = ProductSerializer
-        filter_fields = ('category', 'in_stock')
+        filter_fields = ['category', 'in_stock']
 
 This will automatically create a `FilterSet` class for the given fields, and will allow you to make requests such as:
 


### PR DESCRIPTION
I found the latest version of django-filter requires a list of field
attributes instead of a tuple. This might help others who are looking
over the docs as I got an error trying to implement this using the wrong
data structure

"django-filter Meta.fields contains a field that isn't defined on this
FilterSet ..."
