### PR TITLE
Allow to specify JSON separators for rendering

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -90,6 +90,8 @@ The client may additionally include an `'indent'` media type parameter, in which
 
 **.charset**: `None`
 
+**.separators**: `None`
+
 ## UnicodeJSONRenderer
 
 Renders the request data into `JSON`, using utf-8 encoding.

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -54,6 +54,7 @@ class JSONRenderer(BaseRenderer):
     encoder_class = encoders.JSONEncoder
     ensure_ascii = True
     charset = None
+    separators = None
     # JSON is a binary encoding, that can be encoded as utf-8, utf-16 or utf-32.
     # See: http://www.ietf.org/rfc/rfc4627.txt
     # Also: http://lucumr.pocoo.org/2013/7/19/application-mimetypes-and-encodings/
@@ -69,6 +70,7 @@ class JSONRenderer(BaseRenderer):
         # E.g. If we're being called by the BrowsableAPIRenderer.
         renderer_context = renderer_context or {}
         indent = renderer_context.get('indent', None)
+        separators = renderer_context.get('separators', self.separators)
 
         if accepted_media_type:
             # If the media type looks like 'application/json; indent=4',
@@ -79,9 +81,11 @@ class JSONRenderer(BaseRenderer):
                 indent = max(min(int(indent), 8), 0)
             except (ValueError, TypeError):
                 indent = None
+            if indent:
+                separators = None
 
         ret = json.dumps(data, cls=self.encoder_class,
-            indent=indent, ensure_ascii=self.ensure_ascii)
+            indent=indent, separators=separators, ensure_ascii=self.ensure_ascii)
 
         # On python 2.x json.dumps() returns bytestrings if ensure_ascii=True,
         # but if ensure_ascii=False, the return type is underspecified,
@@ -385,6 +389,7 @@ class BrowsableAPIRenderer(BaseRenderer):
             return '[No renderers were found]'
 
         renderer_context['indent'] = 4
+        renderer_context['separators'] = None
         content = renderer.render(data, accepted_media_type, renderer_context)
 
         render_style = getattr(renderer, 'render_style', 'text')
@@ -488,6 +493,7 @@ class BrowsableAPIRenderer(BaseRenderer):
                 accepted = self.accepted_media_type
                 context = self.renderer_context.copy()
                 context['indent'] = 4
+                context['separators'] = None
                 content = renderer.render(serializer.data, accepted, context)
             else:
                 content = None

--- a/rest_framework/tests/test_renderers.py
+++ b/rest_framework/tests/test_renderers.py
@@ -339,6 +339,20 @@ class JSONRendererTests(TestCase):
         content = renderer.render(obj, 'application/json')
         self.assertEqual(content, '{"countries": ["United Kingdom", "France", "Espa\\u00f1a"]}'.encode('utf-8'))
 
+    def test_separators(self):
+        obj = {'countries': ['United Kingdom', 'France', 'España']}
+        class CompactJSONRenderer(JSONRenderer):
+            separators = (',', ':')
+        renderer = CompactJSONRenderer()
+        content = renderer.render(obj, 'application/json')
+        self.assertEqual(content, '{"countries":["United Kingdom","France","Espa\\u00f1a"]}'.encode('utf-8'))
+
+    def test_separators_context(self):
+        obj = {'countries': ['United Kingdom', 'France', 'España']}
+        renderer = JSONRenderer()
+        content = renderer.render(obj, 'application/json', renderer_context={'separators': (',', ':')})
+        self.assertEqual(content, '{"countries":["United Kingdom","France","Espa\\u00f1a"]}'.encode('utf-8'))
+
 
 class UnicodeJSONRendererTests(TestCase):
     """


### PR DESCRIPTION
The [json.dumps](http://docs.python.org/2/library/json.html#json.dump) function takes an optional `separators` param that controls the JSON item_separator and dict_separator strings. Setting the separators to `(',', ':')` makes the renderer to produce the most compact encoding. For example:

```
>>> import json
>>> json.dumps([1,2,3,{'4': 5, '6': 7}], separators=(',', ':'))
'[1,2,3,{"4":5,"6":7}]'
```

This pull request does not alter the current behaviour and requires a user to opt-in by creating a custom renderer that overrides the `JSONRenderer.separators` attribute, but it might be worth to consider making the compact encoding the default one. Depending on the dataset, changing the separators to compact-ones reduces the output size by 5-8%.

Ref: http://docs.python.org/2.6/library/json.html - http://docs.python.org/3.3/library/json.html
