### PR TITLE
Let JSONEncoder handle Numpy data types.

### DIFF
--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -42,6 +42,8 @@ class JSONEncoder(json.JSONEncoder):
             return str(o.total_seconds())
         elif isinstance(o, decimal.Decimal):
             return str(o)
+        elif hasattr(o, 'tolist'):
+            return o.tolist()
         elif hasattr(o, '__iter__'):
             return [i for i in o]
         return super(JSONEncoder, self).default(o)


### PR DESCRIPTION
json.JSONEncoder cannot serialize Numpy data types. Numpy arrays
and array scalars have a tolist() method which casts the object to
a standard python data type.
