### PR TITLE
Added null value for list.

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -33,7 +33,7 @@ class RelatedField(WritableField):
     many_widget = widgets.SelectMultiple
     form_field_class = forms.ChoiceField
     many_form_field_class = forms.MultipleChoiceField
-    null_values = (None, '', 'None')
+    null_values = (None, '', 'None',[])
 
     cache_choices = False
     empty_label = None


### PR DESCRIPTION
No ValidationError raised, If  "many=True" and "required=True" are set on PrimaryKerRelatedField.

``` python
class CompanySerializer(serializers.ModelSerializer):
    groups = serializer.PrimaryKeyRelatedField(many=True, required=True)
    class Meta:
        model = Company
```

These PUT requests should raise a ValidationError as no groups defined.

```
{"name":"Company Name Ltd.","groups":[]}
{"name":"Company Name Ltd."}
```

Expected error: 

```
{"groups": ["This field is required."]}
```
