### PR TITLE
Fix missing CSRF exemption on viewsets

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 from functools import update_wrapper
 from django.utils.decorators import classonlymethod
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework import views, generics, mixins
 
 
@@ -89,7 +90,7 @@ class ViewSetMixin(object):
         # resolved URL.
         view.cls = cls
         view.suffix = initkwargs.get('suffix', None)
-        return view
+        return csrf_exempt(view)
 
     def initialize_request(self, request, *args, **kargs):
         """


### PR DESCRIPTION
### What is the problem / feature ?

The adjustment to how CSRF exemption was applied to views in https://github.com/tomchristie/django-rest-framework/pull/1706 was not done to the `as_view` method in `rest_framework.viewsets.ViewSetMixin`.
### How did it get fixed / implemented ?

Wrapped the returned view in `csrf_exempt`.
### How can someone test / see it ?

See that the views returned from viewsets are CSRF exempt.

_Here is a cute animal picture for your troubles..._

![squirrel-waterskiing](https://cloud.githubusercontent.com/assets/824194/4323563/75bd5614-3f51-11e4-9eab-8fdd1a4aa32b.png)
