### PR TITLE
Updated DOAC integration link

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -404,4 +404,4 @@ The [Django OAuth2 Consumer][doac] library from [Rediker Software][rediker] is a
 [oauthlib]: https://github.com/idan/oauthlib
 [doac]: https://github.com/Rediker-Software/doac
 [rediker]: https://github.com/Rediker-Software
-[doac-rest-framework]: https://github.com/Rediker-Software/doac/blob/master/docs/markdown/integrations.md#
+[doac-rest-framework]: https://github.com/Rediker-Software/doac/blob/master/docs/integrations.md#


### PR DESCRIPTION
As a part of cleaning up the DOAC documentation, I removed the alternate versions.  This moved all of the files up one directory, which will make the link in the documentation invalid.
