### PR TITLE
Fixed URLField not retrieving the max_length attribute from a ModelField

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -531,6 +531,10 @@ class ModelSerializer(Serializer):
         if issubclass(model_field.__class__, models.TextField):
             kwargs['widget'] = widgets.Textarea
 
+        # URLField not getting correct max_length kwarg
+        if issubclass(model_field.__class__, models.URLField):
+            kwargs['max_length'] = model_field.max_length
+
         # TODO: TypedChoiceField?
         if model_field.flatchoices:  # This ModelField contains choices
             kwargs['choices'] = model_field.flatchoices


### PR DESCRIPTION
The rest framework wasn't sending the `max_length` kwarg to serializers.URLField, so the class was using always the default value even if overwritten on a django model. 

Model:

```
class TestModel(models.Model):
    name = models.CharField(max_length=512, blank=True)
    url = models.URLField(blank=True, max_length=2000)

```

API result:

```
{
    "url": [
        "Ensure this value has at most 200 characters (it has 1540)."
    ]
}
```

Tested on SQLite & PostgreSQL.

Custom serializer fields were working fine.

Test results: https://travis-ci.org/fmartingr/django-rest-framework/builds/5312162
