### PR TITLE
Prevent warning: no files found matching '*.txt' under directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 recursive-include rest_framework/static *.js *.css *.png
-recursive-include rest_framework/templates *.txt *.html
+recursive-include rest_framework/templates *.html


### PR DESCRIPTION
'rest_framework/templates' (there are only .html files in the templates
directory).

Just nitpicking ...
