### PR TITLE
DefaultRouter support for viewsets without an implemented default action

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -19,6 +19,7 @@ import itertools
 from collections import namedtuple
 from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
+from django.core.urlresolvers import NoReverseMatch
 from rest_framework import views
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -287,7 +288,15 @@ class DefaultRouter(SimpleRouter):
             def get(self, request, *args, **kwargs):
                 ret = {}
                 for key, url_name in api_root_dict.items():
-                    ret[key] = reverse(url_name, request=request, format=kwargs.get('format', None))
+                    try:
+                        ret[key] = reverse(
+                            url_name,
+                            request=request,
+                            format=kwargs.get('format', None)
+                        )
+                    except NoReverseMatch:
+                        continue
+
                 return Response(ret)
 
         return APIRoot.as_view()

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -3,7 +3,7 @@ from django.conf.urls import patterns, url, include
 from django.db import models
 from django.test import TestCase
 from django.core.exceptions import ImproperlyConfigured
-from rest_framework import serializers, viewsets, permissions
+from rest_framework import serializers, viewsets, mixins, permissions
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
 from rest_framework.routers import SimpleRouter, DefaultRouter
@@ -284,3 +284,19 @@ class TestDynamicListAndDetailRouter(TestCase):
             else:
                 method_map = 'get'
             self.assertEqual(route.mapping[method_map], endpoint)
+
+
+class TestRootWithAListlessViewset(TestCase):
+    def setUp(self):
+        class NoteViewSet(mixins.RetrieveModelMixin,
+                          viewsets.GenericViewSet):
+            model = RouterTestModel
+
+        self.router = DefaultRouter()
+        self.router.register(r'notes', NoteViewSet)
+        self.view = self.router.urls[0].callback
+
+    def test_api_root(self):
+        request = factory.get('/')
+        response = self.view(request)
+        self.assertEqual(response.data, {})


### PR DESCRIPTION
DefaultRouter's root view would fail if there was a viewset registered that didn't implement the default action (usually the list action). Issue https://github.com/tomchristie/django-rest-framework/issues/1864

This PR makes the DefaultRouter ignore such viewsets in the root view's response.
