### PR TITLE
New lines in browsable API in HTTP details

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -117,8 +117,8 @@
                 <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
             </div>
             <div class="response-info">
-                <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}
-{% for key, val in response.items %}<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>
+                <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b><br>{% autoescape off %}
+{% for key, val in response.items %}<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span><br>
 {% endfor %}
 </div>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
             </div>


### PR DESCRIPTION
If minifaction to the HTML is applied for browsable API, the HTTP response information would loose new lines since HTML white-space would be stripped. Adding `<br>` forces to preserve the new-lines.

Example:
![example](http://content.screencast.com/users/miki725/folders/Jing/media/0df1621c-4282-42d6-926f-3370126ec490/00000025.png)
