### PR TITLE
Python 3 support to convert Token objects to str

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -37,3 +37,6 @@ class Token(models.Model):
 
     def __unicode__(self):
         return self.key
+        
+    def __str__(self):
+        return self.key


### PR DESCRIPTION
`__unicode__` method doesn't work on Python 3
