### PR TITLE
attach serializer class to function based views

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -68,8 +68,22 @@ def api_view(http_method_names):
 
         WrappedAPIView.permission_classes = getattr(func, 'permission_classes',
                                                     APIView.permission_classes)
+        WrappedAPIView.permission_classes = getattr(func, 'permission_classes',
+                                                    APIView.permission_classes)
+
+        def get_serializer_class(self):
+            return getattr(func, 'serializer_class', None)
+
+        WrappedAPIView.get_serializer_class = types.MethodType(get_serializer_class, WrappedAPIView)
 
         return WrappedAPIView.as_view()
+    return decorator
+
+
+def serializer_class(clazz):
+    def decorator(func):
+        func.serializer_class = clazz
+        return func
     return decorator
 
 


### PR DESCRIPTION
For documentation purposes, we need to be able to attach serializers to function-based views.

ariovistus/django-rest-swagger#67
