### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -137,7 +137,7 @@ The `@action` and `@link` decorators can additionally take extra arguments that 
         def set_password(self, request, pk=None):
            ...
 
-The `@action` decorator will route `POST` requests by default, but may also accept other HTTP methods, by using the `method` argument.  For example:
+The `@action` decorator will route `POST` requests by default, but may also accept other HTTP methods, by using the `methods` argument.  For example:
 
         @action(methods=['POST', 'DELETE'])
         def unset_password(self, request, pk=None):


### PR DESCRIPTION
The argument to the `action` decorator is `methods`, not `method`.
