### PR TITLE
ApiClient - made request pass-in able

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -116,8 +116,13 @@ class ForceAuthClientHandler(ClientHandler):
 
 
 class APIClient(APIRequestFactory, DjangoClient):
+    request = None
+
     def __init__(self, enforce_csrf_checks=False, **defaults):
+        self.request = defaults.get('request') if 'request' in defaults else None
+
         super(APIClient, self).__init__(**defaults)
+
         self.handler = ForceAuthClientHandler(enforce_csrf_checks)
         self._credentials = {}
 
@@ -138,6 +143,9 @@ class APIClient(APIRequestFactory, DjangoClient):
             self.logout()  # Also clear any possible session info if required
 
     def request(self, **kwargs):
+        if self.request is not None:
+            return self.request
+
         # Ensure that any credentials set get added to every request.
         kwargs.update(self._credentials)
         return super(APIClient, self).request(**kwargs)


### PR DESCRIPTION
A fairly ugly patch for the APIClient, which I'm using to provide json data to angular via the template context.

By default the APIClient modifies the request (for obvious reasons) but I've tried to set it so that DI the request object means that you can use the current request object instead of regenerating it wholly.

is this a totally bad idea?
