### PR TITLE
Added test for nested model serialization

### DIFF
--- a/rest_framework/tests/test_serializer_nested.py
+++ b/rest_framework/tests/test_serializer_nested.py
@@ -345,3 +345,23 @@ class NestedModelSerializerUpdateTests(TestCase):
         result = deserialize.object
         result.save()
         self.assertEqual(result.id, john.id)
+        
+class NestedModelSerializerTests(TestCase):
+    def test_nested_with_different_source_field_name(self):
+        class PersonSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = models.Person
+                fields = ('id', 'name', 'age')
+
+        class BlogPostSerializer(serializers.ModelSerializer):
+            author = PersonSerializer(source='writer')
+            class Meta:
+                model = models.BlogPost
+                fields = ('id', 'title', 'author')
+
+        data = {'title':'Test blog post', 'author': {'name': 'Person', 'age': 10}}
+
+        serializer = BlogPostSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        self.assertIsNotNone(serializer.object.writer.id, 'Writer has not been saved')        


### PR DESCRIPTION
This shows the existence of a commit mistakes when saving a related object, if the source is not equal to field name

Source of this error https://github.com/vlastv/django-rest-framework/blob/master/rest_framework/serializers.py#L947 where difference is not considered in naming
