### PR TITLE
Use svg version of travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-[build-status-image]: https://secure.travis-ci.org/tomchristie/django-rest-framework.png?branch=master
+[build-status-image]: https://secure.travis-ci.org/tomchristie/django-rest-framework.svg?branch=master
 [travis]: http://travis-ci.org/tomchristie/django-rest-framework?branch=master
 [pypi-version]: https://pypip.in/version/djangorestframework/badge.svg
 [pypi]: https://pypi.python.org/pypi/djangorestframework


### PR DESCRIPTION
Hey. Just noticed that the travis build status badge uses the png version and not the svg one, so this extremely minor PR fixes that.

Looks especially much better on retina screens, also since the pypi badge already is svg. 

Thanks for making this, and have a great day!
