### PR TITLE
Invoke super from UpdateModelMixin.pre_save

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -163,6 +163,7 @@ class UpdateModelMixin(object):
         """
         Set any attributes on the object that are implicit in the request.
         """
+        super(UpdateModelMixin, self).pre_save(obj)
         # pk and/or slug attributes are implicit in the URL.
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
         lookup = self.kwargs.get(lookup_url_kwarg, None)


### PR DESCRIPTION
Thanks for the awesome library. It makes writing APIs a pleasure, and possible to do with hardly any code.

This change allows a subclass of GenericAPIView to add its own pre_save logic. Without this change, CreateMixin will call a view's pre_save method, but once UpdateMixin is added it may not be called anymore, depending on the specific inheritance chain.

Since GenericAPIView has an empty implementation of pre_save, calling it on super should be safe.

My use case here is a user-linked generic view and viewset designed for a model which maps one-to-one with the user model. It automatically locates the user model attribute in `__init__`, filters it in `get_queryset`, and sets it in `pre_save`. Without this patch, it works with the CreateMixin alone, but not after adding UpdateMixin. (Note that pre_save is defined in my `UserLinkedGenericAPIView` subclass, which is listed last, after all the mixins.)
