### PR TITLE
Modify DjangoModelPermissions to return True if get_required_permissions() yields an empty list

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -120,7 +120,7 @@ class DjangoModelPermissions(BasePermission):
 
         perms = self.get_required_permissions(request.method, model_cls)
 
-        if (request.user and
+        if not perms or (request.user and
             request.user.is_authenticated() and
             request.user.has_perms(perms)):
             return True


### PR DESCRIPTION
I have a class derived from ListCreateAPIView, which I want it to use DjangoModelPermissions. GETs from an AnonymousUser were returning False, since the user was not authenticated. But since 

perms = self.get_required_permissions(request.method, model_cls)

was an empty list, it should be returning true. Hence the change. Let me know if it doesn't make sense! cheers
