### PR TITLE
Fix Tutorial5 serializers.py typo

### DIFF
--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -80,7 +80,7 @@ We can easily re-write our existing serializers to use hyperlinking.
         highlight = serializers.HyperlinkedIdentityField(view_name='snippet-highlight', format='html')
     
         class Meta:
-            model = models.Snippet
+            model = Snippet
             fields = ('url', 'highlight', 'owner',
                       'title', 'code', 'linenos', 'language', 'style')
     


### PR DESCRIPTION
A slight typo in Tutorial5's `SnippetSerializer` class's `Meta` class causing an exception `"name 'models' is not defined"`. A subtle one that can confuse Python/Django newbies like me.

As far as I was able to follow and reproduce, at the end of Tutorial5 the `serializers.py` file should look like this:

``` python
from django.forms import widgets
from rest_framework import serializers
from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
from django.contrib.auth.models import User

class SnippetSerializer(serializers.HyperlinkedModelSerializer):
    owner     = serializers.Field(source='owner.username')
    highlight = serializers.HyperlinkedIdentityField(view_name='snippet-highlight', format='html')

    class Meta:
        model  = Snippet
        fields = ('url', 'highlight', 'owner','title', 'code', 'linenos', 'language', 'style')

class UserSerializer(serializers.HyperlinkedModelSerializer):
    snippets = serializers.HyperlinkedRelatedField(many=True, view_name='snippet-detail')

    class Meta:
        model  = User
        fields = ('url', 'username', 'snippets')
```
