### PR TITLE
docs(api-guide/authentication): updated to reflect new standards in Django 1.7

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -168,12 +168,13 @@ The `curl` command line tool may be useful for testing token authenticated APIs.
 
 If you want every user to have an automatically generated Token, you can simply catch the User's `post_save` signal.
 
+    from django.conf import settings
     from django.contrib.auth import get_user_model
     from django.db.models.signals import post_save
     from django.dispatch import receiver
     from rest_framework.authtoken.models import Token
 
-    @receiver(post_save, sender=get_user_model())
+    @receiver(post_save, sender=settings.AUTH_USER_MODEL)
     def create_auth_token(sender, instance=None, created=False, **kwargs):
         if created:
             Token.objects.create(user=instance)


### PR DESCRIPTION
Based on the [new documentation](https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.get_user_model) for Django 1.7 we should now use:

``` python
@receiver(post_save, sender=settings.AUTH_USER_MODEL)
```

instead of:

``` python
@receiver(post_save, sender=get_user_model())
```

 `get_user_model()` only works once Django has imported all models. If you use it like its currently stated in the Rest-framework docs you'll get: 

``` python
django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet.
```

when trying to start your sever after adding token authentication.

From the [docs](https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.get_user_model), ( linked above as well ) :

> New in Django 1.7:
> When connecting to signals sent by the User model, you should specify the custom model using the AUTH_USER_MODEL setting.
