### PR TITLE
Allow OPTIONS to retrieve PUT field metadata on empty objects

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -360,7 +360,9 @@ class GenericAPIView(views.APIView):
                         self.get_object()
                     except Http404:
                         # Http404 should be acceptable and the serializer
-                        # metadata should be populated.
+                        # metadata should be populated. Except this so the
+                        # outer "else" clause of the try-except-else block
+                        # will be executed.
                         pass
             except (exceptions.APIException, PermissionDenied):
                 pass

--- a/rest_framework/tests/test_generics.py
+++ b/rest_framework/tests/test_generics.py
@@ -272,6 +272,48 @@ class TestInstanceView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, expected)
 
+    def test_options_before_instance_create(self):
+        """
+        OPTIONS requests to RetrieveUpdateDestroyAPIView should return metadata
+        before the instance has been created
+        """
+        request = factory.options('/999')
+        with self.assertNumQueries(1):
+            response = self.view(request, pk=999).render()
+        expected = {
+            'parses': [
+                'application/json',
+                'application/x-www-form-urlencoded',
+                'multipart/form-data'
+            ],
+            'renders': [
+                'application/json',
+                'text/html'
+            ],
+            'name': 'Instance',
+            'description': 'Example description for OPTIONS.',
+            'actions': {
+                'PUT': {
+                    'text': {
+                        'max_length': 100,
+                        'read_only': False,
+                        'required': True,
+                        'type': 'string',
+                        'label': 'Text comes here',
+                        'help_text': 'Text description.'
+                    },
+                    'id': {
+                        'read_only': True,
+                        'required': False,
+                        'type': 'integer',
+                        'label': 'ID',
+                    },
+                }
+            }
+        }
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, expected)
+
     def test_get_instance_view_incorrect_arg(self):
         """
         GET requests with an incorrect pk type, should raise 404, not 500.


### PR DESCRIPTION
This allows OPTIONS to return the PUT endpoint's object serializer metadata when the object hasn't been created yet.

When self.get_object() raises a Http404, the behavior should not be the same as a PermissionDenied, which is to not fill in the serializer metadata. A PUT for a new resource url should be able to use OPTIONS to examine the endpoint's metadata prior to executing the PUT.
