### PR TITLE
ModelSerializer.restore_object - wrap ValueError error in a list

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -977,7 +977,7 @@ class ModelSerializer(Serializer):
             try:
                 setattr(instance, key, val)
             except ValueError:
-                self._errors[key] = self.error_messages['required']
+                self._errors[key] = [self.error_messages['required']]
 
         # Any relations that cannot be set until we've
         # saved the model get hidden away on these

--- a/rest_framework/tests/test_serializer.py
+++ b/rest_framework/tests/test_serializer.py
@@ -685,7 +685,7 @@ class ModelValidationTests(TestCase):
         photo_serializer = PhotoSerializer(instance=photo, data={'album': ''}, partial=True)
         self.assertFalse(photo_serializer.is_valid())
         self.assertTrue('album' in photo_serializer.errors)
-        self.assertEqual(photo_serializer.errors['album'], photo_serializer.error_messages['required'])
+        self.assertEqual(photo_serializer.errors['album'], [photo_serializer.error_messages['required']])
 
     def test_foreign_key_with_partial(self):
         """


### PR DESCRIPTION
In ModelSerializer.restore_object, when setting an attribute raises a ValueError, the error is a bare string (the translated "required" string).  The error string should be wrapped in a list.
