### PR TITLE
Use PYTHONDONTWRITEBYTECODE=1 on tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ envlist =
 
 [testenv]
 commands = ./runtests.py --fast
+setenv =
+       PYTHONDONTWRITEBYTECODE=1
 
 [testenv:flake8]
 basepython = python2.7


### PR DESCRIPTION
This fixes bad marshal data errors after running
tests with tox and later running tests manually
via runtests.py. Fixes #1957

Note: If you've already encountered this issue you might have to run the following from the root of this project.

``` bash
$ find . -name '*.pyc' -delete
```
