### PR TITLE
Fix 2.3.3 in release notes

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -44,7 +44,7 @@ You can determine your currently installed version using `pip freeze`:
 
 * Bugfix: HyperlinkedIdentityField now uses `lookup_field` kwarg.
 
-### 2.3.2
+### 2.3.3
 
 **Date**: 16th May 2013
 


### PR DESCRIPTION
The release notes have had two 2.3.2 releases instead of a 2.3.3. It's been bugging me for a while, so here's the fix!
