### PR TITLE
Updated the README.md example to fix a class reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Here's our project's root `urls.py` module:
     
     # Routers provide an easy way of automatically determining the URL conf
     router = routers.DefaultRouter()
-    router.register(r'users', views.UserViewSet)
-    router.register(r'groups', views.GroupViewSet)
+    router.register(r'users', UserViewSet)
+    router.register(r'groups', GroupViewSet)
 
 
     # Wire up our API using automatic URL routing.


### PR DESCRIPTION
Two classnames in the example had "views." prepended to them, which appeared unnecessary.
