### PR TITLE
add regression tests for field Validators

### DIFF
--- a/rest_framework/tests/test_validation.py
+++ b/rest_framework/tests/test_validation.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from django.core.validators import MaxValueValidator
 from django.db import models
 from django.test import TestCase
 from rest_framework import generics, serializers, status
@@ -102,3 +103,46 @@ class TestAvoidValidation(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertDictEqual(serializer.errors,
                              {'non_field_errors': ['Invalid data']})
+
+
+# regression tests for issue: 1493
+
+class ValidationMaxValueValidatorModel(models.Model):
+    number_value = models.PositiveIntegerField(validators=[MaxValueValidator(100)])
+
+
+class ValidationMaxValueValidatorModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ValidationMaxValueValidatorModel
+
+
+class UpdateMaxValueValidationModel(generics.RetrieveUpdateDestroyAPIView):
+    model = ValidationMaxValueValidatorModel
+    serializer_class = ValidationMaxValueValidatorModelSerializer
+
+
+class TestMaxValueValidatorValidation(TestCase):
+
+    def test_max_value_validation_serializer_success(self):
+        serializer = ValidationMaxValueValidatorModelSerializer(data={'number_value': 99})
+        self.assertTrue(serializer.is_valid())
+
+    def test_max_value_validation_serializer_fails(self):
+        serializer = ValidationMaxValueValidatorModelSerializer(data={'number_value': 101})
+        self.assertFalse(serializer.is_valid())
+        self.assertDictEqual({'number_value': ['Ensure this value is less than or equal to 100.']}, serializer.errors)
+
+    def test_max_value_validation_success(self):
+        obj = ValidationMaxValueValidatorModel.objects.create(number_value=100)
+        request = factory.patch('/{0}'.format(obj.pk), {'number_value': 98}, format='json')
+        view = UpdateMaxValueValidationModel().as_view()
+        response = view(request, pk=obj.pk).render()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_max_value_validation_fail(self):
+        obj = ValidationMaxValueValidatorModel.objects.create(number_value=100)
+        request = factory.patch('/{0}'.format(obj.pk), {'number_value': 101}, format='json')
+        view = UpdateMaxValueValidationModel().as_view()
+        response = view(request, pk=obj.pk).render()
+        self.assertEqual(response.content, '{"number_value": ["Ensure this value is less than or equal to 100."]}')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This seems to fail in release `2.3.13` but passes in master.

If you cherry pick this commit to your `master` branch then it works however if you cherry pick this on to `2.1.3` (sha: `c1148241eee3df1139f9855ee3220c82f60726d5`) then field validators like `MaxValueValidator` are not called. 
I'm assuming something fixed this between now and then but I'd like to add regression tests so it doesn't happen again.

Also I feel like this could be a security bug in the current version and I'm wondering if there is any possibility of creating a `2.3.14` release ASAP?
