### PR TITLE
Fixed a bug backticks

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -119,7 +119,7 @@ For example:
         self.check_object_permissions(self.request, obj)
         return obj
 
-Note that if your API doesn't include any object level permissions, you may optionally exclude the ``self.check_object_permissions, and simply return the object from the `get_object_or_404` lookup.
+Note that if your API doesn't include any object level permissions, you may optionally exclude the `self.check_object_permissions`, and simply return the object from the `get_object_or_404` lookup.
 
 #### `get_filter_backends(self)`
 


### PR DESCRIPTION
fix

```
you may optionally exclude the ``self.check_object_permissions, and simply return the object from the `get_object_or_404` lookup.
```

to

```
you may optionally exclude the `self.check_object_permissions`, and simply return the object from the `get_object_or_404` lookup.
```
