### PR TITLE
Check throttles before permissions in APIView.initial

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -315,8 +315,8 @@ class APIView(View):
 
         # Ensure that the incoming request is permitted
         self.perform_authentication(request)
-        self.check_permissions(request)
         self.check_throttles(request)
+        self.check_permissions(request)
 
         # Perform content negotiation and store the accepted info on the request
         neg = self.perform_content_negotiation(request)


### PR DESCRIPTION
I am trying to implement a custom throttle class to throttle requests with an invalid auth token.  Unfortunately [`APIView.initial`](/tomchristie/django-rest-framework/blob/master/rest_framework/views.py#L318-L319) calls `check_permissions` before `check_throttles`. This means that if a request fails a permissions check it cannot be throttled.
