### PR TITLE
Nested Routers: Allow nested URLs for resources, like /carts/{nested_1_pk}/itens/{pk}

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -189,9 +189,6 @@ class SimpleRouter(BaseRouter):
         Given a viewset, return the portion of URL regex that is used
         to match against a single instance.
         """
-        if lookup_prefix:
-            lookup_prefix += '_'
-
         base_regex = '(?P<{lookup_prefix}{lookup_field}>[^/]+)'
         lookup_field = getattr(viewset, 'lookup_field', 'pk')
         return base_regex.format(lookup_field=lookup_field, lookup_prefix=lookup_prefix)


### PR DESCRIPTION
I wrote a PoC NestedSimpleRouter, that nests its URLs into some other router routes. Usage:

``` python
# urls.py
(...)
router = routers.SimpleRouter()
router.register(r'carts', CartViewSet)

carts_router = routers.NestedSimpleRouter(router, r'carts')
carts_router.register(r'itens', ItensViewSet)

url_patterns = patterns('',
    url(r'^', include(router.urls)),
    url(r'^', include(carts_router.urls)),
)
```

This creates the following URLs:

```
^carts/$ [name='cart-list']
^carts/(?P<pk>[^/]+)/$ [name='cart-detail']
^carts/(?P<nested_1_pk>[^/]+)/itens/$ [name='item-list']
^carts/(?P<nested_1_pk>[^/]+)/itens/(?P<pk>[^/]+)/$ [name='item-detail']
```

And is intended to be used like:

``` python
# views.py
class ItemViewSet(viewsets.ViewSet):
    model = Item

    def list(self, request, nested_1_pk=None):
        cart = Cart.objects.get(pk=nested_1_pk)
        return Response([])

    def retrieve(self, request, pk=None, nested_1_pk=None):
        (...)
```

The `nested_1_pk` is automatic, and should grow to `nested_{n}_{lookup_field}` as you nest Nested routers, but this will need more work into `SimpleRouter.get_lookup_regex()` to do it ( and I need some sleep now :P )

It works very well, but have no tests yet.

What you think?
