### PR TITLE
RelatedField is function of serializer class

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -44,7 +44,7 @@ In order to explain the various types of relational fields, we'll use a couple o
 For example, the following serializer.
  
     class AlbumSerializer(serializers.ModelSerializer):
-        tracks = RelatedField(many=True)
+        tracks = serializers.RelatedField(many=True)
         
         class Meta:
             model = Album


### PR DESCRIPTION
When learning django-rest-framework, all the other serializers like PrimaryKeyRelatedField were represented as serializers.PrimaryKeyRelatedField so just updating the base RelatedField to match the syntax.
