### PR TITLE
Add support for limit_choices_to on related fields.

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -102,6 +102,7 @@ By default this field is read-write, although you can change this behavior using
 * `many` - If applied to a to-many relationship, you should set this argument to `True`.
 * `required` - If set to `False`, the field will accept values of `None` or the empty-string for nullable relationships.
 * `queryset` - By default `ModelSerializer` classes will use the default queryset for the relationship.  `Serializer` classes must either set a queryset explicitly, or set `read_only=True`.
+* `limit_choices_to` - Used to filter the `queryset` to a limited set of choices. Either a dictionary, a Q object, or a callable returning a dictionary or Q object can be used.
 
 ## HyperlinkedRelatedField
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -822,9 +822,6 @@ class ModelSerializer(Serializer):
 
         Note that model_field will be `None` for reverse relationships.
         """
-        # TODO: filter queryset using:
-        # .using(db).complex_filter(self.rel.limit_choices_to)
-
         kwargs = {
             'queryset': related_model._default_manager,
             'many': to_many
@@ -845,6 +842,9 @@ class ModelSerializer(Serializer):
 
             if model_field.help_text is not None:
                 kwargs['help_text'] = model_field.help_text
+
+            if model_field.rel.limit_choices_to:
+                kwargs['limit_choices_to'] = model_field.rel.limit_choices_to
 
         return PrimaryKeyRelatedField(**kwargs)
 
@@ -1101,8 +1101,6 @@ class HyperlinkedModelSerializer(ModelSerializer):
         """
         Creates a default instance of a flat relational field.
         """
-        # TODO: filter queryset using:
-        # .using(db).complex_filter(self.rel.limit_choices_to)
         kwargs = {
             'queryset': related_model._default_manager,
             'view_name': self._get_default_view_name(related_model),
@@ -1115,6 +1113,8 @@ class HyperlinkedModelSerializer(ModelSerializer):
                 kwargs['help_text'] = model_field.help_text
             if model_field.verbose_name is not None:
                 kwargs['label'] = model_field.verbose_name
+            if model_field.rel.limit_choices_to:
+                kwargs['limit_choices_to'] = model_field.rel.limit_choices_to
 
         if self.opts.lookup_field:
             kwargs['lookup_field'] = self.opts.lookup_field

--- a/tests/models.py
+++ b/tests/models.py
@@ -134,6 +134,14 @@ class OptionalRelationModel(RESTFrameworkModel):
     other = models.ForeignKey('OptionalRelationModel', blank=True, null=True)
 
 
+# Model for issue #1811
+class LimitedChoicesModel(RESTFrameworkModel):
+    rel = models.ForeignKey(
+        'ForeignKeyTarget',
+        limit_choices_to={'name': 'foo'},
+    )
+
+
 # Model for RegexField
 class Book(RESTFrameworkModel):
     isbn = models.CharField(max_length=13)


### PR DESCRIPTION
Refs #1811.
### What is the problem / feature ?

Serializer fields representing relationships did not support or respect the [`limit_choices_to`](https://docs.djangoproject.com/en/dev/ref/models/fields/#django.db.models.ForeignKey.limit_choices_to) option as introduced from django's `ForeignKey` field.
- Issue #1811 
### How did it get fixed / implemented ?
- Added a new keyword argument `limit_choices_to` to `rest_framework.relations.RelatedField`
- Added support for extracting this value from the model field when auto generating a field.
- Added support for looking this field up from the model in the _appropriate_ situations.
### How can someone test / see it ?

Test coverage, as well as creating a related field using the `limit_choices_to` argument and seeing that the resulting queryset used for the field is correctly filtered.

_Here is a cute animal picture for your troubles..._

![o-monkeys-ride-dogs-570](https://cloud.githubusercontent.com/assets/824194/4176453/0685acce-3605-11e4-8082-c134ac077869.jpg)
