### PR TITLE
Fixed bug in ChoiceField, it is possible to submit 0 as value when it is not in choices

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -552,7 +552,7 @@ class ChoiceField(WritableField):
         Validates that the input is in self.choices.
         """
         super(ChoiceField, self).validate(value)
-        if value and not self.valid_value(value):
+        if value not in validators.EMPTY_VALUES and not self.valid_value(value):
             raise ValidationError(self.error_messages['invalid_choice'] % {'value': value})
 
     def valid_value(self, value):


### PR DESCRIPTION
Since we check just for `bool(value)` and `bool(0)` is `False`, it doesn't perform validation even when `required=True`. `required=True` logic checks value for existing in django core `EMPTY_VALUES` list, but 0 is not in it, which is logical. But in validate of `ChoiseField`, we should do "if value is provided and it is not empty(`None`, `[]`, `{}`), perform validation".

Tom, it is critical, please, take a look :(
