### PR TITLE
Do not apply fix for multichoice help text in later version of Django

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -11,6 +11,7 @@ import inspect
 import re
 import warnings
 from decimal import Decimal, DecimalException
+import django
 from django import forms
 from django.core import validators
 from django.core.exceptions import ValidationError
@@ -143,7 +144,10 @@ class Field(object):
             self.label = None
 
         if help_text is not None:
-            self.help_text = strip_multiple_choice_msg(smart_text(help_text))
+            help_text = smart_text(help_text)
+            if django.VERSION < (1, 6):
+                help_text = strip_multiple_choice_msg(help_text)
+            self.help_text = help_text
         else:
             self.help_text = None
 


### PR DESCRIPTION
The initial fix could cause problems in Django 1.7 when serializers get used as a field. This is due to `force_text` being applied before full initialisation of the apps registry (see #1907).

The fix doesn't seem to be required after version 1.6:
https://code.djangoproject.com/ticket/9321

Reg this PR:
I wasn't able to write a meaningful test for this since I'm not sure how to properly replicate in a test environment.
