### PR TITLE
Description should be html safe

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -110,7 +110,9 @@
 
         <div class="content-main">
             <div class="page-header"><h1>{{ name }}</h1></div>
+            {% block description %}
             {{ description|safe }}
+            {% endblock %}
             <div class="request-info" style="clear: both" >
                 <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
             </div>


### PR DESCRIPTION
The only values that it can contain are retrieved from docstrings.
This allows users to create a mixin that parses the docstring from different formats or fetching them from a CMS.
The block allows to use other filters such as the django.contrib.markup filters.
