### PR TITLE
Set `user` on the original request as well.

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -227,6 +227,7 @@ class Request(object):
         set in the login and logout functions.
         """
         self._user = value
+        self._request.user = value
 
     @property
     def auth(self):
@@ -390,6 +391,7 @@ class Request(object):
             if not user_auth_tuple is None:
                 self._authenticator = authenticator
                 self._user, self._auth = user_auth_tuple
+                self._request.user = self._user
                 return
 
         self._not_authenticated()


### PR DESCRIPTION
In some cases, middleware or signals may attempt to access the original
Django `request` object.  Because we create our own version of the
`request` object, when we set the `request.user` attribute on our
request, the original request object doesn't have the user attribute
similarly set.  This change sets the underlying request's user attribute.
