### PR TITLE
Make TokenAuthentication RFC2617 compliant

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -142,6 +142,7 @@ class TokenAuthentication(BaseAuthentication):
     """
 
     model = Token
+    www_authenticate_realm = 'api'
     """
     A custom token model may be used, but must have the following properties.
 
@@ -176,7 +177,7 @@ class TokenAuthentication(BaseAuthentication):
         return (token.user, token)
 
     def authenticate_header(self, request):
-        return 'Token'
+        return 'Token realm="%s"' % self.www_authenticate_realm
 
 
 class OAuthAuthentication(BaseAuthentication):


### PR DESCRIPTION
RFC2617[0] requires that the scheme in the WWW-Authenticate header is `followed by a comma-separated list of attribute-value pairs which carry the parameters necessary for achieving authentication via that scheme.`. That list must not be empty: `challenge = auth-scheme 1*SP 1#auth-param`.

[0] http://tools.ietf.org/html/rfc2617#section-1.2
