### PR TITLE
Ensure _resolve_model does not return None

### DIFF
--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -43,7 +43,11 @@ def _resolve_model(obj):
     """
     if isinstance(obj, six.string_types) and len(obj.split('.')) == 2:
         app_name, model_name = obj.split('.')
-        return models.get_model(app_name, model_name)
+        resolved_model = models.get_model(app_name, model_name)
+        if not resolved_model:
+            raise ValueError("Django did not return a model for "
+                             "{0}.{1}".format(app_name, model_name))
+        return resolved_model
     elif inspect.isclass(obj) and issubclass(obj, models.Model):
         return obj
     raise ValueError("{0} is not a Django model".format(obj))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,8 @@ from rest_framework.utils.breadcrumbs import get_breadcrumbs
 from rest_framework.views import APIView
 from tests.models import BasicModel
 
+import rest_framework.utils.model_meta
+
 
 class Root(APIView):
     pass
@@ -130,3 +132,34 @@ class ResolveModelTests(TestCase):
     def test_resolve_improper_string_representation(self):
         with self.assertRaises(ValueError):
             _resolve_model('BasicModel')
+
+
+class ResolveModelWithPatchedDjangoTests(TestCase):
+    """
+    Test coverage for when Django's `get_model` returns `None`.
+
+    Under certain circumstances Django may return `None` with `get_model`:
+    http://git.io/get-model-source
+
+    It usually happens with circular imports so it is important that DRF
+    excepts early, otherwise fault happens downstream and is much more
+    difficult to debug.
+
+    """
+
+    def setUp(self):
+        """Monkeypatch get_model."""
+        self.get_model = rest_framework.utils.model_meta.models.get_model
+
+        def get_model(app_label, model_name):
+            return None
+
+        rest_framework.utils.model_meta.models.get_model = get_model
+
+    def tearDown(self):
+        """Revert monkeypatching."""
+        rest_framework.utils.model_meta.models.get_model = self.get_model
+
+    def test_blows_up_if_model_does_not_resolve(self):
+        with self.assertRaises(ValueError):
+            _resolve_model('tests.BasicModel')


### PR DESCRIPTION
Under certain circumstances Django may return `None` with `get_model`:
https://github.com/django/django/blob/1.6.7/django/db/models/loading.py#L265

It usually happens with circular imports so it is important that DRF excepts early, otherwise fault happens downstream and is much more difficult to debug.

The downstream failure looks something like:

```
Traceback (most recent call last):
  File "/lib/python2.7/site-packages/django/utils/autoreload.py", line 93, in wrapper
    fn(*args, **kwargs)
  File "/lib/python2.7/site-packages/django/core/management/commands/runserver.py", line 102, in inner_run
    self.validate(display_num_errors=True)
  File "/lib/python2.7/site-packages/django/core/management/base.py", line 310, in validate
    num_errors = get_validation_errors(s, app)
  File "/lib/python2.7/site-packages/django/core/management/validation.py", line 34, in get_validation_errors
    for (app_name, error) in get_app_errors().items():
  File "/lib/python2.7/site-packages/django/db/models/loading.py", line 196, in get_app_errors
    self._populate()
  File "/lib/python2.7/site-packages/django/db/models/loading.py", line 75, in _populate
    self.load_app(app_name, True)
  File "/lib/python2.7/site-packages/django/db/models/loading.py", line 99, in load_app
    models = import_module('%s.models' % app_name)
  File "/lib/python2.7/site-packages/django/utils/importlib.py", line 40, in import_module
    __import__(name)
...
[code with hidden circular import]
....
  File "/lib/python2.7/site-packages/rest_framework/serializers.py", line 204, in __init__
    self.fields = self.get_fields()
  File "/lib/python2.7/site-packages/rest_framework/serializers.py", line 240, in get_fields
    default_fields = self.get_default_fields()
  File "/lib/python2.7/site-packages/rest_framework/serializers.py", line 722, in get_default_fields
    field = self.get_related_field(model_field, related_model, to_many)
  File "/lib/python2.7/site-packages/rest_framework/serializers.py", line 824, in get_related_field
    'queryset': related_model._default_manager,
AttributeError: 'NoneType' object has no attribute '_default_manager'
```
