### PR TITLE
Set a version for django in tutorial

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -22,7 +22,7 @@ Before we do anything else we'll create a new virtual environment, using [virtua
 
 Now that we're inside a virtualenv environment, we can install our package requirements.
 
-    pip install django
+    pip install django==1.5.1
     pip install djangorestframework
     pip install pygments  # We'll be using this for the code highlighting
 


### PR DESCRIPTION
The latest version of django is not working for the tutorial.

I used this one since it's the one specified on https://github.com/tomchristie/rest-framework-tutorial/blob/master/requirements.txt and it works.
