### PR TITLE
[oauth2] Client credentials should be optional

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -294,7 +294,7 @@ The only thing needed to make the `OAuth2Authentication` class work is to insert
 
 The command line to test the authentication looks like:
 
-    curl -H "Authorization: Bearer <your-access-token>" http://localhost:8000/api/?client_id=YOUR_CLIENT_ID\&client_secret=YOUR_CLIENT_SECRET
+    curl -H "Authorization: Bearer <your-access-token>" http://localhost:8000/api/
 
 ---
 

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -316,19 +316,11 @@ class OAuth2Authentication(BaseAuthentication):
         """
         Authenticate the request, given the access token.
         """
-        client = None
-
-        # Authenticate the client
-        if 'client_id' in request.REQUEST:
-            oauth2_client_form = oauth2_provider_forms.ClientAuthForm(request.REQUEST)
-            if not oauth2_client_form.is_valid():
-                raise exceptions.AuthenticationFailed('Client could not be validated')
-            client = oauth2_client_form.cleaned_data.get('client')
 
         try:
             token = oauth2_provider.models.AccessToken.objects.select_related('user')
-            if client is not None:
-                token = token.filter(client=client)
+            # TODO: Change to timezone aware datetime when oauth2_provider add
+            # support to it.
             token = token.get(token=access_token, expires__gt=datetime.now())
         except oauth2_provider.models.AccessToken.DoesNotExist:
             raise exceptions.AuthenticationFailed('Invalid token')

--- a/rest_framework/tests/authentication.py
+++ b/rest_framework/tests/authentication.py
@@ -500,15 +500,6 @@ class OAuth2Tests(TestCase):
         self.assertEqual(response.status_code, 401)
 
     @unittest.skipUnless(oauth2_provider, 'django-oauth2-provider not installed')
-    def test_get_form_with_wrong_client_data_failing_auth(self):
-        """Ensure GETing form over OAuth with incorrect client credentials fails"""
-        auth = self._create_authorization_header()
-        params = self._client_credentials_params()
-        params['client_id'] += 'a'
-        response = self.csrf_client.get('/oauth2-test/', params, HTTP_AUTHORIZATION=auth)
-        self.assertEqual(response.status_code, 401)
-
-    @unittest.skipUnless(oauth2_provider, 'django-oauth2-provider not installed')
     def test_get_form_passing_auth(self):
         """Ensure GETing form over OAuth with correct client credentials succeed"""
         auth = self._create_authorization_header()


### PR DESCRIPTION
As discussed here:
https://github.com/tomchristie/django-rest-framework/issues/759

I have two concerns about this implementation:
- Since https://github.com/caffeinehit/django-oauth2-provider/pull/15 is not merged to django-oauth2-provider, I did use datetime.datetime to check for expire, which differs from the rest of restframework, that is timezone aware. It would be very nice to see that merged.
- This way, client credentials is optional, but if then are not needed at all, the code could be much simpler by not verifying for client credentials
