### PR TITLE
fix setup.py with new __init__.py boilerplate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_version(package):
     Return package version as listed in `__version__` in `init.py`.
     """
     init_py = open(os.path.join(package, '__init__.py')).read()
-    return re.match("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
+    return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
 def get_packages(package):


### PR DESCRIPTION
re.match was working because **version** used to be at the top of the file. New text above breaks.
