### PR TITLE
add endpoint argument to @action and @link decorators

### DIFF
--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -48,6 +48,14 @@ The following URL pattern would additionally be generated:
 
 * URL pattern: `^users/{pk}/set_password/$`  Name: `'user-set-password'`
 
+You can customize endpoint name by supplying `endpoint` argument like this:
+
+    @action(endpoint='fancy-name')
+    def do_stuff(self, request, pk=None):
+        ...
+
+* URL pattern: `^users/{pk}/fancy-name/$`  Name: `'user-do-stuff'`
+
 # API Guide
 
 ## SimpleRouter

--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -131,6 +131,12 @@ The `@action` decorator will route `POST` requests by default, but may also acce
         @action(methods=['POST', 'DELETE'])
         def unset_password(self, request, pk=None):
            ...
+
+By default endpoint match method name, but this can be overridden with `endpoint` argument.
+
+        @action(endpoint='fancy-name')
+        def do_stuff(self, request, pk=None):
+            ...
 ---
 
 # API Reference

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -107,23 +107,25 @@ def permission_classes(permission_classes):
     return decorator
 
 
-def link(**kwargs):
+def link(endpoint=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for GET requests.
     """
     def decorator(func):
         func.bind_to_methods = ['get']
         func.kwargs = kwargs
+        func.endpoint = endpoint or func.__name__
         return func
     return decorator
 
 
-def action(methods=['post'], **kwargs):
+def action(methods=['post'], endpoint=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for POST requests.
     """
     def decorator(func):
         func.bind_to_methods = methods
         func.kwargs = kwargs
+        func.endpoint = endpoint or func.__name__
         return func
     return decorator

--- a/rest_framework/tests/test_routers.py
+++ b/rest_framework/tests/test_routers.py
@@ -30,6 +30,10 @@ class BasicViewSet(viewsets.ViewSet):
     def action3(self, request, *args, **kwargs):
         return Response({'method': 'action2'})
 
+    @action(endpoint='action-name')
+    def action4(self, request, *args, **kwargs):
+        return Response({'method': 'action4'})
+
     @link()
     def link1(self, request, *args, **kwargs):
         return Response({'method': 'link1'})
@@ -38,6 +42,10 @@ class BasicViewSet(viewsets.ViewSet):
     def link2(self, request, *args, **kwargs):
         return Response({'method': 'link2'})
 
+    @link(endpoint='link-name')
+    def link3(self, request, *args, **kwargs):
+        return Response({'method': 'link3'})
+    
 
 class TestSimpleRouter(TestCase):
     def setUp(self):
@@ -47,7 +55,8 @@ class TestSimpleRouter(TestCase):
         routes = self.router.get_routes(BasicViewSet)
         decorator_routes = routes[2:]
         # Make sure all these endpoints exist and none have been clobbered
-        for i, endpoint in enumerate(['action1', 'action2', 'action3', 'link1', 'link2']):
+        for i, endpoint in enumerate(['action1', 'action2', 'action3', 'action-name',
+                                      'link1', 'link2', 'link-name']):
             route = decorator_routes[i]
             # check url listing
             self.assertEqual(route.url,


### PR DESCRIPTION
Hello!

There is one problem with `@action` and `@link` decorators at the moment: you can not specify endpoint name, it must be the same as python method name. This is painful if you want to use hyphens instead of underscores in urls.

For example, now 

``` python
@action(permission_classes=[IsAdminOrIsSelf])
def set_password(self, request, pk=None):
    ...
```

gets routed to
 `^users/{pk}/set_password/$`. As I understand, there is no obvious, simple and non-magical way to route it to `^users/{pk}/set-password/$`.

So here is what I propose in this pull request:

``` python
@action(permission_classes=[IsAdminOrIsSelf], endpoint='set-password')
def set_password(self, request, pk=None):
    ...
```

 and it's routed to, obviously, `^users/{pk}/set-password/$`.

The other way to solve hyphen-underscore problem would be just to substitute them not only in name but also in url. 

However, I find approach with explicit names better because
- explicit is better than implicit
- it's more backwards-compatible
- it's more general

The drawbacks are that the code gets a bit more complicated and urls naming remains implicit.

So 

``` python
@action(endpoint='fancy-name')
def do_stuff(self, request, pk=None):
    ...
```

will have url-pattern `^users/{pk}/fancy-name/$`  and name: `'user-do-stuff'`.

PS. djangorestframework is fantastic! =)
