### PR TITLE
Reintroduced url arguments in the urls for the tests.

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -76,6 +76,10 @@ class APIRequestFactory(DjangoRequestFactory):
         r = {
             'QUERY_STRING': urlencode(data or {}, doseq=True),
         }
+        # Fix to support old behavior where you have the arguments in the url
+        # See #1461
+        if not data and '?' in path:
+            r['QUERY_STRING'] = path.split('?')[1]
         r.update(extra)
         return self.generic('GET', path, **r)
 

--- a/rest_framework/tests/test_testing.py
+++ b/rest_framework/tests/test_testing.py
@@ -152,3 +152,13 @@ class TestAPIRequestFactory(TestCase):
         simple_png.name = 'test.png'
         factory = APIRequestFactory()
         factory.post('/', data={'image': simple_png})
+
+    def test_request_factory_url_arguments(self):
+        """
+        This is a non regression test against #1461
+        """
+        factory = APIRequestFactory()
+        request = factory.get('/view/?demo=test')
+        self.assertEqual(dict(request.GET), {'demo': ['test']})
+        request = factory.get('/view/', {'demo': 'test'})
+        self.assertEqual(dict(request.GET), {'demo': ['test']})


### PR DESCRIPTION
This should fix #1461.
