### PR TITLE
Update links in 2.4-announcement.md

### DIFF
--- a/docs/topics/2.4-announcement.md
+++ b/docs/topics/2.4-announcement.md
@@ -164,8 +164,8 @@ Once again, many thanks to all the generous [backers and sponsors][kickstarter-s
 
 [lts-releases]: https://docs.djangoproject.com/en/dev/internals/release-process/#long-term-support-lts-releases
 [2-4-release-notes]: release-notes#240
-[view-name-and-description-settings]: ../api-guide/settings/#view-names-and-descriptions
-[client-ip-identification]: ../api-guide/throttling/#how-clients-are-identified
+[view-name-and-description-settings]: ../api-guide/settings#view-names-and-descriptions
+[client-ip-identification]: ../api-guide/throttling#how-clients-are-identified
 [2-3-announcement]: 2.3-announcement
 [github-labels]: https://github.com/tomchristie/django-rest-framework/issues
 [github-milestones]: https://github.com/tomchristie/django-rest-framework/milestones


### PR DESCRIPTION
The links to Django Rest Framework pages were 404ing because the URLs included a slash.
