### PR TITLE
Set up wheel distribution support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ version = get_version('rest_framework')
 
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
+    os.system("python setup.py bdist_wheel upload")
     print("You probably want to also tag the version now:")
     print("  git tag -a %s -m 'version %s'" % (version, version))
     print("  git push --tags")


### PR DESCRIPTION
The changes in setup.cfg will build a single py2 & py3 compatible wheel.

You'll need the wheel package install in your local env when running `setup.py publish` from now on (until it's bundled I guess).

Some resources:
- http://pythonwheels.com
- https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
