### PR TITLE
Fix doc for custom exception sample

### DIFF
--- a/docs/api-guide/exceptions.md
+++ b/docs/api-guide/exceptions.md
@@ -94,7 +94,7 @@ For example, if your API relies on a third party service that may sometimes be u
 
     class ServiceUnavailable(APIException):
         status_code = 503
-        detail = 'Service temporarily unavailable, try again later.'
+        default_detail = 'Service temporarily unavailable, try again later.'
 
 ## ParseError
 


### PR DESCRIPTION
The way to provide a default detail for APIException is to define a `default_detail` attribute on the subclass.

Defining a `detail` attribute without `default_detail` will not work, and will result in empty detail instead.
