### PR TITLE
Add test for default argument in PrimaryKeyRelatedField

### DIFF
--- a/rest_framework/tests/test_serializer.py
+++ b/rest_framework/tests/test_serializer.py
@@ -883,6 +883,34 @@ class ManyRelatedTests(TestCase):
         }
         self.assertEqual(serializer.data, expected)
 
+    def test_default_value(self):
+        writer = Person()
+        writer.save()
+
+        def callable_default():
+            return writer.id
+
+        class BlogPostSerializer(serializers.ModelSerializer):
+            title = serializers.CharField(default=callable_default)
+            writer = serializers.PrimaryKeyRelatedField(many=False, read_only=False, required=False, default=callable_default)
+
+            class Meta:
+                model = BlogPost
+                fields = ('id', 'title', 'writer')
+
+        serializer = BlogPostSerializer(data={})
+
+        self.assertTrue(serializer.is_valid())
+
+        serializer.save()
+
+        expected = {
+            'id': 1,
+            'title': str(callable_default()),
+            'writer': callable_default()
+        }
+        self.assertEqual(serializer.data, expected)
+
 
 class RelatedTraversalTest(TestCase):
     def test_nested_traversal(self):


### PR DESCRIPTION
There is maybe something I didn't catch.

http://stackoverflow.com/questions/18641826/where-to-add-default-value-in-createapiview/18644553?noredirect=1#comment27470619_18644553
