### PR TITLE
add kwargs to get_serializer_context

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -69,15 +69,17 @@ class GenericAPIView(views.APIView):
     # and should be considered private API.
     paginator_class = Paginator
 
-    def get_serializer_context(self):
+    def get_serializer_context(self, **kwargs):
         """
         Extra context provided to the serializer class.
         """
-        return {
+        context = {
             'request': self.request,
             'format': self.format_kwarg,
             'view': self
         }
+        context.update(**kwargs)
+        return context
 
     def get_serializer(self, instance=None, data=None, many=False, partial=False):
         """


### PR DESCRIPTION
to add something to the context you can easily overload the get_serializer_context method. inside you have to call super to get the context, add your stuff and return it. it would save a little boilerplate if we would a take kwargs on the original method. that way the overloaded method is reduced to just the super call with the additional parameters for the context.

instead of:

```
def get_serializer_context(self):
    context = super(SuperClass, self).get_serializer_context()
    context.update(dict(
        example=True
    ))
    return context
```

just do:

```
def get_serializer_context(self):
    return super(SuperClass, self).get_serializer_context(
        example=True
    )
```
