### PR TITLE
Renamed validated_attrs to validated_data to be more in line with other code

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -110,21 +110,21 @@ The first thing we need to get started on our Web API is to provide a way of ser
         style = serializers.ChoiceField(choices=STYLE_CHOICES,
                                         default='friendly')
 
-        def create(self, validated_attrs):
+        def create(self, validated_data):
             """
             Create and return a new `Snippet` instance, given the validated data.
             """
-            return Snippet.objects.create(**validated_attrs)
+            return Snippet.objects.create(**validated_data)
 
-        def update(self, instance, validated_attrs):
+        def update(self, instance, validated_data):
             """
             Update and return an existing `Snippet` instance, given the validated data.
             """
-            instance.title = validated_attrs.get('title', instance.title)
-            instance.code = validated_attrs.get('code', instance.code)
-            instance.linenos = validated_attrs.get('linenos', instance.linenos)
-            instance.language = validated_attrs.get('language', instance.language)
-            instance.style = validated_attrs.get('style', instance.style)
+            instance.title = validated_data.get('title', instance.title)
+            instance.code = validated_data.get('code', instance.code)
+            instance.linenos = validated_data.get('linenos', instance.linenos)
+            instance.language = validated_data.get('language', instance.language)
+            instance.style = validated_data.get('style', instance.style)
             instance.save()
             return instance
 


### PR DESCRIPTION
The `create`and `update` methods in `BaseSerializer`and `ListSerializer` both take `validated_data`as an argument. Those same methods on `ModelSerializer`, however, take `validated_attrs`. This is confusing, especially considering that `validated_data` is used in the documentation for the changelog.
