### PR TITLE
Add property_fields attribute for fast model property access

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -546,6 +546,7 @@ class ModelSerializerOptions(SerializerOptions):
         super(ModelSerializerOptions, self).__init__(meta)
         self.model = getattr(meta, 'model', None)
         self.read_only_fields = getattr(meta, 'read_only_fields', ())
+        self.property_fields = getattr(meta, 'property_fields', ())
 
 
 class ModelSerializer(Serializer):
@@ -693,6 +694,10 @@ class ModelSerializer(Serializer):
                 (self.__class__.__name__, field_name)
             ret[field_name].read_only = True
 
+        # For each of the `property_fields` construct a field
+        for property_name in self.opts.property_fields:
+            ret[property_name] = self.get_property_field(property_name) 
+
         return ret
 
     def get_pk_field(self, model_field):
@@ -732,6 +737,9 @@ class ModelSerializer(Serializer):
             kwargs['required'] = not(model_field.null or model_field.blank)
 
         return PrimaryKeyRelatedField(**kwargs)
+
+    def get_property_field(self, model_property):
+        return CharField(read_only=True, source=model_property)
 
     def get_field(self, model_field):
         """


### PR DESCRIPTION
I was quite dependent on pistons property lookup, so I built this, fields in property_fields will have fields generated for them automatically.

e.g:

``` python
class Spling(serializers.ModelSerializer):
    class Meta:
        model = Post
        fields = ('id', 'title', 'content', 'get_absolute_url', 'author_denormalized')
        property_fields = ('get_absolute_url', 'author_denormalized')
```

where get_absolute_url and author_denormalized are properties on the model

thanks! really digging the project
