### PR TITLE
Additions to allow runtests.py to run pyflakes

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,9 @@ pytest-django==2.6
 pytest==2.5.2
 pytest-cov==1.6
 flake8==2.2.2
+pep8==1.5.7
+mccabe==0.2.1
+pyflakes==0.8.1
 
 # Optional packages
 markdown>=2.1.0


### PR DESCRIPTION
Before adding pep8, mccabe and pyflakes I was seeing errors like

`ImportError: No module named pep8`

`pkg_resources.DistributionNotFound: mccabe>=0.2.1`

`pkg_resources.DistributionNotFound: pyflakes>=0.8.1`

Pull request contains these as additions to requirements.txt in case they are needed.
