### PR TITLE
Escape \u2028 and \u2029 in JSON output.

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -102,6 +102,11 @@ class JSONRenderer(BaseRenderer):
         # and may (or may not) be unicode.
         # On python 3.x json.dumps() returns unicode strings.
         if isinstance(ret, six.text_type):
+            # We always fully escape \u2028 and \u2029 to ensure we output JSON
+            # that is a strict javascript subset. If bytes were returned
+            # by json.dumps() then we don't have these characters in any case.
+            # See: http://timelessrepo.com/json-isnt-a-javascript-subset
+            ret = ret.replace('\u2028', '\\u2028').replace('\u2029', '\\u2029')
             return bytes(ret.encode('utf-8'))
         return ret
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -384,6 +384,15 @@ class UnicodeJSONRendererTests(TestCase):
         content = renderer.render(obj, 'application/json')
         self.assertEqual(content, '{"countries":["United Kingdom","France","España"]}'.encode('utf-8'))
 
+    def test_u2028_u2029(self):
+        # The \u2028 and \u2029 characters should be escaped,
+        # even when the non-escaping unicode representation is used.
+        # Regression test for #2169
+        obj = {'should_escape': '\u2028\u2029'}
+        renderer = JSONRenderer()
+        content = renderer.render(obj, 'application/json')
+        self.assertEqual(content, '{"should_escape":"\\u2028\\u2029"}'.encode('utf-8'))
+
 
 class AsciiJSONRendererTests(TestCase):
     """


### PR DESCRIPTION
Closes #2169.
