### PR TITLE
Meta.error_messages like in django 1.6 model forms

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -626,6 +626,7 @@ class ModelSerializerOptions(SerializerOptions):
         self.write_only_fields = getattr(meta, 'write_only_fields', ())
         self.error_messages = getattr(meta, 'error_messages', {})
 
+
 class ModelSerializer(Serializer):
     """
     A serializer that deals with model instances and querysets.


### PR DESCRIPTION
This way you can pass your own error_messages to model fields like in django 1.6 model forms, without need to define them in Serializer.
