### PR TITLE
parameterize identity field serializer class to allow for easier subclassing

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -903,6 +903,7 @@ class HyperlinkedModelSerializer(ModelSerializer):
     _options_class = HyperlinkedModelSerializerOptions
     _default_view_name = '%(model_name)s-detail'
     _hyperlink_field_class = HyperlinkedRelatedField
+    _hyperlink_identify_field_class = HyperlinkedIdentityField
 
     def get_default_fields(self):
         fields = super(HyperlinkedModelSerializer, self).get_default_fields()
@@ -911,7 +912,7 @@ class HyperlinkedModelSerializer(ModelSerializer):
             self.opts.view_name = self._get_default_view_name(self.opts.model)
 
         if 'url' not in fields:
-            url_field = HyperlinkedIdentityField(
+            url_field = self._hyperlink_identify_field_class(
                 view_name=self.opts.view_name,
                 lookup_field=self.opts.lookup_field
             )


### PR DESCRIPTION
Pull #501 was closed with the resolution that this was out of scope.  This small change makes it much easier to subclass HyperlinkedModelSerializer to force the use of relative URLs like so:

class RelativeHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
    def get_url(self, obj, view_name, request, format):
        # by omiting request we force all urls to be relative
        return super(RelativeHyperlinkedRelatedField, self).get_url(obj, view_name, None, format)

class RelativeHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
    def get_url(self, obj, view_name, request, format):
        # by omiting request we force all urls to be relative
        return super(RelativeHyperlinkedIdentityField, self).get_url(obj, view_name, None, format)

class RelativeHyperlinkedModelSerializer(serializers.HyperlinkedModelSerializer):
    _hyperlink_field_class = RelativeHyperlinkedRelatedField
    _hyperlink_identify_field_class = RelativeHyperlinkedIdentityField
