### PR TITLE
Removed commented-out credits from footer so that django-debug-toolbar works

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -221,9 +221,6 @@
     </div><!-- ./wrapper -->
 
     {% block footer %}
-    <!--<div id="footer">
-        <a class="powered-by" href='http://django-rest-framework.org'>Django REST framework</a>
-    </div>-->
     {% endblock %}
 
     {% block script %}


### PR DESCRIPTION
The comment, although valid, caused that the Django debug toolbar's injected HTML was partially commented-out and thus the toolbar didn't work as expected.
