### PR TITLE
Change the page title to prioritize page content

### DIFF
--- a/mkdocs.py
+++ b/mkdocs.py
@@ -144,7 +144,7 @@ for (dirpath, dirnames, filenames) in os.walk(docs_dir):
         if filename == 'index.md':
             main_title = 'Django REST framework - APIs made easy'
         else:
-            main_title = 'Django REST framework - ' + main_title
+            main_title = main_title + ' - Django REST framework'
 
         if relative_path == 'index.md':
             canonical_url = base_url


### PR DESCRIPTION
When many tab's are open (which is necessary for DRF's documentation), it becomes impossible to determine which tab contains which pieces of documentation.  That they are all related is obvious by the use of a common icon, just not the specific page each tab is loaded to.

This change inverts the order of the title to maintain as much useful context as possible on the tabbar.
