### PR TITLE
Fix object creation with reverse M2M when related_name unspecified

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -873,7 +873,7 @@ class ModelSerializer(Serializer):
 
         # Reverse m2m relations
         for (obj, model) in meta.get_all_related_m2m_objects_with_model():
-            field_name = obj.field.related_query_name()
+            field_name = obj.get_accessor_name()
             if field_name in attrs:
                 m2m_data[field_name] = attrs.pop(field_name)
 


### PR DESCRIPTION
It seems that field.related_query_name() does not return the related_name
for reverse M2M relations when related_name is not explicitly set in the M2M field
definition.

So, change to use obj.get_accessor_name(), where obj is an instance of
RelatedObject, as are returned by a model's
_meta.get_all_related_many_to_many_objects(), or as in the tuples returned by
_meta.get_all_m2m_objects_with_model().
