### PR TITLE
fix url double quoted in Django 1.6

### DIFF
--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -144,7 +144,7 @@ def add_query_param(request, key, val):
     """
     Add a query parameter to the current request url, and return the new url.
     """
-    return replace_query_param(request.get_full_path(), key, val)
+    return replace_query_param(request.build_absolute_uri(), key, val)
 
 
 @register.filter

--- a/rest_framework/tests/test_templatetags.py
+++ b/rest_framework/tests/test_templatetags.py
@@ -1,0 +1,18 @@
+# encoding: utf-8
+from __future__ import unicode_literals
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+from rest_framework.templatetags.rest_framework import add_query_param
+
+factory = APIRequestFactory()
+
+
+class TemplateTagTests(TestCase):
+
+    def test_add_query_param_with_non_latin_charactor(self):
+        request = factory.get("/?q=查询")
+        json_url = add_query_param(request, "format", "json")
+        self.assertIn(json_url, [
+            "http://testserver/?format=json&q=%E6%9F%A5%E8%AF%A2",
+            "http://testserver/?q=%E6%9F%A5%E8%AF%A2&format=json",
+        ])


### PR DESCRIPTION
`get_full_path` returns unicode, so we use `build_absolute_uri` which
returns `iri_to_uri`'ed one
