### PR TITLE
Fix accessing default value of nested serializer

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -434,7 +434,7 @@ class BaseSerializer(WritableField):
         except KeyError:
             if self.default is not None and not self.partial:
                 # Note: partial updates shouldn't set defaults
-                value = copy.deepcopy(self.default)
+                value = copy.deepcopy(self.get_default_value())
             else:
                 if self.required:
                     raise ValidationError(self.error_messages['required'])


### PR DESCRIPTION
We need to use `self.get_default_value()` instead of `self.default` so
that if the default value is a callable it will be evaluated.
