### PR TITLE
override_method should substitute action

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -46,7 +46,7 @@ class override_method(object):
 
     def __enter__(self):
         self.view.request = clone_request(self.request, self.method)
-        action_map = getattr(self, 'action_map', {})
+        action_map = getattr(self.view, 'action_map', {})
         self.view.action = action_map.get(self.method.lower())
         return self.view.request
 


### PR DESCRIPTION
Closes #1106.

A view's action is dependent on the request method. When overriding the method (e.g. to generate a form for a POST request on a GET call to the browseable API), the action should be updated as well. Otherwise, viewset functions may be in a weird limbo state where a 'list' action has a POST method.

Should address https://github.com/tomchristie/django-rest-framework/issues/1106

Not sure where relevant unit tests would be for this -- happy to add though
