### PR TITLE
fix(docs): fix code indentation in serializers.md

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -383,14 +383,14 @@ You may wish to specify multiple fields as write-only.  Instead of adding each f
             fields = ('email', 'username', 'password')
             write_only_fields = ('password',)  # Note: Password field is write-only
 
-    def restore_object(self, attrs, instance=None):
-        """
-        Instantiate a new User instance.
-        """
-        assert instance is None, 'Cannot update users with CreateUserSerializer'                                
-        user = User(email=attrs['email'], username=attrs['username'])
-        user.set_password(attrs['password'])
-        return user
+        def restore_object(self, attrs, instance=None):
+            """
+            Instantiate a new User instance.
+            """
+            assert instance is None, 'Cannot update users with CreateUserSerializer'                                
+            user = User(email=attrs['email'], username=attrs['username'])
+            user.set_password(attrs['password'])
+            return user
  
 ## Specifying fields explicitly 
 


### PR DESCRIPTION
It fixes the indentation of `restore_object()` in the section "Specifying which fields should be write-only" serializers documentation.
