### PR TITLE
Make ChoiceField.from_native() follow IntegerField behaviour on empty values

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -514,6 +514,11 @@ class ChoiceField(WritableField):
                     return True
         return False
 
+    def from_native(self, value):
+        if value in validators.EMPTY_VALUES:
+            return None
+        return super(ChoiceField, self).from_native(value)
+
 
 class EmailField(CharField):
     type_name = 'EmailField'

--- a/rest_framework/tests/test_fields.py
+++ b/rest_framework/tests/test_fields.py
@@ -688,6 +688,14 @@ class ChoiceFieldTests(TestCase):
         f = serializers.ChoiceField(required=False, choices=self.SAMPLE_CHOICES)
         self.assertEqual(f.choices, models.fields.BLANK_CHOICE_DASH + self.SAMPLE_CHOICES)
 
+    def test_from_native_empty(self):
+        """
+        Make sure from_native() returns None on empty param.
+        """
+        f = serializers.ChoiceField(choices=self.SAMPLE_CHOICES)
+        result = f.from_native('')
+        self.assertEqual(result, None)
+
 
 class EmailFieldTests(TestCase):
     """


### PR DESCRIPTION
Currently, if you pass an empty value when de-serializing a ChoiceField, it skips validation and ends up on the instance, which makes the save() call fail if the field can't accept empty string values (e.g. it's an IntegerField)

Discussed on IRC and here : https://groups.google.com/forum/#!msg/django-rest-framework/g3Mnp7YY5hU/_LwTqKf8-Z0J
