### PR TITLE
Test showcasing query string behaviour as described in issue #1586

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -3,13 +3,16 @@
 # Note that we import as `DjangoRequestFactory` and `DjangoClient` in order
 # to make it harder for the user to import the wrong thing without realizing.
 from __future__ import unicode_literals
+try:
+    from urllib import unquote
+except ImportError:
+    from urllib.parse import unquote
 import django
 from django.conf import settings
 from django.test.client import Client as DjangoClient
 from django.test.client import ClientHandler
 from django.test import testcases
 from django.utils.http import urlencode
-from django.utils.six.moves.urllib.parse import unquote
 from rest_framework.settings import api_settings
 from rest_framework.compat import RequestFactory as DjangoRequestFactory
 from rest_framework.compat import force_bytes_or_smart_bytes, six

--- a/rest_framework/tests/test_request.py
+++ b/rest_framework/tests/test_request.py
@@ -355,6 +355,6 @@ class TestQueryString(IETestCase):
     urls = 'rest_framework.tests.test_request'
 
     def test_query_string_utf8(self):
-        qs = {'q': u'pølse'}
+        qs = {'q': 'pølse'}
         response = self.client.get('/', qs)
         self.assertEqual(status.HTTP_200_OK, response.status_code)


### PR DESCRIPTION
As described in issue #1586, when using Internet Explorer together with Python3, and the query string contains raw UTF-8, the request will fail if it's sent through DRF.

Internet Explorer handles query strings very weird, as described by http://stackoverflow.com/questions/18220057/encoding-of-query-string-parameters-in-ie10 - in general, one cannot expect internet explorer to urlencode it's query strings.
