### PR TITLE
Add support for removing field files by sending an empty string

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -307,7 +307,10 @@ class WritableField(Field):
         try:
             if self.use_files:
                 files = files or {}
-                native = files[field_name]
+                try:
+                    native = files[field_name]
+                except KeyError:
+                    native = data[field_name]
             else:
                 native = data[field_name]
         except KeyError:

--- a/rest_framework/tests/test_files.py
+++ b/rest_framework/tests/test_files.py
@@ -7,13 +7,13 @@ import datetime
 
 
 class UploadedFile(object):
-    def __init__(self, file, created=None):
+    def __init__(self, file=None, created=None):
         self.file = file
         self.created = created or datetime.datetime.now()
 
 
 class UploadedFileSerializer(serializers.Serializer):
-    file = serializers.FileField()
+    file = serializers.FileField(required=False)
     created = serializers.DateTimeField()
 
     def restore_object(self, attrs, instance=None):
@@ -47,5 +47,25 @@ class FileSerializerTests(TestCase):
         now = datetime.datetime.now()
 
         serializer = UploadedFileSerializer(data={'created': now})
-        self.assertFalse(serializer.is_valid())
-        self.assertIn('file', serializer.errors)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.object.created, now)
+        self.assertIsNone(serializer.object.file)
+
+    def test_remove_with_empty_string(self):
+        """
+        Passing empty string as data should cause file to be removed
+
+        Test for:
+        https://github.com/tomchristie/django-rest-framework/issues/937
+        """
+        now = datetime.datetime.now()
+        file = BytesIO(six.b('stuff'))
+        file.name = 'stuff.txt'
+        file.size = len(file.getvalue())
+
+        uploaded_file = UploadedFile(file=file, created=now)
+
+        serializer = UploadedFileSerializer(instance=uploaded_file, data={'created': now, 'file': ''})
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.object.created, uploaded_file.created)
+        self.assertIsNone(serializer.object.file)


### PR DESCRIPTION
This fixes issue #937. It allows you to remove a file from a FileField by sending an empty string.

It includes a test case. I modified another test to make things a little simpler, but I manually verified that the old test still works properly.
