### PR TITLE
self._errors might be None when nesting serializers

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -272,6 +272,7 @@ class BaseSerializer(WritableField):
         Converts a dictionary of data into a dictionary of deserialized fields.
         """
         reverted_data = {}
+        self._errors = self._errors or {}
 
         if data is not None and not isinstance(data, dict):
             self._errors['non_field_errors'] = ['Invalid data']


### PR DESCRIPTION
We are nesting serializers. So when calling _from_native()_ on a serializer it creates its _self._errors_ dict. However, on child serializers / fields _restore_fields()_ may be called directly. Then _self._errors_ is _None_ which causes the request to fail.
