### PR TITLE
Stop the API Client converting empty lists/dicts to empty strings

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -36,7 +36,7 @@ class APIRequestFactory(DjangoRequestFactory):
         Encode the data returning a two tuple of (bytes, content_type)
         """
 
-        if not data:
+        if data is None:
             return ('', content_type)
 
         assert format is None or content_type is None, (


### PR DESCRIPTION
The test client performs a naive check on data for empty values:

``` python
    def _encode_data(self, data, format=None, content_type=None):
        """
        Encode the data returning a two tuple of (bytes, content_type)
        """

        if not data:
            return ('', content_type)
       ...
```

This causes issues testing against views that accept empty `list` and `dict` values as valid input. In the test client, these are converted to empty strings, causing unexpected validation issues that don't happen in production use.

This PR simply changes it to an `is None` test. FWIW, this seems to be implied by the keyword argument defaults of `.post`, `.put`, etc.

Tests against python2.7 pass.
