### PR TITLE
Used the cached_property decorator on the request object and the response object

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -9,11 +9,14 @@ The wrapped request then offers a richer API, in particular :
     - form overloading of HTTP method, content type and content
 """
 from __future__ import unicode_literals
+
 from django.conf import settings
 from django.http import QueryDict
 from django.http.multipartparser import parse_header
 from django.utils.datastructures import MultiValueDict
 from django.utils.datastructures import MergeDict as DjangoMergeDict
+from django.utils.functional import cached_property
+
 from rest_framework import HTTP_HEADER_ENCODING
 from rest_framework import exceptions
 from rest_framework.compat import BytesIO
@@ -163,7 +166,7 @@ class Request(object):
     def _default_negotiator(self):
         return api_settings.DEFAULT_CONTENT_NEGOTIATION_CLASS()
 
-    @property
+    @cached_property
     def method(self):
         """
         Returns the HTTP method.
@@ -175,7 +178,7 @@ class Request(object):
             self._load_method_and_content_type()
         return self._method
 
-    @property
+    @cached_property
     def content_type(self):
         """
         Returns the content type header.
@@ -188,7 +191,7 @@ class Request(object):
             self._load_method_and_content_type()
         return self._content_type
 
-    @property
+    @cached_property
     def stream(self):
         """
         Returns an object that may be used to stream the request content.
@@ -211,13 +214,13 @@ class Request(object):
         """
         return self._request.GET
 
-    @property
+    @cached_property
     def data(self):
         if not _hasattr(self, '_full_data'):
             self._load_data_and_files()
         return self._full_data
 
-    @property
+    @cached_property
     def DATA(self):
         """
         Parses the request body and returns the data.
@@ -229,7 +232,7 @@ class Request(object):
             self._load_data_and_files()
         return self._data
 
-    @property
+    @cached_property
     def FILES(self):
         """
         Parses the request body and returns any files uploaded in the request.
@@ -278,7 +281,7 @@ class Request(object):
         """
         self._auth = value
 
-    @property
+    @cached_property
     def successful_authenticator(self):
         """
         Return the instance of the authentication instance class that was used

--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -9,6 +9,7 @@ import django
 from django.core.handlers.wsgi import STATUS_CODE_TEXT
 from django.template.response import SimpleTemplateResponse
 from django.utils import six
+from django.utils.functional import cached_property
 
 
 class Response(SimpleTemplateResponse):
@@ -40,7 +41,7 @@ class Response(SimpleTemplateResponse):
             for name, value in six.iteritems(headers):
                 self[name] = value
 
-    @property
+    @cached_property
     def rendered_content(self):
         renderer = getattr(self, 'accepted_renderer', None)
         media_type = getattr(self, 'accepted_media_type', None)
@@ -73,7 +74,7 @@ class Response(SimpleTemplateResponse):
 
         return ret
 
-    @property
+    @cached_property
     def status_text(self):
         """
         Returns reason text corresponding to our HTTP response status code.


### PR DESCRIPTION
I haven't changed any of the logic here since I did not want to break existing functionality but the private _\* attributes should be removed in order to reduce the memory footprint of each request or response. If you can, please guide me how to do so without breaking existing functionality.
The benefit of using cached_property here is that we don't have to execute the if statement everytime. It's meaningful if your API is getting a lot of requests.
