### PR TITLE
Put template block around the description

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -110,7 +110,9 @@
 
         <div class="content-main">
             <div class="page-header"><h1>{{ name }}</h1></div>
+            {% block description %}
             {{ description }}
+            {% endblock %}
             <div class="request-info" style="clear: both" >
                 <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
             </div>


### PR DESCRIPTION
This is a revised version of #1164 to only include the commit for the template block:
https://github.com/thedrow/django-rest-framework-1/commit/f97885f00f35eb7af2dc0dbc5e823723b28cba3a
