### PR TITLE
Update throttling.md

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -150,7 +150,7 @@ For example, given the following views...
 
     REST_FRAMEWORK = {
         'DEFAULT_THROTTLE_CLASSES': (
-            'rest_framework.throttling.ScopedRateThrottle'
+            'rest_framework.throttling.ScopedRateThrottle',
         ),
         'DEFAULT_THROTTLE_RATES': {
             'contacts': '1000/day',


### PR DESCRIPTION
Added comma to make DEFAULT_THROTTLE_CLASSES a tuple in example, for copy&paste to work nicely.
