### PR TITLE
Fix non form many relations

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -43,6 +43,7 @@ You can determine your currently installed version using `pip freeze`:
 ### Master
 
 * Made Login template more easy to restyle.
+* Bugfix: Fix single pks/slugs are not serialized to list when sent to many relation
 
 ### 2.2.7
 

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from collections import Iterable
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.urlresolvers import resolve, get_script_prefix, NoReverseMatch
 from django import forms
@@ -162,8 +163,8 @@ class RelatedField(WritableField):
         elif value in (None, ''):
             into[(self.source or field_name)] = None
         elif self.many:
-            if isinstance(value, basestring):
-                into[(self.source or field_name)] = self.from_native(value)
+            if isinstance(value, basestring) or not isinstance(value, Iterable):
+                into[(self.source or field_name)] = [self.from_native(value)]
             else:
                 into[(self.source or field_name)] = [self.from_native(item) for item in value]
         else:

--- a/rest_framework/tests/relations_slug.py
+++ b/rest_framework/tests/relations_slug.py
@@ -106,6 +106,33 @@ class SlugForeignKeyTests(TestCase):
         ]
         self.assertEqual(serializer.data, expected)
 
+    def test_reverse_foreign_key_update_only_one_instance_as_string(self):
+        data = {'id': 2, 'name': 'target-2', 'sources': 'source-1'}
+        instance = ForeignKeyTarget.objects.get(pk=2)
+        serializer = ForeignKeyTargetSerializer(instance, data=data)
+        self.assertTrue(serializer.is_valid())
+        # We shouldn't have saved anything to the db yet since save
+        # hasn't been called.
+        queryset = ForeignKeyTarget.objects.all()
+        new_serializer = ForeignKeyTargetSerializer(queryset, many=True)
+        expected = [
+            {'id': 1, 'name': 'target-1', 'sources': ['source-1', 'source-2', 'source-3']},
+            {'id': 2, 'name': 'target-2', 'sources': []},
+        ]
+        self.assertEqual(new_serializer.data, expected)
+
+        serializer.save()
+        self.assertEqual(serializer.data, {'id': 2, 'name': 'target-2', 'sources': ['source-1']})
+
+        # Ensure target 2 is update, and everything else is as expected
+        queryset = ForeignKeyTarget.objects.all()
+        serializer = ForeignKeyTargetSerializer(queryset, many=True)
+        expected = [
+            {'id': 1, 'name': 'target-1', 'sources': ['source-2', 'source-3']},
+            {'id': 2, 'name': 'target-2', 'sources': ['source-1']},
+        ]
+        self.assertEqual(serializer.data, expected)
+
     def test_foreign_key_create(self):
         data = {'id': 4, 'name': 'source-4', 'target': 'target-2'}
         serializer = ForeignKeySourceSerializer(data=data)


### PR DESCRIPTION
## Single Relations not need to be a list anymore when sent to Serializer

When sending a request using JSON to a serializer.SlugRelatedField(many=True) it was only possible to send single instances as a list:

``` JSON
{"related_object": ["slug"]}
```

Now it is possible to send a single slug as a string:

``` JSON
{"related_object": "slug"}
```

It was not able before, because a string is iterable and a the string was interpreted as a list, resulting in one slug lookup for every char in the posted string.

It is also possible to send PKs this way now:

``` JSON
{"related_object": 5}
```

Before you were forced to do it like this:

``` JSON
{"related_object": [5]}
```
## Why do we need this?

If you are on a mobile device, having a HTML5 Form and serialize it to JSON it will result in these ways:

``` JSON
{"related_object": ""}
```

``` JSON
{"related_object": "slug"}
```

``` JSON
{"related_object": ["slug1", "slug2"]}
```
