### PR TITLE
Fixed the update of a 1-to-1 field while deserializing an object

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -450,7 +450,11 @@ class BaseSerializer(WritableField):
                 into[(self.source or field_name)] = None
             else:
                 # Set the serializer object if it exists
-                obj = get_component(self.parent.object, self.source or field_name) if self.parent.object else None
+                try:
+                    obj = get_component(self.parent.object, self.source or field_name) if self.parent.object else None
+                except:
+                    # this can happen when updating a 1-to-1 field
+                    obj = None
 
                 # If we have a model manager or similar object then we need
                 # to iterate through each instance.

--- a/rest_framework/tests/test_serializer_nested.py
+++ b/rest_framework/tests/test_serializer_nested.py
@@ -345,3 +345,30 @@ class NestedModelSerializerUpdateTests(TestCase):
         result = deserialize.object
         result.save()
         self.assertEqual(result.id, john.id)
+
+
+class OneToOneNestedSerializerUpdateTests(TestCase):
+    def test_set_one_to_one_field(self):
+
+        class NullableOneToOneSourceSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = models.NullableOneToOneSource
+
+        class OneToOneTargetSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = models.OneToOneTarget
+
+            nullable_source = NullableOneToOneSourceSerializer()
+
+
+        target = models.OneToOneTarget.objects.create(name='foo')
+        data = {
+            'name': 'Discovery',
+            'nullable_source': {'name': 'Daft Punk'},
+        }
+
+        # create
+        serializer = OneToOneTargetSerializer(data=data, instance=target)
+        self.assertEqual(serializer.is_valid(), True)
+        target = serializer.save()
+        self.assertEqual(target.nullable_source.name, 'Daft Punk')


### PR DESCRIPTION
There is currently an exception thrown when trying to deserialize a one-to-one field (through the related_name) on an already saved object.
The problem is the that code does get_component(object, field). But if that field was previously null, it raises an exception.
The Unit Test added in that commit exhibits the issue.

I'm not 100% satisfied with the patch since it catches any exception. But the problem is that this code is in BaseSerializer where we know nothing about self.opts.model.DoesNotExist, which is the actual exception thrown.

Comments are very welcome.
