### PR TITLE
Fix for UnicodeEncodeError when form data includes an Unicode character

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -334,7 +334,7 @@ class Request(object):
             self._CONTENT_PARAM in self._data and
             self._CONTENTTYPE_PARAM in self._data):
             self._content_type = self._data[self._CONTENTTYPE_PARAM]
-            self._stream = BytesIO(self._data[self._CONTENT_PARAM].encode(HTTP_HEADER_ENCODING))
+            self._stream = BytesIO(self._data[self._CONTENT_PARAM].encode('utf-8'))
             self._data, self._files = (Empty, Empty)
 
     def _parse(self):


### PR DESCRIPTION
After getting lots of "'latin-1' codec can't encode characters in position 62-66: ordinal not in range(256)" when POSTing valid Unicode characters with "multipart/form-data" requests I figured out that the issue is that '_perform_form_overloading()' is trying to encode the form data as with 'iso-8859-1' which fails.
