### PR TITLE
Make is_simple_callable consider default arguments

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -24,10 +24,14 @@ def is_simple_callable(obj):
     """
     True if the object is a callable that takes no arguments.
     """
-    return (
-        (inspect.isfunction(obj) and not inspect.getargspec(obj)[0]) or
-        (inspect.ismethod(obj) and len(inspect.getargspec(obj)[0]) <= 1)
-    )
+    try:
+        args, _, _, defaults = inspect.getargspec(obj)
+    except TypeError:
+        return False
+    else:
+        len_args = len(args) if inspect.isfunction(obj) else len(args) - 1
+        len_defaults = len(defaults) if defaults else 0
+        return len_args <= len_defaults
 
 
 def get_component(obj, attr_name):


### PR DESCRIPTION
I wanted to list all user permissions using get_all_permissions, which has an optional argument 'obj', but is_simple_callable was returning False. Therefore I modified this function to consider the amount of default arguments as well.
