### PR TITLE
Update 3.0-announcement.md

### DIFF
--- a/docs/topics/3.0-announcement.md
+++ b/docs/topics/3.0-announcement.md
@@ -518,7 +518,7 @@ The `MultipleChoiceField` class has been added. This field acts like `ChoiceFiel
 
 #### Changes to the custom field API.
 
-The `from_native(self, value)` and `to_native(self, data)` method names have been replaced with the more obviously named `to_representation(self, value)` and `to_internal_value(self, data)`.
+The `from_native(self, value)` and `to_native(self, data)` method names have been replaced with the more obviously named `to_internal_value(self, data)` and `to_representation(self, value)`.
 
 The `field_from_native()` and `field_to_native()` methods are removed.
 


### PR DESCRIPTION
Swap order of custom field API changes so the two "and" clauses are in the same order.
