### PR TITLE
Alter CSRF exemption implementation

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -103,7 +103,9 @@ class APIView(View):
         """
         view = super(APIView, cls).as_view(**initkwargs)
         view.cls = cls
-        return view
+        # Note: session based authentication is explicitly CSRF validated,
+        # all other authentication is CSRF exempt.
+        return csrf_exempt(view)
 
     @property
     def allowed_methods(self):
@@ -371,9 +373,9 @@ class APIView(View):
         response.exception = True
         return response
 
-    # Note: session based authentication is explicitly CSRF validated,
-    # all other authentication is CSRF exempt.
-    @csrf_exempt
+    # Note: Views are made CSRF exempt from within `as_view` as to prevent
+    # accidental removal of this exemption in cases where `dispatch` needs to
+    # be overridden.
     def dispatch(self, request, *args, **kwargs):
         """
         `.dispatch()` is pretty much the same as Django's regular dispatch,


### PR DESCRIPTION
### What is the problem / feature ?

The previous implementation of decorating `APIView.dispach` with the
`csrf_exempt` decorator allowed for an easy-to-make mistake where
someone could override the `dispatch` method on a view and inadvertantly
remove the csrf exemption of their api view.
### How did it get fixed / implemented ?

This pull request moves the decoration of the view into the `as_view` logic (which I believe is less likely to be overridden). By doing so, it becomes much more difficult to make the mistake via overrides of the dispatch method.

_Here is a cute baby animal picture for your troubles..._

![emperor-penguin-chick-snow-hill-island-antarctica](https://cloud.githubusercontent.com/assets/824194/3706302/06422ab6-1428-11e4-8cdc-e6ae49f6b945.jpg)
