### PR TITLE
Catch ImproperlyConfigured exception in compat.py

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -6,6 +6,7 @@ versions of django/python, and compatibility wrappers around optional packages.
 from __future__ import unicode_literals
 
 import django
+from django.core.exceptions import ImproperlyConfigured
 
 # Try to import six from Django, fallback to included `six`.
 try:
@@ -473,7 +474,7 @@ except ImportError:
 try:
     import oauth_provider
     from oauth_provider.store import store as oauth_provider_store
-except ImportError:
+except (ImportError, ImproperlyConfigured):
     oauth_provider = None
     oauth_provider_store = None
 


### PR DESCRIPTION
Apparently #803 was caused by a bug in django-oauth-plus which has been fixed in v2.1.0. But in case someone still has the old version installed, this "workarounds" the problem.
