### PR TITLE
SimpleDjangoFilter that allows straightforward ORM filtering

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -37,7 +37,7 @@ class SimpleDjangoFilterBackend(BaseFilterBackend):
         for k, v in request.QUERY_PARAMS.iteritems():
             # if entry point matches, collect the original key
             if k.split('__')[0] in fields:
-                params.update({k: v[0]})
+                params.update({k: v[0] if isinstance(v, list) else v})
         return queryset.filter(**params)
 
 


### PR DESCRIPTION
After wrestling for couple of days with django-filter and failing to achieve what I wanted, I decided to write a simple and pretty straightforward hack that allowed me to filter results just like with original ORM.

Right now it's not compatible with other filters as it takes over all params. Please comment on how to make it compatible. One way would be to pop() params in other filters (search, ordering, etc.) and use this filter as the last one.
