### PR TITLE
corrected doc for throttle_classes decorator

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -59,7 +59,7 @@ using the `APIView` class based views.
 Or, if you're using the `@api_view` decorator with function based views.
 
     @api_view('GET')
-    @throttle_classes(UserRateThrottle)
+    @throttle_classes([UserRateThrottle])
     def example_view(request, format=None):
         content = {
             'status': 'request was permitted'


### PR DESCRIPTION
the decorator actually expects an array and otherwise raise an exception.
