### PR TITLE
Recreate bug - id is serialised as a string not as an integer as expected

### DIFF
--- a/rest_framework/tests/test_serializer.py
+++ b/rest_framework/tests/test_serializer.py
@@ -1971,3 +1971,30 @@ class BoolenFieldTypeTest(TestCase):
         '''
         bfield = self.serializer.get_fields()['started']
         self.assertEqual(type(bfield), fields.BooleanField)
+
+
+class IntegerFieldWithSourceTest(TestCase):
+    '''
+    Ensure that IntegerFields with a source kwarg are returned as integers not strings
+
+    '''
+
+    def setUp(self):
+
+        class Obj(object):
+            pass
+
+        obj = Obj()
+        obj.pk = '1'
+
+        class IntegerWithSourceSerializer(serializers.Serializer):
+            id = serializers.IntegerField(source='pk')
+
+        self.serializer = IntegerWithSourceSerializer(instance=obj)
+
+    def test_integerfield_type(self):
+        '''
+        Test that id field is an integer
+        '''
+        data = self.serializer.data
+        self.assertEqual(type(data['id']), int)


### PR DESCRIPTION
Hey guys,

I've recreated some behaviour in this test that I found unexpected - serialising a string attribute of an object (not a model) using an IntegerField results in a string not an integer.

Am I correct in thinking that this should be outputting an integer? Any ideas on what's going wrong or where I could start looking?

Cheers,
