### PR TITLE
Add many_to_native method

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -125,6 +125,9 @@ class RelatedField(WritableField):
 
     ### Regular serializer stuff...
 
+    def many_to_native(self, objects):
+        return [self.to_native(item) for item in objects]
+
     def field_to_native(self, obj, field_name):
         try:
             if self.source == '*':
@@ -145,11 +148,11 @@ class RelatedField(WritableField):
 
         if self.many:
             if is_simple_callable(getattr(value, 'all', None)):
-                return [self.to_native(item) for item in value.all()]
+                return self.many_to_native(value.all())
             else:
                 # Also support non-queryset iterables.
                 # This allows us to also support plain lists of related items.
-                return [self.to_native(item) for item in value]
+                return self.many_to_native(value)
         return self.to_native(value)
 
     def field_from_native(self, data, files, field_name, into):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -326,6 +326,9 @@ class BaseSerializer(WritableField):
 
         return ret
 
+    def many_to_native(self, objects):
+        return [self.to_native(item) for item in objects]
+
     def from_native(self, data, files):
         """
         Deserialize primitives -> objects.
@@ -372,7 +375,7 @@ class BaseSerializer(WritableField):
             return None
 
         if is_simple_callable(getattr(value, 'all', None)):
-            return [self.to_native(item) for item in value.all()]
+            return self.many_to_native(value.all())
 
         if value is None:
             return None
@@ -383,7 +386,7 @@ class BaseSerializer(WritableField):
             many = hasattr(value, '__iter__') and not isinstance(value, (Page, dict, six.text_type))
 
         if many:
-            return [self.to_native(item) for item in value]
+            return self.many_to_native(value)
         return self.to_native(value)
 
     def field_from_native(self, data, files, field_name, into):
@@ -527,7 +530,7 @@ class BaseSerializer(WritableField):
                                   DeprecationWarning, stacklevel=2)
 
             if many:
-                self._data = [self.to_native(item) for item in obj]
+                self._data = self.many_to_native(obj)
             else:
                 self._data = self.to_native(obj)
 


### PR DESCRIPTION
Allows serializers to be easily customized when many=True rather than always returning a list of objects.

In our case, we wanted to replicate Stripe's api which returns a similar format to:

``` json
{
  "object": "customer",
  "id": "cus_2o1yHp2LqS4yoo",
  "cards": {
    "entity": "list",
    "url": "/v1/customers/cus_2o1yHp2LqS4yoo/cards",
    "data": [
      {
        "id": "card_2o1yR1PV91qREi",
        "object": "card",
        "last4": "4242",
        "type": "Visa",
      }
    ]
  }
}
```

Note that "cards" is an object with "entity", "url" and "data" keys rather than an array.

With this pull req, we can now define our own `many_to_native` method on a serializer superclass. Defining it this way allows top level and all nested lists to be presented in the same way. I looked at other ways of accomplishing the same thing, but this seemed like the cleanest (though I'm fairly new to DRF).

``` python
def many_to_native(self, objects):
    data = {
        'entity': 'list',
        'url': self.get_list_url(objects),
        'data': [self.to_native(item) for item in objects]
    }

    return data
```
