### PR TITLE
remove spaces from META['HTTP_X_FORWARDED_FOR'] as throttle key

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -156,7 +156,7 @@ class AnonRateThrottle(SimpleRateThrottle):
         if ident is None:
             ident = request.META.get('REMOTE_ADDR')
         else:
-            ident = u''.join(ident.split())
+            ident = ''.join(ident.split())
 
         return self.cache_format % {
             'scope': self.scope,


### PR DESCRIPTION
memcached cannot handle spaces in keys
