### PR TITLE
Fix typo in example Code

### DIFF
--- a/docs/topics/3.0-announcement.md
+++ b/docs/topics/3.0-announcement.md
@@ -159,7 +159,7 @@ We strongly recommend that you use the namespaced import style of `import serial
 The `validate_<field_name>` method hooks that can be attached to serializer classes change their signature slightly and return type. Previously these would take a dictionary of all incoming data, and a key representing the field name, and would return a dictionary including the validated data for that field:
 
     def validate_score(self, attrs, source):
-        if attrs[score] % 10 != 0:
+        if attrs[source] % 10 != 0:
             raise serializers.ValidationError('This field should be a multiple of ten.')
         return attrs
 


### PR DESCRIPTION
Fix a typo in the example showing how field level validation has been cleaned up.
