### PR TITLE
Using the filenames where relevant

### DIFF
--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -12,7 +12,7 @@ Currently our API doesn't have any restrictions on who can edit or delete code s
 We're going to make a couple of changes to our `Snippet` model class.
 First, let's add a couple of fields.  One of those fields will be used to represent the user who created the code snippet.  The other field will be used to store the highlighted HTML representation of the code.
 
-Add the following two fields to the model.
+Add the following two fields to the `Snippet` model in `models.py`.
 
     owner = models.ForeignKey('auth.User', related_name='snippets')
     highlighted = models.TextField()
@@ -52,7 +52,7 @@ You might also want to create a few different users, to use for testing the API.
 
 ## Adding endpoints for our User models
 
-Now that we've got some users to work with, we'd better add representations of those users to our API.  Creating a new serializer is easy:
+Now that we've got some users to work with, we'd better add representations of those users to our API.  Creating a new serializer is easy. In `serializers.py` add:
 
     from django.contrib.auth.models import User
 
@@ -65,7 +65,7 @@ Now that we've got some users to work with, we'd better add representations of t
 
 Because `'snippets'` is a *reverse* relationship on the User model, it will not be included by default when using the `ModelSerializer` class, so we needed to add an explicit field for it.
 
-We'll also add a couple of views.  We'd like to just use read-only views for the user representations, so we'll use the `ListAPIView` and `RetrieveAPIView` generic class based views.
+We'll also add a couple of views to `views.py`.  We'd like to just use read-only views for the user representations, so we'll use the `ListAPIView` and `RetrieveAPIView` generic class based views.
 
     class UserList(generics.ListAPIView):
         queryset = User.objects.all()
@@ -80,7 +80,7 @@ Make sure to also import the `UserSerializer` class
 
 	from snippets.serializers import UserSerializer
 
-Finally we need to add those views into the API, by referencing them from the URL conf.
+Finally we need to add those views into the API, by referencing them from the URL conf. Add the following to the patterns in `urls.py`.
 
     url(r'^users/$', views.UserList.as_view()),
     url(r'^users/(?P<pk>[0-9]+)/$', views.UserDetail.as_view()),
@@ -98,7 +98,7 @@ On **both** the `SnippetList` and `SnippetDetail` view classes, add the followin
 
 ## Updating our serializer
 
-Now that snippets are associated with the user that created them, let's update our `SnippetSerializer` to reflect that.  Add the following field to the serializer definition:
+Now that snippets are associated with the user that created them, let's update our `SnippetSerializer` to reflect that.  Add the following field to the serializer definition in `serializers.py`:
 
     owner = serializers.Field(source='owner.username')
 


### PR DESCRIPTION
Sometimes it's hard to tell which file the code is intended to go in. Now it spells it out.
