### PR TITLE
Possible issue when serializing large numbers

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -814,6 +814,7 @@ class IntegerField(WritableField):
     type_label = 'integer'
     form_field_class = forms.IntegerField
     empty = 0
+    max_digits = 39  # len(str(2**128))
 
     default_error_messages = {
         'invalid': _('Enter a whole number.'),
@@ -835,7 +836,9 @@ class IntegerField(WritableField):
             return None
 
         try:
-            value = int(str(value))
+            str_value = str(value)
+            validators.MaxLengthValidator(self.max_digits)(str_value)
+            value = int(str_value)
         except (ValueError, TypeError):
             raise ValidationError(self.error_messages['invalid'])
         return value
@@ -846,6 +849,7 @@ class FloatField(WritableField):
     type_label = 'float'
     form_field_class = forms.FloatField
     empty = 0
+    max_digits = 17   # IEEE-754 double can get at most 17 significant digits.
 
     default_error_messages = {
         'invalid': _("'%s' value must be a float."),
@@ -856,6 +860,7 @@ class FloatField(WritableField):
             return None
 
         try:
+            validators.MaxLengthValidator(self.max_digits)(str(value))
             return float(value)
         except (TypeError, ValueError):
             msg = self.error_messages['invalid'] % value
@@ -898,6 +903,9 @@ class DecimalField(WritableField):
             return None
         value = smart_text(value).strip()
         try:
+            # to not change behavior something similar to
+            # .validate(self, value) should be run
+            # validators.MaxLengthValidator(self.max_digits)(str(value))
             value = Decimal(value)
         except DecimalException:
             raise ValidationError(self.error_messages['invalid'])


### PR DESCRIPTION
When using a serializer in the context of the rest framework, a malicious user could send a large number as a string representation (In the example I use a small number, str(2**256), that is big enough for demonstration).  Since the number is converted to an integer in fields.IntegerField.from_native function without checking the length of the input, the system can hang.  One solution is to use a length validation before converting, however this seems a little messy.  Similar concerns exist in FloatField and DecimalField .
