### PR TITLE
Allow serializer mixins to use __init__

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -146,6 +146,8 @@ class Field(object):
         self._errors = []
         self._value = None
         self._name = None
+        
+        super(Field, self).__init__()
 
     @property
     def errors(self):


### PR DESCRIPTION
Added a `super` call in `Field.__init__` so that serializer mixins can hook into the init function.
