### PR TITLE
Don't use request stream since it can only be read once preventing other...

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -295,8 +295,6 @@ class Request(object):
 
         if content_length == 0:
             self._stream = None
-        elif hasattr(self._request, 'read'):
-            self._stream = self._request
         else:
             self._stream = BytesIO(self.raw_post_data)
 


### PR DESCRIPTION
... middleware (particularly sentry) from accessing it.

Pretty sure this is the wrong fix, but here it is nonetheless.

As I roughly understand, calling request.read() means that none of the post data is accessible on the original Django request object anymore. This breaks things like sentry which capture the request body in middleware for error reporting. You could easily imagine other stuff it might break too.

If there's a better fix, please disregard this and either way - thanks for the great software!
