### PR TITLE
Restore body block to base template.

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -25,6 +25,7 @@
         {% endblock %}
     </head>
 
+    {% block body %}
     <body class="{% block bodyclass %}{% endblock %} container">
 
         <div class="wrapper">
@@ -261,4 +262,5 @@
             <script src="{% static "rest_framework/js/default.js" %}"></script>
         {% endblock %}
     </body>
+    {% endblock %}
 </html>


### PR DESCRIPTION
Commit b4c7717cb80cb13a2f13aae8855e226685306880 refactored the login template to override the entire body of the base template, and added a `body` block in base.html to make that possible. However, a subsequent merge seems to have removed those block tags from base.html, with the result that the login template does not render at all.

This PR simply restores the block tags.
