### PR TITLE
Added Django's models.IPAddressField to the ModelSerializer field mapping

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -519,6 +519,7 @@ class ModelSerializer(Serializer):
         models.FloatField: FloatField,
         models.ImageField: ImageField,
         models.IntegerField: IntegerField,
+        models.IPAddressField: CharField,
         models.NullBooleanField: NullBooleanField,
         models.PositiveIntegerField: IntegerField,
         models.PositiveSmallIntegerField: IntegerField,


### PR DESCRIPTION
Very simple change.  Since IPAddressField is a CharField, Django defines an implied max_length that was not being popped from kwargs by ModelField causing an invalid kwarg passed to Field's **init**:

```
  File "build/bdist.macosx-10.10-intel/egg/rest_framework/fields.py", line 1170, in __init__
  super(ModelField, self).__init__(**kwargs)
  TypeError: __init__() got an unexpected keyword argument 'max_length'
```
