### PR TITLE
check for isinstance Page, prevents alt pagination

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -520,7 +520,7 @@ class BaseSerializer(WritableField):
             if self.many is not None:
                 many = self.many
             else:
-                many = hasattr(obj, '__iter__') and not isinstance(obj, (Page, dict))
+                many = hasattr(obj, '__iter__') and not (isinstance(obj, dict) or hasattr(obj, 'next_page_number'))
                 if many:
                     warnings.warn('Implict list/queryset serialization is deprecated. '
                                   'Use the `many=True` flag when instantiating the serializer.',


### PR DESCRIPTION
when using DEFAULT_PAGINATION_SERIALIZER_CLASS and a custom paginator_class
BaseSerializer's checking for isinstance Page doesn't work.

the custom paginator_class has it's own Page that doesn't inherit from
django's base Page and thus its **iter** method causes many=True, and
iterating over the page and trying to serialize the objects through
DEFAULT_PAGINATION_SERIALIZER_CLASS.

proposed fix is to look for a method that would (likely) only be on a Page type object, rather
than for something to be or inherit from the django pagination Page type.
