### PR TITLE
Added support for custom primary key types of custom user models.

### DIFF
--- a/rest_framework/authtoken/migrations/0001_initial.py
+++ b/rest_framework/authtoken/migrations/0001_initial.py
@@ -13,6 +13,15 @@ except ImportError: # django < 1.5
     from django.contrib.auth.models import User
 else:
     User = get_user_model()
+    
+
+def get_user_pk_field_fully_qualified_name():
+    pk_field = User._meta.pk
+    module = pk_field.__class__.__module__
+    if module is None:
+        return pk_field.__class__.__name__
+    return module + '.' + pk_field.__class__.__name__
+
 
 
 class Migration(SchemaMigration):
@@ -48,6 +57,11 @@ class Migration(SchemaMigration):
         },
         "%s.%s" % (User._meta.app_label, User._meta.module_name): {
             'Meta': {'object_name': User._meta.module_name},
+            User._meta.pk.attname: (
+                get_user_pk_field_fully_qualified_name(), [],
+                {'primary_key': 'True',
+                'db_column': "'%s'" % User._meta.pk.column}
+            ),
         },
         'authtoken.token': {
             'Meta': {'object_name': 'Token'},


### PR DESCRIPTION
The following change in migration allows you to use a different field type (other then `AutoField`) for User pks.
If you choose to merge it, please release a hot fix.
