### PR TITLE
Fixed get_component method in Field to get working with subclassess of collections.Mapping

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -10,6 +10,7 @@ import datetime
 import inspect
 import re
 import warnings
+import collections
 from decimal import Decimal, DecimalException
 from django import forms
 from django.core import validators
@@ -52,7 +53,7 @@ def get_component(obj, attr_name):
     Given an object, and an attribute name,
     return that attribute on the object.
     """
-    if isinstance(obj, dict):
+    if isinstance(obj, collections.Mapping):
         val = obj.get(attr_name)
     else:
         val = getattr(obj, attr_name)


### PR DESCRIPTION
Method get_components checks if object is instance of dictionary, but it fails when custom dict-alike implementations (especially subclasses of collections.Mapping) are used.
This commit adds checking for presence of dictionary interface methods on obj in method get_components.
