### PR TITLE
Clarify "raised inside REST framework"

### DIFF
--- a/api-guide/exceptions.html
+++ b/api-guide/exceptions.html
@@ -217,7 +217,7 @@ a.fusion-poweredby {
 <p>REST framework's views handle various exceptions, and deal with returning appropriate error responses.</p>
 <p>The handled exceptions are:</p>
 <ul>
-<li>Subclasses of <code>APIException</code> raised inside of classes subclassing APIView.</li>
+<li>Subclasses of <code>APIException</code> raised inside an APIView class or @api_view.</li>
 <li>Django's <code>Http404</code> exception.</li>
 <li>Django's <code>PermissionDenied</code> exception.</li>
 </ul>


### PR DESCRIPTION
I ran into an issue today where I was not seeing the `rest_framework.views.exception_handler` do what I thought it should be doing. It turned out that I had imported `View` from `rest_framework.views` rather than importing `APIView` from `rest_framework.views`. The phrase "raised inside REST framework" was confusing as I was debugging this issue. I was unsure if that meant that I could raise those exceptions in my code or if it had to originate from within framework code.

I'm not sure if the proposed wording is ideal, I just wanted to point out what I found to be confusing.
