### PR TITLE
Adding transaction rollback to exception_handler

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -7,6 +7,8 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.utils.datastructures import SortedDict
 from django.views.decorators.csrf import csrf_exempt
+from django.db import transaction
+
 from rest_framework import status, exceptions
 from rest_framework.compat import smart_text, HttpResponseBase, View
 from rest_framework.request import Request
@@ -365,6 +367,14 @@ class APIView(View):
 
         if response is None:
             raise
+
+        # We've suppressed the exception but still need to rollback any transaction.
+        if hasattr(transaction, 'set_rollback'):
+            # If running in >=1.6 then mark a rollback as required and let Django deal with it.
+            transaction.set_rollback(True)  # Django 1.6+
+        elif transaction.is_managed():
+            # If running <=1.5 and TransactionMiddleware is installed then force it's rollback behavior.
+            TransactionMiddleware().process_exception(request, None)
 
         response.exception = True
         return response


### PR DESCRIPTION
This PR is to show you the idea, there are other ways to implement it (like, for example, another exception class named RollbackAPIException), anyway I find the interference of APIException capture with the rollback of django transaction middleware on exceptions, a little bit dangerous.

If you find it useful, I can implement with the RollbackAPIException, which is more backward compatible.
