### PR TITLE
Always use specified content type in APIRequestFactory

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -36,7 +36,7 @@ class APIRequestFactory(DjangoRequestFactory):
         """
 
         if not data:
-            return ('', None)
+            return ('', content_type)
 
         assert format is None or content_type is None, (
             'You may not set both `format` and `content_type`.'


### PR DESCRIPTION
If `content_type` is specified in the `APIRequestFactory`, always include it in the request, even if data is empty.

This caused me 2 hours of debugging, because the content type was not set on my requests with empty data :)
