### PR TITLE
Viewsets docs typo

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -225,7 +225,7 @@ To create a base viewset class that provides `create`, `list` and `retrieve` ope
                                     mixins.RetrieveModelMixin,
                                     viewsets.GenericViewSet):
         """
-        A viewset that provides `retrieve`, `update`, and `list` actions.
+        A viewset that provides `retrieve`, `create`, and `list` actions.
 
         To use it, override the class and set the `.queryset` and
         `.serializer_class` attributes.


### PR DESCRIPTION
The docstring in the example said "update" instead of "create".
