### PR TITLE
Add a section for configuring static files so the browsable API css will load

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -127,6 +127,16 @@ We'd also like to set a few global settings.  We'd like to turn on pagination, a
         'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAdminUser',),
         'PAGINATE_BY': 10
     }
+    
+In order for the browsable API to properly render you should also add the
+following information into `tutorial/settings.py`
+
+    INSTALLED_APPS = (
+        ...
+        'django.contrib.staticfiles',
+    )
+    
+    STATIC_URL = '/static/'
 
 Okay, we're done.
 


### PR DESCRIPTION
I'm a total noob to `django-rest-framework` and just walking through the quickstart tonight. I found that when hitting the browsable API the static files don't load so the end user experience looks different than the documentation (no css). It appears that the settings.py generated with the new project (using Django 1.5.4) doesn't automatically setup static files.

I can appreciate that this addition is not directly related to the project, however I think adding would enhance (ever so slightly) the end user experience going through the documentation.
