### PR TITLE
authentication: allow all transport modes of access token in OAuth2Authentication

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -6,6 +6,7 @@ import base64
 
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
+from django.conf import settings
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
 from rest_framework.compat import CsrfViewMiddleware
 from rest_framework.compat import oauth, oauth_provider, oauth_provider_store
@@ -291,6 +292,7 @@ class OAuth2Authentication(BaseAuthentication):
     OAuth 2 authentication backend using `django-oauth2-provider`
     """
     www_authenticate_realm = 'api'
+    allow_query_params_token = settings.DEBUG
 
     def __init__(self, *args, **kwargs):
         super(OAuth2Authentication, self).__init__(*args, **kwargs)
@@ -308,7 +310,13 @@ class OAuth2Authentication(BaseAuthentication):
 
         auth = get_authorization_header(request).split()
 
-        if not auth or auth[0].lower() != b'bearer':
+        if auth and auth[0].lower() == b'bearer':
+            access_token = auth[1]
+        elif 'access_token' in request.POST:
+            access_token = request.POST['access_token']
+        elif 'access_token' in request.GET and self.allow_query_params_token:
+            access_token = request.GET['access_token']
+        else:
             return None
 
         if len(auth) == 1:
@@ -318,7 +326,7 @@ class OAuth2Authentication(BaseAuthentication):
             msg = 'Invalid bearer header. Token string should not contain spaces.'
             raise exceptions.AuthenticationFailed(msg)
 
-        return self.authenticate_credentials(request, auth[1])
+        return self.authenticate_credentials(request, access_token)
 
     def authenticate_credentials(self, request, access_token):
         """


### PR DESCRIPTION
RFC6750 describe three transport modes for access tokens when accessing a
protected resource:
- Auhthorization header with the Bearer authentication type
- form-encoded body parameter
- URI query parameter

This patch add support for last two transport modes.
