### PR TITLE
allow serialization of blank choice if field is not required

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -928,6 +928,10 @@ class ChoiceField(Field):
         ])
 
         super(ChoiceField, self).__init__(**kwargs)
+        
+        if not self.required:
+            self.choices[''] = ''
+            self.choice_strings_to_values[''] = ''
 
     def to_internal_value(self, data):
         try:


### PR DESCRIPTION
When a ChoiceField is not required, a KeyError is raised when attempting to serialize a record where it has not been set.

This code prevents the error for an underlying CharField, but it seems likely that the fix belongs elsewhere or must be changed to work with other field types.
