### PR TITLE
Fix non-JSON output from JSONRenderer

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -62,9 +62,6 @@ class JSONRenderer(BaseRenderer):
         """
         Render `data` into JSON.
         """
-        if data is None:
-            return bytes()
-
         # If 'indent' is provided in the context, then pretty print the result.
         # E.g. If we're being called by the BrowsableAPIRenderer.
         renderer_context = renderer_context or {}


### PR DESCRIPTION
The render method of JSONRenderer returns b'' when the input is None, but that is not valid JSON. If the check at the beginning of the render method is removed it will (IMHO correctly) return b'null'.
