### PR TITLE
Make sure APIRoot.get can take on args, kwargs so router can be embedded...

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -284,10 +284,10 @@ class DefaultRouter(SimpleRouter):
         class APIRoot(views.APIView):
             _ignore_model_permissions = True
 
-            def get(self, request, format=None, *args, **kwargs):
+            def get(self, request, *args, **kwargs):
                 ret = {}
                 for key, url_name in api_root_dict.items():
-                    ret[key] = reverse(url_name, request=request, format=format)
+                    ret[key] = reverse(url_name, request=request, format=kwargs.get('format'))
                 return Response(ret)
 
         return APIRoot.as_view()


### PR DESCRIPTION
... within any URL pattern.

I was dealing with a simple project where my router was being included in a URL pattern with a named group which resulted in APIRoot view error `get() got an unexpected keyword argument '<name of group>'`. Digging into the code, I think a regression was introduced with the https://github.com/tomchristie/django-rest-framework/commit/aff88d15f7a483bca2da120339b1b346aa8b1d4c where earlier `APIRoot.get()` was able to take on additional args and kwargs because of the `@api_view` decorator, now it is not. 

Simple steps to reproduce error on `master` branch: 
- In your `urls.py` instead of using `url(r'^somenamespace/', include(router.urls))` use `url(r'^(?P<namedgroup>[-\w]+)/', include(router.urls))`

Please let me know if I'm understanding it wrong, or haven't patched a proper fix. 
