### PR TITLE
Using user.get_username() instead of user.username.

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -344,7 +344,7 @@ class OAuth2Authentication(BaseAuthentication):
         user = token.user
 
         if not user.is_active:
-            msg = 'User inactive or deleted: %s' % user.username
+            msg = 'User inactive or deleted: %s' % user.get_username()
             raise exceptions.AuthenticationFailed(msg)
 
         return (user, token)


### PR DESCRIPTION
This solves an error when using a auth model that does not have a username field.

Issue: #1832
