### PR TITLE
Add the snippets.url to the tutorial master urls.py

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -303,6 +303,14 @@ Finally we need to wire these views up.  Create the `snippets/urls.py` file:
         url(r'^snippets/(?P<pk>[0-9]+)/$', 'snippet_detail'),
     )
 
+Then edit tutorial/urls.py and add:
+
+    import snippets.urls
+    
+    urlpatterns = patterns('',
+        url(r'', include('snippets.urls')),
+    )
+
 It's worth noting that there are a couple of edge cases we're not dealing with properly at the moment.  If we send malformed `json`, or if a request is made with a method that the view doesn't handle, then we'll end up with a 500 "server error" response.  Still, this'll do for now.
 
 ## Testing our first attempt at a Web API


### PR DESCRIPTION
Not sure what versions of Django this may be required for - I needed it in my old 1.5 install
