### PR TITLE
copy default kwarg from model to serializer

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -88,6 +88,9 @@ def get_field_kwargs(field_name, model_field):
         kwargs['read_only'] = True
         return kwargs
 
+    if model_field.has_default():
+        kwargs['default'] = model_field.get_default()
+
     if model_field.has_default() or model_field.blank or model_field.null:
         kwargs['required'] = False
 


### PR DESCRIPTION
ModelSerializer no longer copies the 'default' setting from the model when loading the initial field list.
