### PR TITLE
Catch ProtectedError and return 409 Conflict

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -7,6 +7,7 @@ which allows mixin classes to be composed in interesting ways.
 from __future__ import unicode_literals
 
 from django.core.exceptions import ValidationError
+from django.db.models import ProtectedError
 from django.http import Http404
 from rest_framework import status
 from rest_framework.response import Response
@@ -191,6 +192,9 @@ class DestroyModelMixin(object):
     def destroy(self, request, *args, **kwargs):
         obj = self.get_object()
         self.pre_delete(obj)
-        obj.delete()
+        try:
+            obj.delete()
+        except ProtectedError:
+            return Response('Cannot delete object because of protected foreign key relation', status=status.HTTP_409_CONFLICT)
         self.post_delete(obj)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
When we try to delete an object that has a reverse relation with on_delete set to PROTECT on the foreign key we will get a ProtectedError exception. This will catch the exception and return 409 Conflict instead of 500 Internal Server Errror. I am not really sure what the best status code should be in this case, 409 Conflict looks like the one that best matches what is going on.
