### PR TITLE
Adding utility method to APIClient

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -158,6 +158,16 @@ Note that calling `credentials` a second time overwrites any existing credential
 
 The `credentials` method is appropriate for testing APIs that require authentication headers, such as basic authentication, OAuth1a and OAuth2 authentication, and simple token authentication schemes.
 
+#### .temporary_credentials(**kwargs)
+
+The `temporary_credentials` method has the same behavior as the `credentials` method but as a context manager. It will
+set the credential for all the requests within the context and then set back the original ones.
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+    with client.temporary_credentials(HTTP_AUTHORIZATION='Token ' + other_token.key)
+        # test code within context using this temporary credentials
+
 #### .force_authenticate(user=None, token=None)
 
 Sometimes you may want to bypass authentication, and simple force all requests by the test client to be automatically treated as authenticated.

--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -2,7 +2,10 @@
 
 # Note that we import as `DjangoRequestFactory` and `DjangoClient` in order
 # to make it harder for the user to import the wrong thing without realizing.
+
 from __future__ import unicode_literals
+
+from contextlib import contextmanager
 import django
 from django.conf import settings
 from django.test.client import Client as DjangoClient
@@ -126,6 +129,13 @@ class APIClient(APIRequestFactory, DjangoClient):
         Sets headers that will be used on every outgoing request.
         """
         self._credentials = kwargs
+
+    @contextmanager
+    def temporary_credentials(self, **kwargs):
+        original_credentials = self._credentials
+        self.credentials(**kwargs)
+        yield
+        self._credentials = original_credentials
 
     def force_authenticate(self, user=None, token=None):
         """

--- a/rest_framework/tests/test_testing.py
+++ b/rest_framework/tests/test_testing.py
@@ -47,6 +47,19 @@ class TestAPITestClient(TestCase):
             response = self.client.get('/view/')
             self.assertEqual(response.data['auth'], 'example')
 
+    def test_temporary_credentials(self):
+        def assert_auth(expected):
+            response = self.client.get('/view/')
+            self.assertEqual(expected, response.data['auth'])
+
+        persistent_credentials = {'HTTP_AUTHORIZATION': 'persistent'}
+        temporal_credentials = {'HTTP_AUTHORIZATION': 'temporal'}
+        self.client.credentials(**persistent_credentials)
+        assert_auth('persistent')
+        with self.client.temporary_credentials(**temporal_credentials):
+            assert_auth('temporal')
+        assert_auth('persistent')
+
     def test_force_authenticate(self):
         """
         Setting `.force_authenticate()` forcibly authenticates each request.


### PR DESCRIPTION
```
- temporary_credentials acts as the credentials method
  but only for a context
```

I created this utility method in some of my projects, I find it useful so maybe other will do as well. 
I see one problem with this: People using python 2.6 would need to import the with statement from **future** to use it

Thanks
