### PR TITLE
always obey X-HTTP-METHOD-OVERRIDE header

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -279,10 +279,9 @@ class Request(object):
         if not _hasattr(self, '_method'):
             self._method = self._request.method
 
-            if self._method == 'POST':
-                # Allow X-HTTP-METHOD-OVERRIDE header
-                self._method = self.META.get('HTTP_X_HTTP_METHOD_OVERRIDE',
-                                             self._method)
+            # Allow X-HTTP-METHOD-OVERRIDE header
+            self._method = self.META.get('HTTP_X_HTTP_METHOD_OVERRIDE',
+                                         self._method)
 
     def _load_stream(self):
         """

--- a/rest_framework/tests/test_request.py
+++ b/rest_framework/tests/test_request.py
@@ -66,6 +66,9 @@ class TestMethodOverloading(TestCase):
         request = Request(factory.post('/', {'foo': 'bar'}, HTTP_X_HTTP_METHOD_OVERRIDE='DELETE'))
         self.assertEqual(request.method, 'DELETE')
 
+        request = Request(factory.get('/', {'foo': 'bar'}, HTTP_X_HTTP_METHOD_OVERRIDE='DELETE'))
+        self.assertEqual(request.method, 'DELETE')
+
 
 class TestContentParsing(TestCase):
     def test_standard_behaviour_determines_no_content_GET(self):


### PR DESCRIPTION
required to support old flash/flex clients that need to do everything as
GET requests (apparently to allow for any error handling)
