### PR TITLE
Use URL output representation for FileField, not path representation.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -974,7 +974,7 @@ class FileField(WritableField):
 
     def to_native(self, value):
         if api_settings.PREPEND_MEDIA_URL:
-            return api_settings.MEDIA_URL + value.name
+            return settings.MEDIA_URL + value.name
         return value.name
 
 

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -122,7 +122,6 @@ DEFAULTS = {
     
     # Prepending MEDIA_URL to FileField
     'PREPEND_MEDIA_URL': False,
-    'MEDIA_URL': '/',
 }
 
 


### PR DESCRIPTION
Closes #1368.

The additional settings:

```
# rest framework configuration
REST_FRAMEWORK = {
    ...
    'PREPEND_MEDIA_URL': True
}
```
