### PR TITLE
Fix Anonymous User errors in Django-guardian

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -155,7 +155,7 @@ class DjangoObjectPermissionsFilter(BaseFilterBackend):
     perm_format = '%(app_label)s.view_%(model_name)s'
 
     def filter_queryset(self, request, queryset, view):
-        user = request.user
+        user = request.user if request.user.is_authenticated() else guardian.utils.get_anonymous_user()
         model_cls = queryset.model
         kwargs = {
             'app_label': model_cls._meta.app_label,


### PR DESCRIPTION
Fix Anonymous User errors when using both django-guardian and DjangoModelPermissionsOrAnonReadOnly.

The django-guardian AnonymousUser differs from the Django.contrib.auth one. If you try to get_objects_for_user() using the default Django.contrib.auth user it fails.
