### PR TITLE
Fix for field_to_native iterating over None

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -333,7 +333,7 @@ class BaseSerializer(Field):
             many = hasattr(obj, '__iter__') and not isinstance(obj, (Page, dict))
 
         if many:
-            return [self.to_native(item) for item in obj]
+            return [self.to_native(item) for item in many]
         return self.to_native(obj)
 
     @property


### PR DESCRIPTION
The field_to_native method in BaseSerializer tries to iterating over obj when many is specified. This fixes the issue.
