### PR TITLE
Minimal appearance fixes in addition to #663

### DIFF
--- a/rest_framework/static/rest_framework/css/default.css
+++ b/rest_framework/static/rest_framework/css/default.css
@@ -154,6 +154,12 @@ html, body {
     margin-bottom: 0;
 }
 
+.well {
+    -webkit-box-shadow: none;
+       -moz-box-shadow: none;
+            box-shadow: none;
+}
+
 .well .form-actions {
     padding-bottom: 0;
     margin-bottom: 0;
@@ -168,7 +174,6 @@ html, body {
 }
 
 .nav-tabs > li {
-    margin-bottom: -3px;
     float: right;
 }
 
@@ -184,13 +189,9 @@ html, body {
     background: #f5f5f5;
 }
 
-.tabs-below > .nav-tabs {
-    border-bottom: none !important;
-}
-
-.tabs-below > .nav-tabs > li {
-    margin-bottom: -2px !important;
-    margin-right: 0 !important;
+.tabbable.first-tab-active .tab-content
+{
+    border-top-right-radius: 0;
 }
 
 #footer, #push {

--- a/rest_framework/static/rest_framework/js/default.js
+++ b/rest_framework/static/rest_framework/js/default.js
@@ -4,4 +4,10 @@ $('.js-tooltip').tooltip({
     delay: 1000
 });
 
+$('a[data-toggle="tab"]:first').on('shown', function (e) {
+    $(e.target).parents('.tabbable').addClass('first-tab-active');
+});
+$('a[data-toggle="tab"]:not(:first)').on('shown', function (e) {
+    $(e.target).parents('.tabbable').removeClass('first-tab-active');
+});
 $('.form-switcher a:first').tab('show');


### PR DESCRIPTION
I've a little bit fixed appearance of the tab content panel following the tabs panel. It looked a kind of dirty. And saved a rounded border if the first tab is not selected:
![s](https://f.cloud.github.com/assets/668115/184702/c14d5a0e-7ce6-11e2-82ca-453ee141aab3.gif)
