### PR TITLE
Fix grammar in login error message

### DIFF
--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -22,7 +22,7 @@ class AuthTokenSerializer(serializers.Serializer):
                 attrs['user'] = user
                 return attrs
             else:
-                msg = _('Unable to login with provided credentials.')
+                msg = _('Unable to log in with provided credentials.')
                 raise serializers.ValidationError(msg)
         else:
             msg = _('Must include "username" and "password"')


### PR DESCRIPTION
"Login" is a noun or adjective; "log in" is a verb [[1]](http://grammarist.com/spelling/log-in-login/). Here, we're using the infinitive form of the verb, so it should be "log in."
