### PR TITLE
Added has_lookup_field argument to the link and action decorators.

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -142,8 +142,15 @@ The `@action` decorator will route `POST` requests by default, but may also acce
         @action(methods=['POST', 'DELETE'])
         def unset_password(self, request, pk=None):
            ...
-           
+
 The two new actions will then be available at the urls `^users/{pk}/set_password/$` and `^users/{pk}/unset_password/$`
+
+The `@action` and `@link` decorators will add `{pk}` to the route by default, by using the `has_lookup_field` argument this behavior can be disabled.
+*The `has_lookup_field` argument has no effect when using `ModelViewSet` or `ReadOnlyModelViewSet`*
+
+        @action(has_lookup_field=False)
+        def others(self, request):
+           ...
 
 
 ---

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -107,22 +107,24 @@ def permission_classes(permission_classes):
     return decorator
 
 
-def link(**kwargs):
+def link(has_lookup_field=True, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for GET requests.
     """
     def decorator(func):
+        func.has_lookup_field = has_lookup_field
         func.bind_to_methods = ['get']
         func.kwargs = kwargs
         return func
     return decorator
 
 
-def action(methods=['post'], **kwargs):
+def action(methods=['post'], has_lookup_field=True, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for POST requests.
     """
     def decorator(func):
+        func.has_lookup_field = has_lookup_field
         func.bind_to_methods = methods
         func.kwargs = kwargs
         return func


### PR DESCRIPTION
This patch adds the `has_lookup_field` to @action and @link so that custom routes without a pk can be defined in a GenericViewSet.
