### PR TITLE
quickstart.md: fix instruction mistake. Don't cd to parent directory.

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -22,7 +22,6 @@ Create a new Django project named `tutorial`, then start a new app called `quick
     django-admin.py startproject tutorial
     cd tutorial
     django-admin.py startapp quickstart
-	cd ..
 
 Now sync your database for the first time:
 


### PR DESCRIPTION
There is a mistake in the quickstart instructions. By changing to the parent directory the command "python manage.py migrate” will fail. 

Example:
(...)
(env)oscr@Loke:~/tutorial/tutorial$ django-admin.py startapp quickstart
(env)oscr@Loke:~/tutorial/tutorial$ cd ..
(env)oscr@Loke:~/tutorial$ python manage.py migrate
python: can't open file 'manage.py': [Errno 2] No such file or directory
(env)oscr@Loke:~/tutorial$ cd -
/home/oscr/tutorial/tutorial
(env)oscr@Loke:~/tutorial/tutorial$ python manage.py migrate
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, sessions
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying sessions.0001_initial... OK
(env)oscr@Loke:~/tutorial/tutorial$ 
