### PR TITLE
Create tz-aware datetime objects

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -3,10 +3,10 @@ Provides various authentication policies.
 """
 from __future__ import unicode_literals
 import base64
-from datetime import datetime
 
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import timezone
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
 from rest_framework.compat import CsrfViewMiddleware
 from rest_framework.compat import oauth, oauth_provider, oauth_provider_store
@@ -320,9 +320,7 @@ class OAuth2Authentication(BaseAuthentication):
 
         try:
             token = oauth2_provider.models.AccessToken.objects.select_related('user')
-            # TODO: Change to timezone aware datetime when oauth2_provider add
-            # support to it.
-            token = token.get(token=access_token, expires__gt=datetime.now())
+            token = token.get(token=access_token, expires__gt=timezone.now())
         except oauth2_provider.models.AccessToken.DoesNotExist:
             raise exceptions.AuthenticationFailed('Invalid token')
 


### PR DESCRIPTION
So far the `OAuth2Authentication` backend created naive `datetime` objects when
authenticating the provided credentials.

`django-oauth2-provider` handles tz-aware datetimes since version
0.2.5 (cf [commit 343e422ce1](https://github.com/caffeinehit/django-oauth2-provider/commit/343e422ce1963d3fdcdeeab786338b35b0e01732)).

This commit uses `django.utils.timezone` to generate tz-aware datetimes when
verifying that a presented `AccessToken` is valid (as in not yet expired).
