### PR TITLE
pass many=False to pagination_serializer_class()

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -111,7 +111,8 @@ class GenericAPIView(views.APIView):
 
         pagination_serializer_class = SerializerClass
         context = self.get_serializer_context()
-        return pagination_serializer_class(instance=page, context=context)
+        return pagination_serializer_class(instance=page, context=context,
+                                           many=False)
 
     def paginate_queryset(self, queryset, page_size=None):
         """


### PR DESCRIPTION
pagination serializers should always have many=False set, otherwise they'll
be passed the individual objects of the page rather than the page object
itself. this is a real/better fix for #1186. removes the need for the
deprecated isinstance Page check, though it's left in place since it
doesn't hurt anything.
