### PR TITLE
Makes it easy to change AuthToken model class when overriding built-in O...

### DIFF
--- a/rest_framework/authtoken/views.py
+++ b/rest_framework/authtoken/views.py
@@ -19,7 +19,7 @@ class ObtainAuthToken(APIView):
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():
             user = serializer.validated_data['user']
-            token, created = Token.objects.get_or_create(user=user)
+            token, created = self.model.objects.get_or_create(user=user)
             return Response({'token': token.key})
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
Makes it easy to change AuthToken model class when overriding built-in ObtainAuthToken view.
ObtainAuthToken view has a `model` attribute, but it uses a Token class whatever in `post()` method.
