### PR TITLE
'lookup_prefix' on SimpleRouter.get_lookup_regex, easing code de-duplication

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -184,18 +184,18 @@ class SimpleRouter(BaseRouter):
                 bound_methods[method] = action
         return bound_methods
 
-    def get_lookup_regex(self, viewset):
+    def get_lookup_regex(self, viewset, lookup_prefix=''):
         """
         Given a viewset, return the portion of URL regex that is used
         to match against a single instance.
         """
         if self.trailing_slash:
-            base_regex = '(?P<{lookup_field}>[^/]+)'
+            base_regex = '(?P<{lookup_prefix}{lookup_field}>[^/]+)'
         else:
             # Don't consume `.json` style suffixes
-            base_regex = '(?P<{lookup_field}>[^/.]+)'
+            base_regex = '(?P<{lookup_prefix}{lookup_field}>[^/.]+)'
         lookup_field = getattr(viewset, 'lookup_field', 'pk')
-        return base_regex.format(lookup_field=lookup_field)
+        return base_regex.format(lookup_field=lookup_field, lookup_prefix=lookup_prefix)
 
     def get_urls(self):
         """


### PR DESCRIPTION
This allows @alanjds/drf-nested-routers to not duplicate/monkeypatch work made here. Without retro-compatible patch, updates on SimpleRouter.get_lookup_regex will need to be copied-over to drf-nested-routers, violating DRY. Also, all router needed a "nested" version will probable need to be copied-over too.

Related to #1048
