### PR TITLE
The default get_view_name method should attempt to get the view's name from an instance of the provided view class

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -25,7 +25,7 @@ def get_view_name(view_cls, suffix=None):
     try:
         view = view_cls()
         name = view.get_view_name()
-    else:
+    except:
         name = view_cls.__name__
     name = formatting.remove_trailing_string(name, 'View')
     name = formatting.remove_trailing_string(name, 'ViewSet')


### PR DESCRIPTION
It enables overriding the view's name for the browseable API.
