### PR TITLE
Refactor login template to extend base.

### DIFF
--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -69,6 +69,7 @@ For more specific CSS tweaks than simply overriding the default bootstrap theme 
 
 All of the blocks available in the browsable API base template that can be used in your `api.html`.
 
+* `body`                       - The entire html `<body>`.
 * `bodyclass`                  - Class attribute for the `<body>` tag, empty by default.
 * `bootstrap_theme`            - CSS for the Bootstrap theme.
 * `bootstrap_navbar_variant`   - CSS class for the navbar.

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -24,6 +24,7 @@
     {% endblock %}
     </head>
 
+  {% block body %}
   <body class="{% block bodyclass %}{% endblock %} container">
 
     <div class="wrapper">
@@ -230,4 +231,5 @@
     <script src="{% static "rest_framework/js/default.js" %}"></script>
     {% endblock %}
   </body>
+  {% endblock %}
 </html>

--- a/rest_framework/templates/rest_framework/login_base.html
+++ b/rest_framework/templates/rest_framework/login_base.html
@@ -1,17 +1,8 @@
+{% extends "rest_framework/base.html" %}
 {% load url from future %}
 {% load rest_framework %}
-<html>
 
-    <head>
-        {% block style %}
-        {% block bootstrap_theme %}
-            <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
-            <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
-        {% endblock %}
-        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/default.css" %}"/>
-        {% endblock %}
-    </head>
-
+    {% block body %}
     <body class="container">
 
         <div class="container-fluid" style="margin-top: 30px">
@@ -50,4 +41,4 @@
             </div><!-- /.row-fluid -->
         </div><!-- /.container-fluid -->
     </body>
-</html>
+    {% endblock %}


### PR DESCRIPTION
While experimenting with extending DRF, I found that the login page
1) had no title, and 2) duplicated `<head>` info from base.html.

This change adds a new `{% block body %}` to the base.html template
which allows override of the entire html `<body>`. login_base.html
has its duplicated head info stripped, and now extends base.html
to share common html `<head>` templating.

As part of this change, pretify.css is unnecessarily added to
login_base.html.  If this is deemed a problem, it will be easy to
block that css out, and have login_base.html override the block.

Ideally, I would have liked to create a new api_base.html that extends
base.html, move the api specific logic into that template, and leave
base.html content agnostic, to truely be a unifying base for all DRF
pages.  But this change would break current apps that override
api.html and expect base.html to be the immediate super template. :/

This change is benificial because it:
- removes duplication of header declarations (mostly css includes)
- adds a html title to the login page
- standardizes html header info across all DRF pages

Docs are updated to reflect the new structure.
