### PR TITLE
Use parent's primary key when model is derived via multitable inheritance

### DIFF
--- a/rest_framework/tests/multitable_inheritance.py
+++ b/rest_framework/tests/multitable_inheritance.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 from django.db import models
+from django.test import TestCase
+from rest_framework import serializers
 from rest_framework.tests.models import RESTFrameworkModel
 
 
+# Models
 class ParentModel(RESTFrameworkModel):
     name1 = models.CharField(max_length=100)
 
@@ -14,3 +17,51 @@ class ChildModel(ParentModel):
 class AssociatedModel(RESTFrameworkModel):
     ref = models.OneToOneField(ParentModel, primary_key=True)
     name = models.CharField(max_length=100)
+
+
+# Serializers
+class DerivedModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ChildModel
+
+
+class AssociatedModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AssociatedModel
+
+
+# Tests
+class IneritedModelSerializationTests(TestCase):
+
+    def test_multitable_inherited_model_fields_as_expected(self):
+        """
+        Assert that the parent pointer field is not included in the fields
+        serialized fields
+        """
+        child = ChildModel(name1='parent name', name2='child name')
+        serializer = DerivedModelSerializer(child)
+        self.assertEqual(set(serializer.data.keys()),
+                         set(['name1', 'name2', 'id']))
+
+    def test_onetoone_primary_key_model_fields_as_expected(self):
+        """
+        Assert that a model with a onetoone field that is the primary key is
+        not treated like a derived model
+        """
+        parent = ParentModel(name1='parent name')
+        associate = AssociatedModel(name='hello', ref=parent)
+        serializer = AssociatedModelSerializer(associate)
+        self.assertEqual(set(serializer.data.keys()),
+                         set(['name', 'ref']))
+
+    def test_data_is_valid_without_parent_ptr(self):
+        """
+        Assert that the pointer to the parent table is not a required field
+        for input data
+        """
+        data = {
+            'name1': 'parent name',
+            'name2': 'child name',
+        }
+        serializer = DerivedModelSerializer(data=data)
+        self.assertEqual(serializer.is_valid(), True)

--- a/rest_framework/tests/serializer.py
+++ b/rest_framework/tests/serializer.py
@@ -5,8 +5,6 @@ from rest_framework import serializers
 from rest_framework.tests.models import (HasPositiveIntegerAsChoice, Album, ActionItem, Anchor, BasicModel,
     BlankFieldModel, BlogPost, Book, CallableDefaultValueModel, DefaultValueModel,
     ManyToManyModel, Person, ReadOnlyManyToManyModel, Photo)
-from rest_framework.tests.multitable_inheritance import (ParentModel,
-    ChildModel, AssociatedModel)
 import datetime
 import pickle
 
@@ -96,16 +94,6 @@ class PositiveIntegerAsChoiceSerializer(serializers.ModelSerializer):
 class BrokenModelSerializer(serializers.ModelSerializer):
     class Meta:
         fields = ['some_field']
-
-
-class DerivedModelSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ChildModel
-
-
-class AssociatedModelSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = AssociatedModel
 
 
 class BasicTests(TestCase):
@@ -1122,39 +1110,3 @@ class DeserializeListTestCase(TestCase):
         self.assertFalse(serializer.is_valid())
         expected = [{}, {'email': ['This field is required.']}, {}]
         self.assertEqual(serializer.errors, expected)
-
-
-class IneritedModelSerializationTests(TestCase):
-
-    def test_multitable_inherited_model_fields_as_expected(self):
-        """
-        Assert that the parent pointer field is not included in the fields
-        serialized fields
-        """
-        child = ChildModel(name1='parent name', name2='child name')
-        serializer = DerivedModelSerializer(child)
-        self.assertEqual(set(serializer.data.keys()),
-                         set(['name1', 'name2', 'id']))
-
-    def test_onetoone_primary_key_model_fields_as_expected(self):
-        """
-        Assert that a model with a onetoone field that is the primary key is
-        not treated like a derived model
-        """
-        parent = ParentModel(name1='parent name')
-        associate = AssociatedModel(name='hello', ref=parent)
-        serializer = AssociatedModelSerializer(associate)
-        self.assertEqual(set(serializer.data.keys()),
-                         set(['name', 'ref']))
-
-    def test_data_is_valid_without_parent_ptr(self):
-        """
-        Assert that the pointer to the parent table is not a required field
-        for input data
-        """
-        data = {
-            'name1': 'parent name',
-            'name2': 'child name',
-        }
-        serializer = DerivedModelSerializer(data=data)
-        self.assertEqual(serializer.is_valid(), True)


### PR DESCRIPTION
Currently, the following code will fail:

```
class ParentModel (Model):
    name1 = CharField(max_length=100)

class ChildModel (ParentModel):
    """Derived from ParentModel"""
    name2 = CharField(max_length=100)

class DerivedModelSerializer (ModelSerializer):
    class Meta:
        model = ChildModel

serializer = DerivedModelSerializer(data={
    'name1': 'abc', 'name2': 'xyz'
})
assert serializer.is_valid()
```

DRF will expect parentmodel_ptr to be a field on the serializer. This should not be expected.  The given patch fixes this.
