### PR TITLE
Also proxy `__setattr__` on `Request` object

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -418,3 +418,9 @@ class Request(object):
         Proxy other attributes to the underlying HttpRequest object.
         """
         return getattr(self._request, attr)
+    
+    def __setattr__(self, attr, value):
+        """
+        Proxy other attributes to the underlying HttpRequest object.
+        """
+        return setattr(self._request, attr, value)


### PR DESCRIPTION
This caused lots of confusion when a library was setting some state on the django request object, but in this case, it was being set on the wrapped Request and was not actually being set to the underlying `HttpRequest` as expected.
