### PR TITLE
Token authentication: header setting

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -12,6 +12,7 @@ from rest_framework.compat import CsrfViewMiddleware
 from rest_framework.compat import oauth, oauth_provider, oauth_provider_store
 from rest_framework.compat import oauth2_provider
 from rest_framework.authtoken.models import Token
+from rest_framework.settings import api_settings
 
 
 def get_authorization_header(request):
@@ -20,7 +21,7 @@ def get_authorization_header(request):
 
     Hide some test client ickyness where the header can be unicode.
     """
-    auth = request.META.get('HTTP_AUTHORIZATION', b'')
+    auth = request.META.get(api_settings.AUTHORIZATION_HEADER, b'')
     if type(auth) == type(''):
         # Work around django test client oddness
         auth = auth.encode(HTTP_HEADER_ENCODING)

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -70,6 +70,7 @@ DEFAULTS = {
     # Authentication
     'UNAUTHENTICATED_USER': 'django.contrib.auth.models.AnonymousUser',
     'UNAUTHENTICATED_TOKEN': None,
+    'AUTHORIZATION_HEADER': 'HTTP_AUTHORIZATION',
 
     # Browser enhancements
     'FORM_METHOD_OVERRIDE': '_method',


### PR DESCRIPTION
Hello,

My hosting company swallows the "HTTP_AUTHENTICATION" header.

So I decided to make it a setting, so I could work around the problem.

I did not touch the tests, cause I'm not sure how to do it.

Maybe there is a better solution for my problem, and I would be glad to have your feedback on it.

Cheers
