### PR TITLE
Improved exception message for missing serializer model meta option

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -424,9 +424,8 @@ class ModelSerializer(Serializer):
         """
 
         cls = self.opts.model
-        if cls is None:
-            raise AttributeError("Serializer class '%s' is missing 'model' Meta option" %
-                                 self.__class__.__name__)
+        assert cls is not None, \
+                "Serializer class '%s' is missing 'model' Meta option" % self.__class__.__name__
         opts = get_concrete_model(cls)._meta
         pk_field = opts.pk
         # while pk_field.rel:

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -365,7 +365,7 @@ class ValidationTests(TestCase):
         """
         try:
             serializer = BrokenModelSerializer()
-        except AttributeError as e:
+        except AssertionError as e:
             self.assertEquals(e.args[0], "Serializer class 'BrokenModelSerializer' is missing 'model' Meta option")
         except:
             self.fail('Wrong exception type thrown.')


### PR DESCRIPTION
The default exception when forgetting or mistyping the `model` meta option in a serializer is `AttributeError: 'NoneType' object has no attribute '_meta'`. That won't make a lot of sense to most users without debugging the traceback.

I added a check which raises an AttributeError with the message `Serializer class 'ClassName' is missing 'model' Meta option`. This should make things clearer.

Possibly an even better alternative would be an AssertionError instead of an AttributeError, which is slightly misleading. Also, should `Meta` in the error message be capitalized or not?

Test is provided and runs on all tox targets.
