### PR TITLE
Fixes CharField behaviour and introduces proper validation for ModelField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -429,6 +429,11 @@ class ModelField(WritableField):
             "type": self.model_field.get_internal_type()
         }
 
+    def validate(self, value):
+        super(ModelField, self).validate(value)
+        if value is None and not self.model_field.null:
+            raise ValidationError(self.error_messages['invalid'])
+
 
 ##### Typed Fields #####
 


### PR DESCRIPTION
This PR fixes problems described at #1570, #1665 and #1663

In short: 
- CharField should return "" (empty string) for empty values like django.form CharField does. Since django model prevents charfield to be nullable https://docs.djangoproject.com/en/dev/ref/models/fields/#null we can assume this is correct behaviour for DRF.
- ModelField throws error if value is None and bounded model field is not nullable. (django docs says it is our responsability to make this check, thats why it is here, otherwise it'd result int IntegrityError which is not usefull for any api client.) See: https://code.djangoproject.com/ticket/22921

All tests are green.
