### PR TITLE
Display the media type of the API response on the browsable API

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -427,7 +427,7 @@ class BrowsableAPIRenderer(BaseRenderer):
                 files = request.FILES
             except ParseError:
                 data = None
-                files = None        
+                files = None
         else:
             data = None
             files = None
@@ -544,6 +544,14 @@ class BrowsableAPIRenderer(BaseRenderer):
         raw_data_patch_form = self.get_raw_data_form(view, 'PATCH', request)
         raw_data_put_or_patch_form = raw_data_put_form or raw_data_patch_form
 
+        response_headers = dict(response.items())
+        renderer_content_type = ''
+        if renderer:
+            renderer_content_type = '%s' % renderer.media_type
+            if renderer.charset:
+                renderer_content_type += ' ;%s' % renderer.charset
+        response_headers['Content-Type'] = renderer_content_type
+
         context = {
             'content': self.get_content(renderer, data, accepted_media_type, renderer_context),
             'view': view,
@@ -555,6 +563,7 @@ class BrowsableAPIRenderer(BaseRenderer):
             'breadcrumblist': self.get_breadcrumbs(request),
             'allowed_methods': view.allowed_methods,
             'available_formats': [renderer.format for renderer in view.renderer_classes],
+            'response_headers': response_headers,
 
             'put_form': self.get_rendered_html_form(view, 'PUT', request),
             'post_form': self.get_rendered_html_form(view, 'POST', request),

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -118,7 +118,7 @@
             </div>
             <div class="response-info">
                 <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}
-{% for key, val in response.items %}<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>
+{% for key, val in response_headers.items %}<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>
 {% endfor %}
 </div>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
             </div>

--- a/rest_framework/tests/test_renderers.py
+++ b/rest_framework/tests/test_renderers.py
@@ -256,6 +256,18 @@ class RendererEndToEndTests(TestCase):
         self.assertEqual(resp.get('Content-Type', None), None)
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_contains_headers_of_api_response(self):
+        """
+        Issue #1437
+
+        Test we display the headers of the API response and not those from the
+        HTML response
+        """
+        resp = self.client.get('/html1')
+        self.assertContains(resp, '>GET, HEAD, OPTIONS<')
+        self.assertContains(resp, '>application/json<')
+        self.assertNotContains(resp, '>text/html; charset=utf-8<')
+
 
 _flat_repr = '{"foo": ["bar", "baz"]}'
 _indented_repr = '{\n  "foo": [\n    "bar",\n    "baz"\n  ]\n}'


### PR DESCRIPTION
Fixes https://github.com/tomchristie/django-rest-framework/issues/1331

Not really happy about the template if but I can't really overwrite the response content type directly
