### PR TITLE
Fix ImageFile validation.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1004,7 +1004,8 @@ class ImageField(FileField):
         if hasattr(data, 'temporary_file_path'):
             file = data.temporary_file_path()
         else:
-            if hasattr(data, 'read'):
+            if hasattr(data, 'read') and hasattr(data, 'seek'):
+                data.seek(0)
                 file = BytesIO(data.read())
             else:
                 file = BytesIO(data['content'])


### PR DESCRIPTION
Closes #1378.

Before validating an in-memory image file, seek to the beginning of the file. This is required to in case the same file is validated more than once. Currently, the same image file is validated twice when uploading an ImageField through the browser API - once when creating the model object, and once when rendering the HTML response.
