### PR TITLE
Do not require UniqueTogether validation for updates (PATCH) since the update may be partial.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -592,7 +592,8 @@ class ModelSerializer(Serializer):
         # Note that we make sure to check `unique_together` both on the
         # base model class, but also on any parent classes.
         for parent_class in [model_class] + list(model_class._meta.parents.keys()):
-            if self.context.get('request').method != 'PATCH':
+            http_method = getattr(self.context.get('request'), 'method', None)
+            if http_method and http_method != 'PATCH':
                 for unique_together in parent_class._meta.unique_together:
                     if field_names.issuperset(set(unique_together)):
                         validator = UniqueTogetherValidator(


### PR DESCRIPTION
This was a quick workaround when troubleshooting an issue when passing partial data via PATCH to update a resource where `unique_together` constraints were imposed on the model and the serializer validation was trying to enforce the uniqueness even though it only had partial data.

``` python
class Extension(models.Model):                                                                                                         
    ext = models.CharField(max_length=255)                                                                               
    domain = models.ForeignKey(Domain)                                          

    class Meta:                                                                 
        db_table = 'extension'                                                  
        unique_together = (("ext", "domain"),)         
```

``` python
class ExtensionSerializer(HyperlinkedModelSerializer):                          
    domain = HrefRelatedField(view_name='domain-detail', lookup_field='name', queryset=Domain.objects.all())                                                                       

    class Meta(HyperlinkedModelSerializer.Meta):                                
        model = Extension                                                       
        fields = ('url', 'ext', 'domain')     
```

PATCH http://testserver/v1/extensions/1/ --- {'domain': 'http://testserver/v1/domains/2/'}

Results in KeyError 'ext' because ModelSerializer.get_validators() looks for all fields specific in `unique_together` in the PATCH (partial) update.
