### PR TITLE
don't implicitly import provider.oauth2

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -551,6 +551,8 @@ except (ImportError, ImproperlyConfigured):
 # OAuth 2 support is optional
 try:
     import provider as oauth2_provider
+    from provider import scope as oauth2_provider_scope
+    from provider import constants as oauth2_constants
     if oauth2_provider.__version__ in ('0.2.3', '0.2.4'):
         # 0.2.3 and 0.2.4 are supported version that do not support
         # timezone aware datetimes
@@ -561,6 +563,8 @@ try:
         from django.utils.timezone import now as provider_now
 except ImportError:
     oauth2_provider = None
+    oauth2_provider_scope = None
+    oauth2_constants = None
     provider_now = None
 
 # Handle lazy strings

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -8,7 +8,8 @@ import warnings
 SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 
 from django.http import Http404
-from rest_framework.compat import (get_model_name, oauth2_provider)
+from rest_framework.compat import (get_model_name, oauth2_provider_scope,
+                                   oauth2_constants)
 
 
 class BasePermission(object):
@@ -218,8 +219,8 @@ class TokenHasReadWriteScope(BasePermission):
         if hasattr(token, 'resource'):  # OAuth 1
             return read_only or not request.auth.resource.is_readonly
         elif hasattr(token, 'scope'):  # OAuth 2
-            required = oauth2_provider.constants.READ if read_only else oauth2_provider.constants.WRITE
-            return oauth2_provider.scope.check(required, request.auth.scope)
+            required = oauth2_constants.READ if read_only else oauth2_constants.WRITE
+            return oauth2_provider_scope.check(required, request.auth.scope)
 
         assert False, ('TokenHasReadWriteScope requires either the'
         '`OAuthAuthentication` or `OAuth2Authentication` authentication '

--- a/rest_framework/tests/test_authentication.py
+++ b/rest_framework/tests/test_authentication.py
@@ -19,7 +19,7 @@ from rest_framework.authentication import (
 )
 from rest_framework.authtoken.models import Token
 from rest_framework.compat import patterns, url, include
-from rest_framework.compat import oauth2_provider
+from rest_framework.compat import oauth2_provider, oauth2_provider_scope
 from rest_framework.compat import oauth, oauth_provider
 from rest_framework.test import APIRequestFactory, APIClient
 from rest_framework.views import APIView
@@ -581,7 +581,7 @@ class OAuth2Tests(TestCase):
     def test_post_form_with_invalid_scope_failing_auth(self):
         """Ensure POSTing with a readonly scope instead of a write scope fails"""
         read_only_access_token = self.access_token
-        read_only_access_token.scope = oauth2_provider.scope.SCOPE_NAME_DICT['read']
+        read_only_access_token.scope = oauth2_provider_scope.SCOPE_NAME_DICT['read']
         read_only_access_token.save()
         auth = self._create_authorization_header(token=read_only_access_token.token)
         response = self.csrf_client.get('/oauth2-with-scope-test/', HTTP_AUTHORIZATION=auth)
@@ -593,7 +593,7 @@ class OAuth2Tests(TestCase):
     def test_post_form_with_valid_scope_passing_auth(self):
         """Ensure POSTing with a write scope succeed"""
         read_write_access_token = self.access_token
-        read_write_access_token.scope = oauth2_provider.scope.SCOPE_NAME_DICT['write']
+        read_write_access_token.scope = oauth2_provider_scope.SCOPE_NAME_DICT['write']
         read_write_access_token.save()
         auth = self._create_authorization_header(token=read_write_access_token.token)
         response = self.csrf_client.post('/oauth2-with-scope-test/', HTTP_AUTHORIZATION=auth)


### PR DESCRIPTION
The django-oauth2-provider package is extensible to support multiple backend implementations in addition or substitution to the included default, provider.oauth2.   However, by implicitly importing provider.oauth2 through the rest_framework.compat, django automatically links up model relations from provider.oauth2 to auth.user.  If a different backend is in use besides the default provider.oauth2, this is undesirable and causes errors when iterating through model relations if the provider.oauth2 database tables do not exist.

This patch prevents global importing of the provider.oauth2 module but it still relies on it for test cases; all of which still pass.
