### PR TITLE
Fixed UnicodeDecodeError on get_name and get_description methods

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -14,6 +14,7 @@ import json
 from django import forms
 from django.http.multipartparser import parse_header
 from django.template import RequestContext, loader, Template
+from django.utils.encoding import force_unicode
 from rest_framework.compat import yaml
 from rest_framework.exceptions import ConfigurationError
 from rest_framework.settings import api_settings
@@ -405,13 +406,13 @@ class BrowsableAPIRenderer(BaseRenderer):
         try:
             return view.get_name()
         except AttributeError:
-            return view.__doc__
+            return force_unicode(view.__doc__)
 
     def get_description(self, view):
         try:
             return view.get_description(html=True)
         except AttributeError:
-            return view.__doc__
+            return force_unicode(view.__doc__)
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         """

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -4,6 +4,7 @@ Provides an APIView class that is used as the base of all class-based views.
 from __future__ import unicode_literals
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
+from django.utils.encoding import force_unicode
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.views.decorators.csrf import csrf_exempt
@@ -96,7 +97,7 @@ class APIView(View):
         Override to customize.
         """
         # TODO: deprecate?
-        name = self.__class__.__name__
+        name = force_unicode(self.__class__.__name__)
         name = _remove_trailing_string(name, 'View')
         return _camelcase_to_spaces(name)
 
@@ -106,7 +107,7 @@ class APIView(View):
         Override to customize.
         """
         # TODO: deprecate?
-        description = self.__doc__ or ''
+        description = force_unicode(self.__doc__) or u''
         description = _remove_leading_indent(description)
         if html:
             return self.markup_description(description)


### PR DESCRIPTION
If you try to use non-ascii encoded stiring in docstrings to your views. Here is a sample:

``` python
# -*- coding: utf-8 -*-

@api_view(('GET',))
def api_root(request, format=None):
    """ 
    Проверка
    """
    ...
```

You'll get a `UnicodeDecodeError` on your browsable api page:

```
Traceback (most recent call last):
  File "/Users/wronglink/Src/django-rest-framework/rest_framework/response.py", line 44, in rendered_content
    return renderer.render(self.data, media_type, context)
  File "/Users/wronglink/Src/django-rest-framework/rest_framework/renderers.py", line 437, in render
    description = self.get_description(view)
  File "/Users/wronglink/Src/django-rest-framework/rest_framework/renderers.py", line 407, in get_description
    return view.get_description(html=True)
  File "/Users/wronglink/Src/django-rest-framework/rest_framework/views.py", line 111, in get_description
    description = _remove_leading_indent(description)
  File "/Users/wronglink/Src/django-rest-framework/rest_framework/views.py", line 35, in _remove_leading_indent
    for line in content.splitlines()[1:] if line.lstrip()]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 4: ordinal not in range(128)
```

It could be fixed by unicode docstring, but django has it's own unicode forcing util, that will do most of the work.

P.S.
BTW isn't that a mistake that `rest_framework.renderers.BrowsableAPIRenderer.get_name` method returns `view.__doc__` (not something like `view.__class__.__name__` as `rest_framework.views.APIView.get_name` does)?
