### PR TITLE
Separating handler logic out of dispatch. 

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -376,6 +376,17 @@ class APIView(View):
         response.exception = True
         return response
 
+    def get_handler(self, request, *args, **kwargs):
+        """
+        Return the appropriate handler method.
+        """
+        if request.method.lower() in self.http_method_names:
+            handler = getattr(self, request.method.lower(),
+                              self.http_method_not_allowed)
+        else:
+            handler = self.http_method_not_allowed
+        return handler
+
     # Note: Views are made CSRF exempt from within `as_view` as to prevent
     # accidental removal of this exemption in cases where `dispatch` needs to
     # be overridden.
@@ -392,16 +403,8 @@ class APIView(View):
 
         try:
             self.initial(request, *args, **kwargs)
-
-            # Get the appropriate handler method
-            if request.method.lower() in self.http_method_names:
-                handler = getattr(self, request.method.lower(),
-                                  self.http_method_not_allowed)
-            else:
-                handler = self.http_method_not_allowed
-
+            handler = self.get_handler(request, *args, **kwargs)
             response = handler(request, *args, **kwargs)
-
         except Exception as exc:
             response = self.handle_exception(exc)
 


### PR DESCRIPTION
Hi,
I have a minor change that moves the logic out to determine which handler (such as `.get()`, `.post()`) into it's own separate method. 
The rational for this, is from a recent use case of `Viewsets` with a current project.
Often, depending on a difference in request object, such as the presence of a QUERY_PARAM (which can't to my knowledge be detected with current Router setup, please correct me if I'm mistaken) combined with the type of request action (e.g. retrieve, create, destroy, etc) it's really useful to point to custom methods for DRYness + testability.  

Currently we have to overwrite the entire dispatch, when we are just concerned with determining the handler. Instead, it would be nice overwrite just the handler logic! 

Let me know if the above makes sense. Happy to explain in more detail + welcome to feedback on this! 
