### PR TITLE
Failing test for nested object deletion

### DIFF
--- a/rest_framework/tests/serializer_bulk_update.py
+++ b/rest_framework/tests/serializer_bulk_update.py
@@ -169,6 +169,7 @@ class BulkUpdateSerializerTests(TestCase):
         class PageSerializer(serializers.Serializer):
             id = serializers.IntegerField()
             number = serializers.IntegerField()
+            book_id = serializers.IntegerField()
 
             def restore_object(self, attrs, instance=None):
                 if instance:
@@ -302,7 +303,6 @@ class BulkUpdateSerializerTests(TestCase):
         book = self.Book.object_map[0]
         serializer = self.BookNestedSerializer(book, data=data)
         self.assertEqual(serializer.is_valid(), True)
-        self.assertEqual(serializer.data, data)
         serializer.save()
         book = self.Book.object_map[0]
         new_data = self.BookNestedSerializer(book).data


### PR DESCRIPTION
While working on one-to-many writable serializers I came across this bug.  Basically we don't pass the `._deleted` attribute up to the parent serializer (the only one which calls save).  I'm not sure the best approach to fix this.  I think we should fix it before opening the one-to-many pull request though.

Also, I wasn't sure the best place to put the test.  I needed a combination `serializer_bulk_update.py` and `serializer_nested.py` test setup.

Thoughts?
