### PR TITLE
Handle list deserialization errors

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -93,6 +93,8 @@ To serialize a queryset instead of an object instance, you should pass the `many
 
 When deserializing data, you always need to call `is_valid()` before attempting to access the deserialized object.  If any validation errors occur, the `.errors` and `.non_field_errors` properties will contain the resulting error messages.
 
+When deserialising a list of items, errors will be returned as a list of tuples. The first item in an error tuple will be the index of the item with the error in the original data; The second item in the tuple will be a dict with the individual errors for that item.
+
 ### Field-level validation
 
 You can specify custom field-level validation by adding `.validate_<fieldname>` methods to your `Serializer` subclass. These are analagous to `.clean_<fieldname>` methods on Django forms, but accept slightly different arguments.

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -268,7 +268,16 @@ class ValidationTests(TestCase):
         data = ['i am', 'a', 'list']
         serializer = CommentSerializer(self.comment, data=data, many=True)
         self.assertEqual(serializer.is_valid(), False)
-        self.assertEqual(serializer.errors, {'non_field_errors': ['Invalid data']})
+        self.assertTrue(isinstance(serializer.errors, list))
+
+        self.assertEqual(
+            serializer.errors,
+            [
+                (0, {'non_field_errors': ['Invalid data']}),
+                (1, {'non_field_errors': ['Invalid data']}),
+                (2, {'non_field_errors': ['Invalid data']})
+            ]
+        )
 
         data = 'and i am a string'
         serializer = CommentSerializer(self.comment, data=data)
@@ -1072,3 +1081,37 @@ class NestedSerializerContextTests(TestCase):
 
         # This will raise RuntimeError if context doesn't get passed correctly to the nested Serializers
         AlbumCollectionSerializer(album_collection, context={'context_item': 'album context'}).data
+
+
+class DeserializeListTestCase(TestCase):
+
+    def setUp(self):
+        self.data = {
+            'email': 'nobody@nowhere.com',
+            'content': 'This is some test content',
+            'created': datetime.datetime(2013, 3, 7),
+        }
+
+    def test_no_errors(self):
+        data = [self.data.copy() for x in range(0, 3)]
+        serializer = CommentSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertTrue(isinstance(serializer.object, list))
+        self.assertTrue(
+            all((isinstance(item, Comment) for item in serializer.object))
+        )
+
+    def test_errors_return_as_list(self):
+        invalid_item = self.data.copy()
+        invalid_item['email'] = ''
+        data = [self.data.copy(), invalid_item, self.data.copy()]
+
+        serializer = CommentSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertTrue(isinstance(serializer.errors, list))
+        self.assertEqual(1, len(serializer.errors))
+        expected = (1, {'email': ['This field is required.']})
+        self.assertEqual(
+            serializer.errors[0],
+            expected
+        )


### PR DESCRIPTION
Before this change errors from deserializing lists of data may have been hidden due to repeated calls to .from_native overwriting the self._errors dict.

Now .from_native iterates over the list storing each error as a tuple in a list, each tuple looking like this:

(index, error_dict) where index is the index of the item with the error, and error_dict is the error dictionary returned when evaluating the individual item.

Single item deserialization works as before.
