### PR TITLE
HTMLFormRenderer fix for list/create api

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -353,7 +353,8 @@ class HTMLFormRenderer(BaseRenderer):
         """
         renderer_context = renderer_context or {}
         request = renderer_context['request']
-
+        view = renderer_context['view']
+        data = view.get_serializer(instance=getattr(view, 'object', None)).data
         template = loader.get_template(self.template)
         context = RequestContext(request, {'form': data})
         return template.render(context)


### PR DESCRIPTION
From the class doc:
"If the serializer was instantiated without an object then this will
    return an HTML form not bound to any object"

but with a "data" like:

``` json
{
    "count": 0, 
    "next": null, 
    "previous": null, 
    "results": []
}
```

The rendered form is:

![schermata 2014-05-22 alle 21 15 14](https://cloud.githubusercontent.com/assets/639459/3058900/740a9fc6-e1e5-11e3-97c4-0de5d3bb4ef3.png)

and not the unbound form.
