### PR TITLE
Unittest for non-native validation only fields + use case added to serializer docs

### DIFF
--- a/rest_framework/tests/test_validation_only_fields.py
+++ b/rest_framework/tests/test_validation_only_fields.py
@@ -40,21 +40,15 @@ class ValidationOnlyFieldsExampleSerializer(serializers.ModelSerializer):
         model = ValidationOnlyFieldsExampleModel
         fields = ('email', 'password', 'password_confirmation', 'accept_our_terms_and_conditions',)
         write_only_fields = ('password',)
-        validation_only_fields = ('password_confirmation', 'accept_our_terms_and_conditions',)
 
     def restore_object(self, attrs, instance=None):
-        # Flow: south-bound -- object creation: model instance
-        for attr in self.Meta.validation_only_fields:
+        for attr in ('password_confirmation', 'accept_our_terms_and_conditions'):
             attrs.pop(attr)
         return super(ValidationOnlyFieldsExampleSerializer, self).restore_object(attrs, instance)
 
     def to_native(self, obj):
-        try:
-            # Flow: north-bound -- form creation: browser API
-            return super(ValidationOnlyFieldsExampleSerializer, self).to_native(obj)
-        except AttributeError as e:
-            # Flow: south-bound -- object validation: model class
-            for field in self.Meta.validation_only_fields:
+        if obj is not None:
+            for field in ('password_confirmation', 'accept_our_terms_and_conditions'):
                 self.fields.pop(field)
         return super(ValidationOnlyFieldsExampleSerializer, self).to_native(obj)
 


### PR DESCRIPTION
I tested starting from 2.3.13 moving backward  all the way to 2.3.5 to see where just overriding the restore_object() to handle the non-native fields was sufficient enough without breaking the browsable API. None of the versions worked so I have come to believe that forms in browsable API were not ever (within the aforementioned versions) including the non-native fields, and to_native() must be overridden to achieve this.

With this pull request:
1. I have added a use case to the serializer documentation to help people use this feature
2. I have added a unittest so moving forward we don't unintentionally break this process
3. I have tested (Travis CI) the unit test and pep8 verified the file (--ignore=E128,E225,E501)

Will we natively support validation-only fields in the near future?  Well, if so, then we would just update the unittest as well as the documentation to reflect the changes.
