### PR TITLE
Correct example use of ValidationFailed

### DIFF
--- a/docs/topics/3.0-announcement.md
+++ b/docs/topics/3.0-announcement.md
@@ -154,9 +154,11 @@ We now include a simpler `ValidationFailed` exception class in REST framework th
 
 The `validate_<field_name>` method hooks that can be attached to serializer classes change their signature slightly and return type. Previously these would take a dictionary of all incoming data, and a key representing the field name, and would return a dictionary including the validated data for that field:
 
+    from rest_framework.exceptions import ValidationFailed
+
     def validate_score(self, attrs, source):
         if attrs[score] % 10 != 0:
-            raise ValidationError('This field should be a multiple of ten.')
+            raise ValidationFailed('This field should be a multiple of ten.')
         return attrs
 
 This is now simplified slightly, and the method hooks simply take the value to be validated, and return it's validated value.


### PR DESCRIPTION
Having just introduced the new `ValidationFailed` exception, the example
then suggests the old `ValidationError`.
