### PR TITLE
oauth validate_token fix

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -275,7 +275,7 @@ class OAuthAuthentication(BaseAuthentication):
         Check the token and raise an `oauth.Error` exception if invalid.
         """
         oauth_server, oauth_request = oauth_provider.utils.initialize_server_request(request)
-        oauth_server.verify_request(oauth_request, consumer, token)
+        oauth_provider.utils.verify_oauth_request(request, oauth_request, consumer, token)
 
     def check_nonce(self, request, oauth_request):
         """


### PR DESCRIPTION
The difference seems to be that verify_oauth_request apply a fix, the comment in the code is:

```
#Ensure the passed keys and secrets are ascii, or HMAC will complain.
```
