### PR TITLE
Changed return status for CSRF failures to HTTP 403

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -129,7 +129,7 @@ class SessionAuthentication(BaseAuthentication):
         reason = CSRFCheck().process_view(request, None, (), {})
         if reason:
             # CSRF failed, bail with explicit error message
-            raise exceptions.AuthenticationFailed('CSRF Failed: %s' % reason)
+            raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)
 
 
 class TokenAuthentication(BaseAuthentication):


### PR DESCRIPTION
By default, Django returns "HTTP 403 Forbidden" responses when CSRF
validation failed[1]. CSRF is a case of authorization, not of
authentication. Therefore `PermissionDenied` should be raised instead
of `AuthenticationFailed`.

This replaces pull request #1613.

[1] https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#rejected-requests
