### PR TITLE
Fix #1804

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 recursive-include rest_framework/static *.js *.css *.png
 recursive-include rest_framework/templates *.html
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
Excludes the **pycache**, pyc and pyo files from the packaging.
