### PR TITLE
Support extra kwargs in url paths

### DIFF
--- a/rest_framework/tests/hyperlinkedserializers.py
+++ b/rest_framework/tests/hyperlinkedserializers.py
@@ -80,9 +80,13 @@ class OptionalRelationDetail(generics.RetrieveUpdateDestroyAPIView):
     model_serializer_class = serializers.HyperlinkedModelSerializer
 
 
+class ExtraKwargDetailSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = ExtraKwargModel
+
 class ExtraKwargDetail(generics.RetrieveUpdateDestroyAPIView):
     model = ExtraKwargModel
-    model_serializer_class = serializers.HyperlinkedModelSerializer
+    serializer_class = ExtraKwargDetailSerializer
 
 urlpatterns = patterns('',
     url(r'^basic/$', BasicList.as_view(), name='basicmodel-list'),
@@ -275,7 +279,8 @@ class TestNestedRelationHyperlinkedView(TestCase):
         """
         Create 1 ExtraKwargModel instance.
         """
-        ExtraKwargModel().save()
+        self.basic = BasicModel.objects.create()
+        self.model = ExtraKwargModel.objects.create(basic=self.basic)
         self.objects = ExtraKwargModel.objects
         self.detail_view = ExtraKwargDetail.as_view()
 

--- a/rest_framework/tests/models.py
+++ b/rest_framework/tests/models.py
@@ -125,7 +125,7 @@ class OptionalRelationModel(RESTFrameworkModel):
 
 # Model to test multiple kwargs in url
 class ExtraKwargModel(RESTFrameworkModel):
-    pass
+    basic = models.ForeignKey(BasicModel)
 
 # Model for RegexField
 class Book(RESTFrameworkModel):


### PR DESCRIPTION
Currently, having more than one kwarg in your api paths causes reverse() to fail since only the pk and/or slug argument is passed to reverse in the kwargs.

I've attached a test case demonstrating the problem and added a couple of lines to fix it for the case of the HyperlinkedIdentityField. 

It probably also needs to be fixed for HyperlinkedRelatedField, which I'd be happy to do if this is an acceptable solution to this bug.
