### PR TITLE
Update mixins.py

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -114,7 +114,7 @@ class UpdateModelMixin(object):
     """
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
-        force_insert = kwargs.pop('force_insert', False)
+        force_insert = kwargs.pop('force_insert', True)
         self.object = self.get_object_or_none()
 
         serializer = self.get_serializer(self.object, data=request.DATA,


### PR DESCRIPTION
Availability to pass force_insert keyword arg to UpdateModelMixin.update() #1299
Explicit is better than implicit.
