### PR TITLE
DictWithMetadata.__getstate__ was never called (Fix for 645)

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -31,7 +31,7 @@ class DictWithMetadata(dict):
         """
         # return an instance of the first dict in MRO that isn't a DictWithMetadata
         for base in self.__class__.__mro__:
-            if not isinstance(base, DictWithMetadata) and isinstance(base, dict):
+            if not issubclass(base, DictWithMetadata) and issubclass(base, dict):
                 return base(self)
 
 

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -870,6 +870,13 @@ class SerializerPickleTests(TestCase):
                 fields = ('name', 'age')
         pickle.dumps(InnerPersonSerializer(Person(name="Noah", age=950)).data)
 
+    def test_getstate_method_should_not_return_none(self):
+        '''Regression test for 
+        https://github.com/tomchristie/django-rest-framework/issues/645
+        '''
+        d = serializers.DictWithMetadata({1:1})
+        self.assertEqual(d.__getstate__(), serializers.SortedDict({1:1}))
+
 
 class DepthTest(TestCase):
     def test_implicit_nesting(self):


### PR DESCRIPTION
I think I just found out the problem, self.**class.**.**mro** return a list of classes, not instances, the code used isinstance. So the method was never called.

There must be something done by other cache backends that python-memcached don't, to ensure data was pickled even if **getstate** returns None.
