### PR TITLE
Added get_filter_backends method

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -121,6 +121,22 @@ For example:
 
 Note that if your API doesn't include any object level permissions, you may optionally exclude the ``self.check_object_permissions, and simply return the object from the `get_object_or_404` lookup.
 
+#### `get_filter_backends(self)`
+
+Returns the classes that should be used to filter the queryset. Defaults to returning the `filter_backends` attribute.
+
+May be override to provide more complex behavior with filters, as using different (or even exlusive) lists of filter_backends depending on different criteria.
+
+For example:
+
+    def get_filter_backends(self):
+        if "geo_route" in self.request.QUERY_PARAMS:
+            return (GeoRouteFilter, CategoryFilter)
+        elif "geo_point" in self.request.QUERY_PARAMS:
+            return (GeoPointFilter, CategoryFilter)
+
+        return (CategoryFilter,)
+
 #### `get_serializer_class(self)`
 
 Returns the class that should be used for the serializer.  Defaults to returning the `serializer_class` attribute, or dynamically generating a serializer class if the `model` shortcut is being used.
@@ -328,7 +344,7 @@ You can then simply apply this mixin to a view or viewset anytime you need to ap
         serializer_class = UserSerializer
         lookup_fields = ('account', 'username')
 
-Using custom mixins is a good option if you have custom behavior that needs to be used 
+Using custom mixins is a good option if you have custom behavior that needs to be used
 
 ## Creating custom base classes
 
@@ -337,7 +353,7 @@ If you are using a mixin across multiple views, you can take this a step further
     class BaseRetrieveView(MultipleFieldLookupMixin,
                            generics.RetrieveAPIView):
         pass
-    
+
     class BaseRetrieveUpdateDestroyView(MultipleFieldLookupMixin,
                                         generics.RetrieveUpdateDestroyAPIView):
         pass

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -175,6 +175,14 @@ class GenericAPIView(views.APIView):
         method if you want to apply the configured filtering backend to the
         default queryset.
         """
+        for backend in self.get_filter_backends():
+            queryset = backend().filter_queryset(self.request, queryset, self)
+        return queryset
+
+    def get_filter_backends(self):
+        """
+        Returns the list of filter backends that this view requires.
+        """
         filter_backends = self.filter_backends or []
         if not filter_backends and self.filter_backend:
             warnings.warn(
@@ -185,10 +193,8 @@ class GenericAPIView(views.APIView):
                 PendingDeprecationWarning, stacklevel=2
             )
             filter_backends = [self.filter_backend]
+        return filter_backends
 
-        for backend in filter_backends:
-            queryset = backend().filter_queryset(self.request, queryset, self)
-        return queryset
 
     ########################
     ### The following methods provide default implementations


### PR DESCRIPTION
Hi!

I have this PR to add a small feature I needed before. By default, the ViewSet applies all the filters in filter_backends. 

For some resources, you may need to choose which filters you want to apply; and you may have different sets of filters (you want to apply one of them and avoid applying other), but you don't really need two resources. 

Besides, this check shouldn't be done inside the filter, because establishes interdependences between filters.

I haven't added tests as other similar methods don't have any, such as get_serializer_class or get_permissios_classes. For me it has sense because they are extremely simple methods. Nevertheless, if you prefer any tests on this, I could add some.

Please, consider adding this feature in the main django-rest-framework branch.
