### PR TITLE
Fix nested serializers with renamed fields

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -422,7 +422,9 @@ class BaseSerializer(WritableField):
 
         if self.source == '*':
             if value:
-                into.update(value)
+                reverted_data = self.restore_fields(value, {})
+                if not self._errors:
+                    into.update(reverted_data)
         else:
             if value in (None, ''):
                 into[(self.source or field_name)] = None

--- a/rest_framework/tests/test_serializer.py
+++ b/rest_framework/tests/test_serializer.py
@@ -105,6 +105,17 @@ class ModelSerializerWithNestedSerializer(serializers.ModelSerializer):
         model = Person
 
 
+class NestedSerializerWithRenamedField(serializers.Serializer):
+    renamed_info = serializers.Field(source='info')
+
+
+class ModelSerializerWithNestedSerializerWithRenamedField(serializers.ModelSerializer):
+    nested = NestedSerializerWithRenamedField(source='*')
+
+    class Meta:
+        model = Person
+
+
 class PersonSerializerInvalidReadOnly(serializers.ModelSerializer):
     """
     Testing for #652.
@@ -455,6 +466,20 @@ class ValidationTests(TestCase):
             'nested': {'info': 'hi'}},
         )
         self.assertEqual(serializer.is_valid(), True)
+
+    def test_writable_star_source_with_inner_source_fields(self):
+        """
+        Tests that a serializer with source="*" correctly expands the
+        it's fields into the outer serializer even if they have their
+        own 'source' parameters.
+        """
+
+        serializer = ModelSerializerWithNestedSerializerWithRenamedField(data={
+            'name': 'marko',
+            'nested': {'renamed_info': 'hi'}},
+        )
+        self.assertEqual(serializer.is_valid(), True)
+        self.assertEqual(serializer.errors, {})
 
 
 class CustomValidationTests(TestCase):


### PR DESCRIPTION
Nested serializers (with source='*') expand their fields into their parent serializer.

Unfortunately they do so without respecting the `source` of their own fields.

This fixes the issue and includes a test.
