### PR TITLE
Convert any types (strings usualy) to integer

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -777,6 +777,12 @@ class IntegerField(WritableField):
             raise ValidationError(self.error_messages['invalid'])
         return value
 
+    def to_native(self, value):
+        value = super(IntegerField, self).to_native(value)
+        if value is None:
+            return value
+        return int(value)
+
 
 class FloatField(WritableField):
     type_name = 'FloatField'


### PR DESCRIPTION
I have a serializer like this:

``` python
class ProfileSerializer(serializers.HyperlinkedModelSerializer):
    ...
    id = serializers.IntegerField(source='user_id', read_only=True)
```

Sometimes user_id field has string type on put requests. JSON response gotten:

``` javascript
{
    "id": "17", 
   ...
}
```

expected:

``` javascript
{
    "id": 17, 
   ...
}
```
