### PR TITLE
Add a .keys() method to BindingDict

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -230,6 +230,9 @@ class BindingDict(object):
     def items(self):
         return self.fields.items()
 
+    def keys(self):
+        return self.fields.keys()
+
     def values(self):
         return self.fields.values()
 


### PR DESCRIPTION
I have some code in place to add and modify the field list based on arguments that are passed into a serializer's context. Doing this requires knowing which fields have been defined and modifying the fields as necessary. Because of the addition of `BindingDict`, the simple task of `serializer.fields.keys()` is no longer possible.

This simple patch adds another pass-through method to restore this functionality, by way of the new `BindingDict`.
