### PR TITLE
Fix serializer default None field bug

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -354,7 +354,14 @@ class WritableField(Field):
             else:
                 native = data[field_name]
         except KeyError:
-            if self.default is not None and not self.partial:
+            try:
+                allow_none = self.allow_none
+            except AttributeError:
+                allow_none = False
+            if (
+                (self.default is None and allow_none) or
+                (self.default is not None)
+            ) and not self.partial:
                 # Note: partial updates shouldn't set defaults
                 native = self.get_default_value()
             else:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -913,6 +913,8 @@ class ReadOnlyManyToManyTests(TestCase):
 class DefaultValueTests(TestCase):
     def setUp(self):
         class DefaultValueSerializer(serializers.ModelSerializer):
+            default_none_field = serializers.CharField(default=None, required=False, allow_none=True)
+
             class Meta:
                 model = DefaultValueModel
 
@@ -927,6 +929,15 @@ class DefaultValueTests(TestCase):
         self.assertEqual(len(self.objects.all()), 1)
         self.assertEqual(instance.pk, 1)
         self.assertEqual(instance.text, 'foobar')
+
+    def test_create_using_none_as_default(self):
+        data = {}
+        serializer = self.serializer_class(data=data)
+        self.assertEqual(serializer.is_valid(), True)
+        instance = serializer.save()
+        self.assertEqual(len(self.objects.all()), 1)
+        self.assertEqual(instance.pk, 1)
+        self.assertEqual(instance.default_none_field, None)
 
     def test_create_overriding_default(self):
         data = {'text': 'overridden'}


### PR DESCRIPTION
When adding an extra CharField to a serializer for a project I was working I found that adding a default=None keyword arg meant that the resulting serializer instance gave an AttributeError when trying to access that field.

After some poking around I found out it was because of None values not being accepted by an if statement
