### PR TITLE
Fixed pluralization and slashes in urlpatterns example

### DIFF
--- a/docs/api-guide/format-suffixes.md
+++ b/docs/api-guide/format-suffixes.md
@@ -28,9 +28,9 @@ Example:
     from rest_framework.urlpatterns import format_suffix_patterns
     
     urlpatterns = patterns('blog.views',
-        url(r'^/$', 'api_root'),
-        url(r'^comment/$', 'comment_root'),
-        url(r'^comment/(?P<pk>[0-9]+)/$', 'comment_instance')
+        url(r'^$', 'api_root'),
+        url(r'^comments$', 'comment_root'),
+        url(r'^comments/(?P<pk>[0-9]+)$', 'comment_instance')
     )
     
     urlpatterns = format_suffix_patterns(urlpatterns, allowed=['json', 'html'])


### PR DESCRIPTION
- Everywhere else you're using plural nouns as resource names, here you used a singular noun (`comment`). I changed it to `comments`.
- As seen in #679, `format_suffix_patterns` doesn't seem to work with url patterns that end with a slash. Therefore I removed the slashes from the example. (This still needs to be fixed though.)
