### PR TITLE
Generate random token directly

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -1,5 +1,5 @@
-import uuid
-import hmac
+import binascii
+import os
 from hashlib import sha1
 from django.conf import settings
 from django.db import models
@@ -34,8 +34,7 @@ class Token(models.Model):
         return super(Token, self).save(*args, **kwargs)
 
     def generate_key(self):
-        unique = uuid.uuid4()
-        return hmac.new(unique.bytes, digestmod=sha1).hexdigest()
+        return binascii.hexlify(os.urandom(20))
 
     def __unicode__(self):
         return self.key


### PR DESCRIPTION
This improves token generation in two ways:
- The use of HMAC doesn't appear to add any security. Normally, HMAC is used to sign some content, but in this case, the content being signed is the empty string. 
- The use of uuid4 unnecessarily restricts the size of the auth token. In this pull request, I still use 40 bytes to keep the token compatible, but this opens up the possibility of increasing security later.

Current implementation:
- Generate the random bytes using uuid
- Convert to hex using hmac

Implementation in this pull request:
- Generate the random bytes using urandom ([the backend for uuid4](https://github.com/python-git/python/blob/master/Lib/uuid.py#L527)) 
- Convert to hex using hexlify
