### PR TITLE
FIX BaseSerializer.from_native has an altered signature

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -331,7 +331,7 @@ class BaseSerializer(WritableField):
 
         return ret
 
-    def from_native(self, data, files):
+    def from_native(self, data, files=None):
         """
         Deserialize primitives -> objects.
         """


### PR DESCRIPTION
- base classes define it with one parameter
- BaseSerializer currently defines a second parameter, which we make optional here for method-dispatch passivity

This is a simple change that we decided to keep from #1285 before closing down that PR.
