### PR TITLE
Add Field.many_to_native for more control over iterable serialization

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -160,10 +160,16 @@ class Field(object):
         if is_protected_type(value):
             return value
         elif hasattr(value, '__iter__') and not isinstance(value, (dict, six.string_types)):
-            return [self.to_native(item) for item in value]
+            return self.many_to_native(value)
         elif isinstance(value, dict):
             return dict(map(self.to_native, (k, v)) for k, v in value.items())
         return smart_text(value)
+
+    def many_to_native(self, many_values, key_func=(lambda value: value)):
+        """
+        Return a list of many simple objects.
+        """
+        return [self.to_native(key_func(value)) for value in many_values]
 
     def attributes(self):
         """

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -133,7 +133,7 @@ class RelatedField(WritableField):
             return None
 
         if self.many:
-            return [self.to_native(item) for item in value.all()]
+            return self.many_to_native(value.all())
         return self.to_native(value)
 
     def field_from_native(self, data, files, field_name, into):
@@ -223,7 +223,7 @@ class PrimaryKeyRelatedField(RelatedField):
                 queryset = getattr(obj, self.source or field_name)
 
             # Forward relationship
-            return [self.to_native(item.pk) for item in queryset.all()]
+            return self.many_to_native(queryset.all(), lambda item: item.pk)
 
         # To-one relationship
         try:

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -317,7 +317,7 @@ class BaseSerializer(Field):
 
         # If the object has an "all" method, assume it's a relationship
         if is_simple_callable(getattr(obj, 'all', None)):
-            return [self.to_native(item) for item in obj.all()]
+            return self.many_to_native(obj.all())
 
         if obj is None:
             return None
@@ -328,7 +328,7 @@ class BaseSerializer(Field):
             many = hasattr(obj, '__iter__') and not isinstance(obj, (Page, dict, six.text_type))
 
         if many:
-            return [self.to_native(item) for item in obj]
+            return self.many_to_native(obj)
         return self.to_native(obj)
 
     @property
@@ -385,7 +385,7 @@ class BaseSerializer(Field):
                                   PendingDeprecationWarning, stacklevel=2)
 
             if many:
-                self._data = [self.to_native(item) for item in obj]
+                self._data = self.many_to_native(obj)
             else:
                 self._data = self.to_native(obj)
 


### PR DESCRIPTION
Add many_to_native to fields for more control over iterable object serialization. My particular use-case is that I have a model where each instance corresponds to a Twitter user. I want to retrieve and cache users' avatars, full names, and other information from Twitter on an as-needed basis -- essentially when the corresponding user instance needs to be serialized. However, I don't want to make a separate Twitter API call for each user if I have a number of them (waste of time and API limits). Instead, when I know I'm going to be serializing them in bulk, I want to precache as much as I can at once.

My Serializer would look something like:

```
class UserSerializer (ModelSerializer):
    avatar_url = SerializerMethodField('get_avatar_url')

    class Meta:
        model = User

    ...

    def get_avatar_url(self, obj):
        service = self.get_twitter_service()

        # Use the cached info, if available. Otherwise, fetch it.
        return service.get_avatar_url(obj)

    def many_to_native(self, many_obj):
        service = self.get_twitter_service()

        # Hit the service once and cache all the users' info.
        service.get_users_info(many_obj)
        return super(UserSerializer, self).many_to_native(many_obj)
```

The serializer for this model is used as a field in several other serializers as well.
