### PR TITLE
DRF Any Permissions (docs)

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -188,6 +188,16 @@ Note that the generic views will check the appropriate object level permissions,
 
 Also note that the generic views will only check the object-level permissions for views that retrieve a single model instance.  If you require object-level filtering of list views, you'll need to filter the queryset separately.  See the [filtering documentation][filtering] for more details.
 
+---
+
+# Third party packages
+
+The following third party packages are also available.
+
+## DRF Any Permissions
+
+Django Rest Framework requires that a user meets all permissions before they can access a view.  You may need the user to meet only one of the permission requirements to access a view, which is why [DRF Any Permissions][drf-any-permissions] was created.
+
 [cite]: https://developer.apple.com/library/mac/#documentation/security/Conceptual/AuthenticationAndAuthorizationGuide/Authorization/Authorization.html
 [authentication]: authentication.md
 [throttling]: throttling.md
@@ -197,3 +207,4 @@ Also note that the generic views will only check the object-level permissions fo
 [django-oauth2-provider]: https://github.com/caffeinehit/django-oauth2-provider
 [2.2-announcement]: ../topics/2.2-announcement.md
 [filtering]: filtering.md
+[drf-any-permissions]: https://github.com/kevin-brown/drf-any-permissions


### PR DESCRIPTION
I created a package that gives you better control over what permissions are required when accessing a view.  It supports all of the current permissions classes (it just reuses the current API) and allows for them to be chained.

It's up on PyPi as [drf-any-permissions](https://pypi.python.org/pypi/drf-any-permissions).
