### PR TITLE
Incorrect import in Tutorial - Step 6 - ViewSets

### DIFF
--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -59,7 +59,7 @@ To see what's going on under the hood let's first explicitly create a set of vie
 
 In the `urls.py` file we bind our `ViewSet` classes into a set of concrete views.
 
-    from snippets.resources import SnippetResource, UserResource
+    from snippets.views import SnippetViewSet, UserViewSet
 
     snippet_list = SnippetViewSet.as_view({
         'get': 'list',


### PR DESCRIPTION
I could be mistaken, but there is not snippets. resources created, the preceding step creates the ViewSet classes in the snippets.views module. 

I got an error, and importing snippets.views instead of snippets.resources resolved it. 

Traceback:
File "/usr/local/lib/python2.6/dist-packages/django/core/handlers/base.py" in get_response
1.                     resolver_match = resolver.resolve(request.path_info)
   File "/usr/local/lib/python2.6/dist-packages/django/core/urlresolvers.py" in resolve
2.             for pattern in self.url_patterns:
   File "/usr/local/lib/python2.6/dist-packages/django/core/urlresolvers.py" in url_patterns
3.         patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
   File "/usr/local/lib/python2.6/dist-packages/django/core/urlresolvers.py" in urlconf_module
4.             self._urlconf_module = import_module(self.urlconf_name)
   File "/usr/local/lib/python2.6/dist-packages/django/utils/importlib.py" in import_module
5.     **import**(name)
   File "/home/atarzwell/src/resttest/resttest/urls.py" in <module>
6.     url(r'^', include('snippets.urls')),
   File "/usr/local/lib/python2.6/dist-packages/django/conf/urls/**init**.py" in include
7.         urlconf_module = import_module(urlconf_module)
   File "/usr/local/lib/python2.6/dist-packages/django/utils/importlib.py" in import_module
8.     **import**(name)
   File "/home/atarzwell/src/resttest/snippets/urls.py" in <module>
9. from snippets.resources import SnippetResource, UserResource

Exception Type: ImportError at /snippets/1/highlight/
Exception Value: No module named resources
