### PR TITLE
Fixed #1105 -- Add hook for custom context in `BrowsableAPIRenderer`.

### DIFF
--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -115,12 +115,15 @@ The context that's available to the template:
 * `name`                : The name of the resource
 * `post_form`           : A form instance for use by the POST form (if allowed)
 * `put_form`            : A form instance for use by the PUT form (if allowed)
+* `display_edit_forms`  : A boolean indicating whether or not POST, PUT and PATCH forms will be displayed
 * `request`             : The request object
 * `response`            : The response object
 * `version`             : The version of Django REST Framework
 * `view`                : The view handling the request
 * `FORMAT_PARAM`        : The view can accept a format override
 * `METHOD_PARAM`        : The view can accept a method override
+
+You can override the `BrowsableAPIRenderer.get_context()` method to customise the context that gets passed to the template.
 
 #### Not using base.html
 

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -568,9 +568,6 @@ class BrowsableAPIRenderer(BaseRenderer):
         """
         Returns the context used to render.
         """
-        self.accepted_media_type = accepted_media_type or ''
-        self.renderer_context = renderer_context or {}
-
         view = renderer_context['view']
         request = renderer_context['request']
         response = renderer_context['response']
@@ -581,7 +578,7 @@ class BrowsableAPIRenderer(BaseRenderer):
         raw_data_patch_form = self.get_raw_data_form(view, 'PATCH', request)
         raw_data_put_or_patch_form = raw_data_put_form or raw_data_patch_form
 
-        context = RequestContext(request, {
+        context = {
             'content': self.get_content(renderer, data, accepted_media_type, renderer_context),
             'view': view,
             'request': request,
@@ -604,18 +601,22 @@ class BrowsableAPIRenderer(BaseRenderer):
             'raw_data_patch_form': raw_data_patch_form,
             'raw_data_put_or_patch_form': raw_data_put_or_patch_form,
 
-            'allow_form': bool(response.status_code != 403),
+            'display_edit_forms': bool(response.status_code != 403),
 
             'api_settings': api_settings
-        })
+        }
         return context
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         """
         Render the HTML for the browsable API representation.
         """
+        self.accepted_media_type = accepted_media_type or ''
+        self.renderer_context = renderer_context or {}
+
         template = loader.get_template(self.template)
         context = self.get_context(data, accepted_media_type, renderer_context)
+        context = RequestContext(renderer_context['request'], context)
         ret = template.render(context)
 
         # Munge DELETE Response code to allow us to return content

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -122,7 +122,7 @@
             </div>
         </div>
 
-            {% if allow_form %}
+            {% if display_edit_forms %}
 
                 {% if post_form or raw_data_post_form %}
                 <div {% if post_form %}class="tabbable"{% endif %}>


### PR DESCRIPTION
Replace hard coded response status check with `allow_form` context
variable, so that it can be overridden in a custom renderer class.
