### PR TITLE
Fix infered field type for models.NullBooleanField

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -606,6 +606,7 @@ class ModelSerializer(Serializer):
         models.TextField: CharField,
         models.CommaSeparatedIntegerField: CharField,
         models.BooleanField: BooleanField,
+        models.NullBooleanField: BooleanField,
         models.FileField: FileField,
         models.ImageField: ImageField,
     }


### PR DESCRIPTION
I believe this should address https://groups.google.com/forum/#!topic/django-rest-framework/D9mXEftpuQ8 (It seems to do the trick for my configuration).

I've submitted the test cases in a separate so they can be discussed/accepted/rejected independently.
