### PR TITLE
Let format suffixes and no-trailing slash work together

### DIFF
--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -25,10 +25,10 @@ def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required):
             view = urlpattern._callback or urlpattern._callback_str
             kwargs = urlpattern.default_args
             name = urlpattern.name
-            # Add in both the existing and the new urlpattern
+            # Add in both the new and the existing urlpattern
+            ret.append(url(regex, view, kwargs, name))
             if not suffix_required:
                 ret.append(urlpattern)
-            ret.append(url(regex, view, kwargs, name))
 
     return ret
 


### PR DESCRIPTION
Having trailing_slash=False on my Router with format suffixes optional is broken right now. The order of url regexes that will be checked is:

```
...
^mytype/(?P<pk>[^/]+)$
^mytype/(?P<pk>[^/]+)\.(?P<format>[a-z]+)$
...
```

requesting mytype/123.json will match the first pattern, causing pk to be set to "123.json". This pull request will  reverse the order those two regexes are checked and correctly set pk to "123" and format to "json".
