### PR TITLE
Make sure APIRoot.get can take on args, kwargs so router can be embedded...

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -284,10 +284,10 @@ class DefaultRouter(SimpleRouter):
         class APIRoot(views.APIView):
             _ignore_model_permissions = True
 
-            def get(self, request, format=None):
+            def get(self, request, *args, **kwargs):
                 ret = {}
                 for key, url_name in api_root_dict.items():
-                    ret[key] = reverse(url_name, request=request, format=format)
+                    ret[key] = reverse(url_name, request=request, format=kwargs.get('format', None))
                 return Response(ret)
 
         return APIRoot.as_view()


### PR DESCRIPTION
... within any URL pattern.

Cleaner patch for the problem described in https://github.com/tomchristie/django-rest-framework/pull/1849
