### PR TITLE
Fix model serializer nestesd delete behavior

### DIFF
--- a/rest_framework/tests/relations_nested.py
+++ b/rest_framework/tests/relations_nested.py
@@ -287,3 +287,22 @@ class ReverseNestedOneToManyTests(TestCase):
 
         ]
         self.assertEqual(serializer.data, expected)
+
+    def test_one_to_many_delete(self):
+        data = {'id': 1, 'name': 'target-1', 'sources': [{'id': 1, 'name': 'source-1'},
+                                                         {'id': 3, 'name': 'source-3'}]}
+        instance = OneToManyTarget.objects.get(pk=1)
+        serializer = self.Serializer(instance, data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+
+        # Ensure source 2 is deleted, and everything else is as
+        # expected.
+        queryset = OneToManyTarget.objects.all()
+        serializer = self.Serializer(queryset)
+        expected = [
+            {'id': 1, 'name': 'target-1', 'sources': [{'id': 1, 'name': 'source-1'},
+                                                      {'id': 3, 'name': 'source-3'}]}
+
+        ]
+        self.assertEqual(serializer.data, expected)


### PR DESCRIPTION
@tomchristie I realized no test existed for model serializer delete, and it was totally broken.  I think this is more inline with what your comment suggested a while back anyway.  I'm not sure what I was thinking with the last changes I made... :/

One note: I'm not sure if deeply nested delete works for regular serializers (the tests only test one level deep).
