### PR TITLE
Allow overriding of HyperlinkedIdentityField.lookup_field value.

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -514,12 +514,20 @@ class HyperlinkedIdentityField(Field):
 
         super(HyperlinkedIdentityField, self).__init__(*args, **kwargs)
 
+    def get_lookup_value(self, obj):
+        """Return the value of the lookup field.  Subclasses can override this
+        for custom behavior which is more complex than returning a pk or other
+        named attribute of the object.
+
+        """
+        return getattr(obj, self.lookup_field)
+
     def field_to_native(self, obj, field_name):
         request = self.context.get('request', None)
         format = self.context.get('format', None)
         view_name = self.view_name or self.parent.opts.view_name
-        lookup_field = getattr(obj, self.lookup_field)
-        kwargs = {self.lookup_field: lookup_field}
+
+        kwargs = {self.lookup_field: self.get_lookup_value(obj)}
 
         if request is None:
             warnings.warn("Using `HyperlinkedIdentityField` without including the "


### PR DESCRIPTION
Add the ability to get a HyperlinkedIdentityField value from a method call rather than a straight attribute lookup.  This allows subclasses to transform the value returned as needed.

I made this change to solve a real use case which I'm hitting now.  Fields returned are straight-up primary keys, but those keys are not returned verbatim to the client.  Instead, what I need to return in a hyperlinked field is `primarykey * MULTIPLIER`.  This change allows me to create a HyperlinkedIdentityField subclass and override the method.

All tests pass and new tests were added to cover this use case.
