### PR TITLE
Update Travis to test Django 1.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.3"
 
 env:
-  - DJANGO="django==1.6"
+  - DJANGO="django==1.6.2"
   - DJANGO="django==1.5.5"
   - DJANGO="django==1.4.10"
   - DJANGO="django==1.3.7"


### PR DESCRIPTION
We should be testing the latest version of Django 1.6 as we're doing in the other 1.x releases.
