### PR TITLE
Test to demonstrate inconsistent full update behavior with omitted fields

### DIFF
--- a/rest_framework/tests/models.py
+++ b/rest_framework/tests/models.py
@@ -43,8 +43,10 @@ class SlugBasedModel(RESTFrameworkModel):
 
 
 class DefaultValueModel(RESTFrameworkModel):
+    required_field = models.CharField(max_length=100)
     text = models.CharField(default='foobar', max_length=100)
     extra = models.CharField(blank=True, null=True, max_length=100)
+    extra_not_nullable = models.CharField(blank=True, max_length=100)
 
 
 class CallableDefaultValueModel(RESTFrameworkModel):


### PR DESCRIPTION
This is for #1445. I've added a failing test that demonstrates the inconsistent behavior when omitting fields in a full update. I've also added some checks to the existing test for partial updates to ensure that the other field types are not updated.
