### PR TITLE
GenericAPIView now applies filter_backend for list and retrieve api views

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -18,6 +18,16 @@ class GenericAPIView(views.APIView):
     model = None
     serializer_class = None
     model_serializer_class = api_settings.DEFAULT_MODEL_SERIALIZER_CLASS
+    filter_backend = api_settings.FILTER_BACKEND
+
+    def filter_queryset(self, queryset):
+        """
+        Given a queryset, filter it with whichever filter backend is in use.
+        """
+        if not self.filter_backend:
+            return queryset
+        backend = self.filter_backend()
+        return backend.filter_queryset(self.request, queryset, self)
 
     def get_serializer_context(self):
         """
@@ -81,16 +91,6 @@ class MultipleObjectAPIView(MultipleObjectMixin, GenericAPIView):
     paginate_by = api_settings.PAGINATE_BY
     paginate_by_param = api_settings.PAGINATE_BY_PARAM
     pagination_serializer_class = api_settings.DEFAULT_PAGINATION_SERIALIZER_CLASS
-    filter_backend = api_settings.FILTER_BACKEND
-
-    def filter_queryset(self, queryset):
-        """
-        Given a queryset, filter it with whichever filter backend is in use.
-        """
-        if not self.filter_backend:
-            return queryset
-        backend = self.filter_backend()
-        return backend.filter_queryset(self.request, queryset, self)
 
     def get_pagination_serializer(self, page=None):
         """

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -97,7 +97,9 @@ class RetrieveModelMixin(object):
     Should be mixed in with `SingleObjectAPIView`.
     """
     def retrieve(self, request, *args, **kwargs):
-        self.object = self.get_object()
+        queryset = self.get_queryset()
+        filtered_queryset = self.filter_queryset(queryset)
+        self.object = self.get_object(filtered_queryset)
         serializer = self.get_serializer(self.object)
         return Response(serializer.data)
 


### PR DESCRIPTION
Before this commit only the MultipleObjectAPIView would apply a filter_backend, leaving the SingleObjectAPIView to return objects you might otherwise expect to have been filtered out.

It's worth mentioning that when a SingleObjectAPIView makes a request for an object that should be excluded, a 404 is the expected result.

I asked Tom about this in a previous issue (still open at this time)

For reference https://github.com/tomchristie/django-rest-framework/issues/682
