### PR TITLE
Fix default field when is a simple callable function

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -250,6 +250,9 @@ class WritableField(Field):
         self.validators = self.default_validators + validators
         self.default = default if default is not None else self.default
 
+        if is_simple_callable(self.default):
+            self.default = self.default()
+
         # Widgets are ony used for HTML forms.
         widget = widget or self.widget
         if isinstance(widget, type):


### PR DESCRIPTION
When I have::

```
from time import time

def utc_now_miliseconds():
    return (int(time() * 1000))

class HouseSerializer(serializers.Serializer):
    name = serializers.CharField(max_length=200)
    timestamp = serializers.IntegerField(default=utcnow_miliseconds)
```

If I consume an endpoint with this serializer the function return the value::

```
curl -XPOST -d "name=23" http://localhost:8000/api/home/
```

the values are name=23 and timestamp is some 1369846517231
