### PR TITLE
Add model attribute to the get_queryset example in docs

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -187,6 +187,7 @@ Note that you can use any of the standard attributes or method overrides provide
         A simple ViewSet for viewing and editing the accounts
         associated with the user.
         """
+        model = Account
         serializer_class = AccountSerializer
         permission_classes = [IsAccountAdminOrReadOnly]
 


### PR DESCRIPTION
Tiny little change to documentation.

Currently, leaving both `model` and `queryset` attributes out when defining a ModelViewset causes an assertion failure:
`'base_name' argument not specified, and could not automatically determine the name from the viewset, as it does not have a '.model' or '.queryset' attribute.`

Perhaps this is an indication of an underlying issue (i.e. this assertion should be adjusted to account for a `get_queryset` method being present), but fixing the documentation as things currently stand might help avoid confusion.
