### PR TITLE
Clarify read-only & `unique_together` Documentation

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -509,7 +509,7 @@ Model fields which have `editable=False` set, and `AutoField` fields will be set
 
 **Note**: There is a special-case where a read-only field is part of a `unique_together` constraint at the model level. Here you **must** specify the field explicitly and provide a valid default value.
 
-A common example of this is a read-only relation to currently authenticated `User` which is `unique_together` with another identifier. In this case you would declare the user field like so:
+A common example of this is a read-only relation to the currently authenticated `User` which is `unique_together` with another identifier. In this case you would declare the user field like so:
 
     user = serializers.PrimaryKeyRelatedField(read_only=True, default=serializers.CurrentUserDefault())
 


### PR DESCRIPTION
Fixes #2164 — assuming we're happy it's just a docs issue.

This adds the extra info I needed when I encountered the issue. 

As per suggestion in #2164, I'll have a look at also calling it out in the relevant tutorial section. 
