### PR TITLE
Don't have the ModelSerializer trust deserialized objects to not have re...

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -741,7 +741,7 @@ class ModelSerializer(Serializer):
         Override the default method to also include model field validation.
         """
         instance = super(ModelSerializer, self).from_native(data, files)
-        if instance:
+        if not self._errors:
             return self.full_clean(instance)
 
     def save_object(self, obj, **kwargs):


### PR DESCRIPTION
...define bool()ean-ness.

If the model we're using the ModelSerializer for has redefined methods that act as a boolean (`__bool__` or `__len__`), it may not return the object even though it `is_valid()`, and should.

I banged my head against the wall for a bit because I had a django Model that redefined `__len__` for some other state inside the Model that is used in my django app, and then I couldn't figure out why this was failing:

``` python
serializer = FooSerializer(data=request.DATA)
if serializer.is_valid():
     assert serializer.object is not None, "This would blow up."
```

I thought this is the best way to fix it, since `BaseSerializer.from_native()` uses `self._errors` to check state; I figured that was better than having `from_native()` return `None`, and then checking `instance is not None`, but maybe that's more correct?
