### PR TITLE
docfix: update installation example to work with django 1.6

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ Don't forget to make sure you've also added `rest_framework` to your `INSTALLED_
 We're ready to create our API now.
 Here's our project's root `urls.py` module:
 
-    from django.conf.urls.defaults import url, patterns, include
+    from django.conf.urls import url, patterns, include
     from django.contrib.auth.models import User, Group
     from rest_framework import viewsets, routers
 


### PR DESCRIPTION
looks like django.conf.urls.defaults was deprecated as of django 1.6: https://docs.djangoproject.com/en/1.6/internals/deprecation/#id1
