### PR TITLE
get_component should work with custom mapping types

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -10,6 +10,7 @@ import datetime
 import inspect
 import re
 import warnings
+import collections
 from decimal import Decimal, DecimalException
 from django import forms
 from django.core import validators
@@ -50,7 +51,7 @@ def get_component(obj, attr_name):
     Given an object, and an attribute name,
     return that attribute on the object.
     """
-    if hasattr(obj, '__getitem__'):
+    if isinstance(obj, collections.Mapping):
         val = obj[attr_name]
     else:
         val = getattr(obj, attr_name)


### PR DESCRIPTION
I have a model field in my project which returns a custom implementation of Mapping. `get_component` chokes on it because it subclasses `collections.MutableMapping` instead of `dict`.

Python 2.6 added the abstract classes in the `collections` module and made it such that the default `dict()` constructor returns an object which inherits from these abstract classes. This shouldn't change anything besides support a new use case. Users of previous python versions should still be supported under the old behaviour.
