### PR TITLE
Added test to show potential issue with UniqueValidator being added to t...

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -20,6 +20,15 @@ class UniquenessSerializer(serializers.ModelSerializer):
         model = UniquenessModel
 
 
+class AnotherUniquenessModel(models.Model):
+    code = models.IntegerField(unique=True)
+
+
+class AnotherUniquenessSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AnotherUniquenessModel
+
+
 class TestUniquenessValidation(TestCase):
     def setUp(self):
         self.instance = UniquenessModel.objects.create(username='existing')
@@ -50,6 +59,17 @@ class TestUniquenessValidation(TestCase):
         serializer = UniquenessSerializer(self.instance, data=data)
         assert serializer.is_valid()
         assert serializer.validated_data == {'username': 'existing'}
+
+    def test_doesnt_pollute_model(self):
+        instance = AnotherUniquenessModel.objects.create(code='100')
+        serializer = AnotherUniquenessSerializer(instance)
+        self.assertEqual(
+            AnotherUniquenessModel._meta.get_field('code').validators, [])
+
+        # Accessing data shouldn't effect validators on the model
+        serializer.data
+        self.assertEqual(
+            AnotherUniquenessModel._meta.get_field('code').validators, [])
 
 
 # Tests for `UniqueTogetherValidator`


### PR DESCRIPTION
In our codebase we have models which are sometimes accessed through Django REST framework and sometimes with Django forms.

In the attached test case the UniqueValidator is being added to the underlying model field validators which causes issue when full_clean is run on the model.

The same doesn't happen to the `UniquenessModel` already in the test case. Not sure if this is because it has an additional validator (max_length) - I'll continue to dig.
