### PR TITLE
Update formatting.py

### DIFF
--- a/rest_framework/utils/formatting.py
+++ b/rest_framework/utils/formatting.py
@@ -49,6 +49,13 @@ def get_view_name(cls, suffix=None):
     """
     Return a formatted name for an `APIView` class or `@api_view` function.
     """
+    if hasattr(cls,'Meta'):
+        # this allows for a simple override of the name used in the template
+        if cls.Meta.view_name:
+            if cls.Meta.suffix:
+                return cls.Meta.view_name + ' ' + suffix
+            return cls.Meta.view_name
+                                                                
     name = cls.__name__
     name = _remove_trailing_string(name, 'View')
     name = _remove_trailing_string(name, 'ViewSet')


### PR DESCRIPTION
Simple update that allows setting the title used in the Browseable API and to not use a suffix if desired.

```
Class MyAPIView(viewsets.GenericViewSet):
    def Meta:
        view_name = 'API View'
        view_name_suffix = False
```
