### PR TITLE
Address pending deprecation of Model._meta.module_name in Django 1.6

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -80,6 +80,14 @@ except ImportError:
         Image = None
 
 
+def get_model_name(model_cls):
+    try:
+        return model_cls._meta.model_name
+    except AttributeError:
+        # < 1.6 used module_name instead of model_name
+        return model_cls._meta.module_name
+
+
 def get_concrete_model(model_cls):
     try:
         return model_cls._meta.concrete_model

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -4,7 +4,7 @@ returned by list views.
 """
 from __future__ import unicode_literals
 from django.db import models
-from rest_framework.compat import django_filters, six, guardian
+from rest_framework.compat import django_filters, six, guardian, get_model_name
 from functools import reduce
 import operator
 
@@ -158,7 +158,7 @@ class DjangoObjectPermissionsFilter(BaseFilterBackend):
         model_cls = queryset.model
         kwargs = {
             'app_label': model_cls._meta.app_label,
-            'model_name': model_cls._meta.module_name
+            'model_name': get_model_name(model_cls)
         }
         permission = self.perm_format % kwargs
         return guardian.shortcuts.get_objects_for_user(user, permission, queryset)

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -8,7 +8,8 @@ import warnings
 SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 
 from django.http import Http404
-from rest_framework.compat import oauth2_provider_scope, oauth2_constants
+from rest_framework.compat import (get_model_name, oauth2_provider_scope,
+                                   oauth2_constants)
 
 
 class BasePermission(object):
@@ -116,7 +117,7 @@ class DjangoModelPermissions(BasePermission):
         """
         kwargs = {
             'app_label': model_cls._meta.app_label,
-            'model_name': model_cls._meta.module_name
+            'model_name': get_model_name(model_cls)
         }
         return [perm % kwargs for perm in self.perms_map[method]]
 
@@ -177,7 +178,7 @@ class DjangoObjectPermissions(DjangoModelPermissions):
     def get_required_object_permissions(self, method, model_cls):
         kwargs = {
             'app_label': model_cls._meta.app_label,
-            'model_name': model_cls._meta.module_name
+            'model_name': get_model_name(model_cls)
         }
         return [perm % kwargs for perm in self.perms_map[method]]
 

--- a/rest_framework/tests/test_permissions.py
+++ b/rest_framework/tests/test_permissions.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.test import TestCase
 from django.utils import unittest
 from rest_framework import generics, status, permissions, authentication, HTTP_HEADER_ENCODING
-from rest_framework.compat import guardian
+from rest_framework.compat import guardian, get_model_name
 from rest_framework.filters import DjangoObjectPermissionsFilter
 from rest_framework.test import APIRequestFactory
 from rest_framework.tests.models import BasicModel
@@ -202,7 +202,7 @@ class ObjectPermissionsIntegrationTests(TestCase):
 
         # give everyone model level permissions, as we are not testing those
         everyone = Group.objects.create(name='everyone')
-        model_name = BasicPermModel._meta.module_name
+        model_name = get_model_name(BasicPermModel)
         app_label = BasicPermModel._meta.app_label
         f = '{0}_{1}'.format
         perms = {


### PR DESCRIPTION
From Django 1.6, `Model._meta.module_name` will be deprecated.
See https://github.com/django/django/commit/ec469ade2b04b94bfeb59fb0fc7d9300470be615

This patch fixes the resulting `PendingDeprecationWarning` in the log.
