### PR TITLE
handle zero and negative available_requests

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -136,6 +136,8 @@ class SimpleRateThrottle(BaseThrottle):
             remaining_duration = self.duration
 
         available_requests = self.num_requests - len(self.history) + 1
+        if available_requests <= 0:
+            return None
 
         return remaining_duration / float(available_requests)
 


### PR DESCRIPTION
This change is a fix for issue https://github.com/tomchristie/django-rest-framework/issues/1438.

This is when the total number of outstanding requests is less than the total allowed requests due to the change of the throttle rate in the settings file.

Higher the discrepancy, shorter the wait time. This is so the system can catch up.

Also, avoids negative wait time and divide by zero exceptions.

All unit tests pass.
