### PR TITLE
Tutorial part5: make snippet.owner a hyperlink too

### DIFF
--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -76,7 +76,7 @@ The `HyperlinkedModelSerializer` has the following differences from `ModelSerial
 We can easily re-write our existing serializers to use hyperlinking.
 
     class SnippetSerializer(serializers.HyperlinkedModelSerializer):
-        owner = serializers.Field(source='owner.username')
+        owner = serializers.HyperlinkedIdentityField(view_name='user-detail')
         highlight = serializers.HyperlinkedIdentityField(view_name='snippet-highlight', format='html')
     
         class Meta:


### PR DESCRIPTION
When converting to Hyperlinked serializers in part5 of the tutorial, we can use a hyperlink for the "owner" attribute of a snippet too.
