### PR TITLE
Raise appropriate error in serializer when making a partial update to set a required RelatedField to null (issue #1158)

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -896,7 +896,10 @@ class ModelSerializer(Serializer):
         # Update an existing instance...
         if instance is not None:
             for key, val in attrs.items():
-                setattr(instance, key, val)
+                try:
+                    setattr(instance, key, val)
+                except ValueError:
+                    self._errors[key] = self.error_messages['required']
 
         # ...or create a new instance
         else:


### PR DESCRIPTION
Addresses issue #1158.

Uses the failing test cases from the issue report, updated to add two assertions to ensure that the correct error message is being served.
