### PR TITLE
Add write_only_fields support

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -321,10 +321,10 @@ class BaseSerializer(WritableField):
         for field_name, field in self.fields.items():
             if field.read_only and obj is None:
                continue
-			elif field_name in getattr(self.opts, 'write_only_fields', ()):
-				key = self.get_field_key(field_name)
-				ret.fields[key] = self.augment_field(field, field_name, key, '')
-			else:
+            elif field_name in getattr(self.opts, 'write_only_fields', ()):
+                key = self.get_field_key(field_name)
+                ret.fields[key] = self.augment_field(field, field_name, key, '')
+            else:
                 field.initialize(parent=self, field_name=field_name)
                 key = self.get_field_key(field_name)
                 value = field.field_to_native(obj, field_name)
@@ -879,8 +879,8 @@ class ModelSerializer(Serializer):
         """
         Restore the model instance.
         """
-		attrs = dict((k,v) for (k,v) in filter(
-			lambda x:x not in getattr(self.opts, 'write_only_fields', ()), attrs.items()))
+        attrs = dict((k,v) for (k,v) in filter(
+            lambda x:x not in getattr(self.opts, 'write_only_fields', ()), attrs.items()))
         m2m_data = {}
         related_data = {}
         nested_forward_relations = {}


### PR DESCRIPTION
I was surprised to find that there wasn't any built-in support for write-only fields. I needed a field that I could validate, but didn't store or read from. For instance, when taking a password confirmation field. I put it in `serializers.Serializer` instead of `serializers.ModelSerializer` because this can be used completely independent of any model as well.

Thus, I added the functionality. It doesn't pass the field on to the model when saving (obviously), but it permits you to use `validate_<x>` functions. Example usage:

```
class ProfileSerializer(serializers.Serializer):
    class Meta:
        write_only_fields = ('current_password','password')
    email = serializers.CharField(required=False)
    password = serializers.CharField(required=False)
    current_password = serializers.CharField()

    def validate_current_password(self, attrs, source):
        if self.object is None:
            return attrs
        u = authenticate(username=self.object.user.email, password=attrs[source])
        if u is not None:
            return attrs
        else:
            raise serializers.ValidationError('Error!')
```
