### PR TITLE
Fix default values always being False for browsable API

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -428,7 +428,7 @@ class BooleanField(WritableField):
     def field_from_native(self, data, files, field_name, into):
         # HTML checkboxes do not explicitly represent unchecked as `False`
         # we deal with that here...
-        if isinstance(data, QueryDict):
+        if isinstance(data, QueryDict) and self.default is None:
             self.default = False
 
         return super(BooleanField, self).field_from_native(

--- a/rest_framework/tests/test_serializer.py
+++ b/rest_framework/tests/test_serializer.py
@@ -1743,3 +1743,42 @@ class TestSerializerTransformMethods(TestCase):
                 'b_renamed': None,
             }
         )
+
+
+class DefaultTrueBooleanModel(models.Model):
+    cat = models.BooleanField(default=True)
+    dog = models.BooleanField(default=False)
+
+
+class SerializerDefaultTrueBoolean(TestCase):
+
+    def setUp(self):
+        super(SerializerDefaultTrueBoolean, self).setUp()
+
+        class DefaultTrueBooleanSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = DefaultTrueBooleanModel
+                fields = ('cat', 'dog')
+
+        self.default_true_boolean_serializer = DefaultTrueBooleanSerializer
+
+    def test_enabled_as_false(self):
+        serializer = self.default_true_boolean_serializer(data={'cat': False,
+                                                                'dog': False})
+        self.assertEqual(serializer.is_valid(), True)
+        self.assertEqual(serializer.data['cat'], False)
+        self.assertEqual(serializer.data['dog'], False)
+
+    def test_enabled_as_true(self):
+        serializer = self.default_true_boolean_serializer(data={'cat': True,
+                                                                'dog': True})
+        self.assertEqual(serializer.is_valid(), True)
+        self.assertEqual(serializer.data['cat'], True)
+        self.assertEqual(serializer.data['dog'], True)
+
+    def test_enabled_partial(self):
+        serializer = self.default_true_boolean_serializer(data={'cat': False},
+                                                          partial=True)
+        self.assertEqual(serializer.is_valid(), True)
+        self.assertEqual(serializer.data['cat'], False)
+        self.assertEqual(serializer.data['dog'], False)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/tomchristie/django-rest-framework/commit/28ff6fb1ec02b7a04c4a0db54885f3735b6dd43f that caused the default value for BooleanFields to be overridden when form data is passed to the serializer.  While #1248 already exists, and does fix the issue (somewhat, I'll post the issues there later), this fixes it at the source of the problem.

/cc @tomwalker
