### PR TITLE
Display validation errors on login form

### DIFF
--- a/rest_framework/templates/rest_framework/login_base.html
+++ b/rest_framework/templates/rest_framework/login_base.html
@@ -52,7 +52,7 @@
                                 <input type="hidden" name="next" value="{{ next }}" />
                                 {% if form.non_field_errors %}
                                     {% for error in form.non_field_errors %}
-                                        <div class="well well-small text-error">{{ error }}</div>
+                                        <div class="well well-small text-error" style="border: none">{{ error }}</div>
                                     {% endfor %}
                                 {% endif %}
                                 <div class="form-actions-no-box">


### PR DESCRIPTION
Closes #1464.

I've added small changes that display error message on the login form.
This is the original state of the login form:

![login_form](https://cloud.githubusercontent.com/assets/7045848/4149745/c5102d1a-3437-11e4-8d80-7426697d093f.png)

If bad credentials are provided, corresponding error message is displayed:

![login_bad_credentials](https://cloud.githubusercontent.com/assets/7045848/4149758/dcfcf534-3437-11e4-9bbe-de927f9c638c.png)

If 'Username' or 'Password' fields are empty HTML5 validation applies:

![login_empty_user](https://cloud.githubusercontent.com/assets/7045848/4149766/f62e56d8-3437-11e4-8839-4e198e1d208e.png)

![login_empty_pass](https://cloud.githubusercontent.com/assets/7045848/4149773/fa91e816-3437-11e4-8a50-cc01652b4e7d.png)

If the browser doesn't support HTML5 form validation, then this would be expected to display when the user submits an empty form:
![login_form_empty_fields](https://cloud.githubusercontent.com/assets/7045848/4149783/0fa8864c-3438-11e4-9a53-2eb7c5c2315e.png)
