### PR TITLE
`_resolve_model` should work with unicode strings

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -49,7 +49,7 @@ def _resolve_model(obj):
     String representations should have the format:
         'appname.ModelName'
     """
-    if type(obj) == str and len(obj.split('.')) == 2:
+    if isinstance(obj, six.string_types) and len(obj.split('.')) == 2:
         app_name, model_name = obj.split('.')
         return models.get_model(app_name, model_name)
     elif inspect.isclass(obj) and issubclass(obj, models.Model):
@@ -759,9 +759,9 @@ class ModelSerializer(Serializer):
                     field.read_only = True
 
                 ret[accessor_name] = field
-        
+
         # Ensure that 'read_only_fields' is an iterable
-        assert isinstance(self.opts.read_only_fields, (list, tuple)), '`read_only_fields` must be a list or tuple' 
+        assert isinstance(self.opts.read_only_fields, (list, tuple)), '`read_only_fields` must be a list or tuple'
 
         # Add the `read_only` flag to any fields that have been specified
         # in the `read_only_fields` option
@@ -776,10 +776,10 @@ class ModelSerializer(Serializer):
                 "on serializer '%s'." %
                 (field_name, self.__class__.__name__))
             ret[field_name].read_only = True
-        
+
         # Ensure that 'write_only_fields' is an iterable
-        assert isinstance(self.opts.write_only_fields, (list, tuple)), '`write_only_fields` must be a list or tuple' 
-        
+        assert isinstance(self.opts.write_only_fields, (list, tuple)), '`write_only_fields` must be a list or tuple'
+
         for field_name in self.opts.write_only_fields:
             assert field_name not in self.base_fields.keys(), (
                 "field '%s' on serializer '%s' specified in "
@@ -790,7 +790,7 @@ class ModelSerializer(Serializer):
                 "Non-existant field '%s' specified in `write_only_fields` "
                 "on serializer '%s'." %
                 (field_name, self.__class__.__name__))
-            ret[field_name].write_only = True            
+            ret[field_name].write_only = True
 
         return ret
 

--- a/rest_framework/tests/test_serializers.py
+++ b/rest_framework/tests/test_serializers.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 from rest_framework.serializers import _resolve_model
 from rest_framework.tests.models import BasicModel
+from rest_framework.compat import six
 
 
 class ResolveModelTests(TestCase):
@@ -17,6 +18,10 @@ class ResolveModelTests(TestCase):
 
     def test_resolve_string_representation(self):
         resolved_model = _resolve_model('tests.BasicModel')
+        self.assertEqual(resolved_model, BasicModel)
+
+    def test_resolve_unicode_representation(self):
+        resolved_model = _resolve_model(six.text_type('tests.BasicModel'))
         self.assertEqual(resolved_model, BasicModel)
 
     def test_resolve_non_django_model(self):


### PR DESCRIPTION
### What is the problem / feature ?

The helper function `rest_framework.serializers._resolve_model` did not work correctly with unicode string representations of models.
### How did it get fixed / implemented ?

Changed the check from `type(obj) == str` to `isinstance(obj, six.string_types)`.

_Here is a cute baby animal picture for your troubles..._

![kitten-and-baby-deer_491862](https://cloud.githubusercontent.com/assets/824194/3059397/241802d2-e1eb-11e3-9c35-27ae77b6ea4c.jpg)
