### PR TITLE
Updated quick start project set up order

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -6,8 +6,8 @@ We're going to create a simple API to allow admin users to view and edit the use
 
 Create a new Django project named `tutorial`, then start a new app called `quickstart`.
 
-    # Set up a new project
-    django-admin.py startproject tutorial
+	# Create the project directory
+	mkdir tutorial
     cd tutorial
 
     # Create a virtualenv to isolate our package dependencies locally
@@ -17,6 +17,9 @@ Create a new Django project named `tutorial`, then start a new app called `quick
     # Install Django and Django REST framework into the virtualenv
     pip install django
     pip install djangorestframework
+
+    # Set up a new project
+    django-admin.py startproject tutorial
 
     # Create a new app
     python manage.py startapp quickstart


### PR DESCRIPTION
Setting up a Django project requires for Django to be installed. In the updated version of the quick start guide, first we create the directory, then creating the virtual environment , then installing Django and Django REST Framework. Finally we are able to create a new Django project and therefore an app. 

Before this pull request, unless you had Django installed globally, initializing the project using `django-admin.py startproject tutorial` was failing with the following error `-bash: django-admin.py: command not found`.
