### PR TITLE
Make get_queryset work with django-filter

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -38,10 +38,8 @@ class DjangoFilterBackend(BaseFilterBackend):
         """
         filter_class = getattr(view, 'filter_class', None)
         filter_fields = getattr(view, 'filter_fields', None)
-        model_cls = getattr(view, 'model', None)
-        queryset = getattr(view, 'queryset', None)
-        if model_cls is None and queryset is not None:
-            model_cls = queryset.model
+        queryset = view.get_queryset()
+        model_cls = queryset.model
 
         if filter_class:
             filter_model = filter_class.Meta.model

--- a/rest_framework/tests/filters.py
+++ b/rest_framework/tests/filters.py
@@ -70,9 +70,19 @@ if django_filters:
         filter_fields = ['decimal', 'date']
         filter_backend = filters.DjangoFilterBackend
 
+    class GetQuerysetView(generics.ListCreateAPIView):
+        serializer_class = FilterableItemSerializer
+        filter_class = SeveralFieldsFilter
+        filter_backend = filters.DjangoFilterBackend
+
+        def get_queryset(self):
+            return FilterableItem.objects.all()
+
     urlpatterns = patterns('',
         url(r'^(?P<pk>\d+)/$', FilterClassDetailView.as_view(), name='detail-view'),
         url(r'^$', FilterClassRootView.as_view(), name='root-view'),
+        url(r'^get-queryset/$', GetQuerysetView.as_view(),
+            name='get-queryset-view'),
     )
 
 
@@ -146,6 +156,14 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected_data = [f for f in self.data if f['decimal'] == search_decimal]
         self.assertEqual(response.data, expected_data)
+
+    @unittest.skipUnless(django_filters, 'django-filters not installed')
+    def test_filter_with_get_queryset_only(self):
+        view = GetQuerysetView.as_view()
+        request = factory.get('/get-queryset/')
+        view(request).render()
+        # Used to raise "issubclass() arg 2 must be a class or tuple of classes"
+        # here when neither `model' nor `queryset' was specified.
 
     @unittest.skipUnless(django_filters, 'django-filters not installed')
     def test_get_filtered_class_root_view(self):


### PR DESCRIPTION
DjangoFilterBackend would raise `issubclass() arg 2 must be a class or tuple of classes` when only specifying `serializer_class` and `get_queryset`. Example:

``` python
class AccountListView(generics.RetrieveAPIView):
    serializer_class = MyModelSerializer
    filter_class = MyDjangoFilter
    filter_backend = DjangoFilterBackend

    def get_queryset(self):
        return MyModel.objects.filter(some_field='foo')
```
