### PR TITLE
Enable testing on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 
 env:
   - DJANGO="https://www.djangoproject.com/download/1.7b2/tarball/"
@@ -41,4 +42,7 @@ matrix:
       env: DJANGO="django==1.4.11"
     - python: "3.3"
       env: DJANGO="django==1.3.7"
-
+    - python: "3.4"
+      env: DJANGO="django==1.4.11"
+    - python: "3.4"
+      env: DJANGO="django==1.3.7"


### PR DESCRIPTION
As per [this Travis CI blog post](http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/), testing on Python 3.4 is now supported.
