### PR TITLE
PATCH requests should not be able to create objects.

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -142,11 +142,14 @@ class UpdateModelMixin(object):
         try:
             return self.get_object()
         except Http404:
-            # If this is a PUT-as-create operation, we need to ensure that
-            # we have relevant permissions, as if this was a POST request.
-            # This will either raise a PermissionDenied exception,
-            # or simply return None
-            self.check_permissions(clone_request(self.request, 'POST'))
+            if self.request.method == 'PUT':
+                # For PUT-as-create operation, we need to ensure that we have
+                # relevant permissions, as if this was a POST request.  This
+                # will either raise a PermissionDenied exception, or simply
+                # return None.
+                self.check_permissions(clone_request(self.request, 'POST'))
+            else:
+                raise
 
     def pre_save(self, obj):
         """

--- a/rest_framework/tests/test_generics.py
+++ b/rest_framework/tests/test_generics.py
@@ -338,6 +338,17 @@ class TestInstanceView(TestCase):
         new_obj = SlugBasedModel.objects.get(slug='test_slug')
         self.assertEqual(new_obj.text, 'foobar')
 
+    def test_patch_cannot_create_an_object(self):
+        """
+        PATCH requests should not be able to create objects.
+        """
+        data = {'text': 'foobar'}
+        request = factory.patch('/999', data, format='json')
+        with self.assertNumQueries(1):
+            response = self.view(request, pk=999).render()
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertFalse(self.objects.filter(id=999).exists())
+
 
 class TestOverriddenGetObject(TestCase):
     """


### PR DESCRIPTION
Fixed an issue with `PATCH` request being catched into PUT-as-create fallback.
