### PR TITLE
Raise error if `fields` on serializer is not a list of strings.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -759,6 +759,12 @@ class ModelSerializer(Serializer):
         depth = getattr(self.Meta, 'depth', 0)
         extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
 
+        if fields and not isinstance(fields, (list, tuple)):
+            raise TypeError('`fields` must be a list or tuple')
+
+        if exclude and not isinstance(exclude, (list, tuple)):
+            raise TypeError('`exclude` must be a list or tuple')
+
         assert not (fields and exclude), "Cannot set both 'fields' and 'exclude'."
 
         extra_kwargs = self._include_additional_options(extra_kwargs)

--- a/tests/test_serializer_metaclass.py
+++ b/tests/test_serializer_metaclass.py
@@ -1,0 +1,62 @@
+from django.test import TestCase
+from rest_framework import serializers
+from .models import BasicModel
+
+
+class TestSerializerMetaClass(TestCase):
+    def setUp(self):
+        class FieldsSerializer(serializers.ModelSerializer):
+            text = serializers.CharField()
+
+            class Meta:
+                model = BasicModel
+                fields = ('text')
+
+        class ExcludeSerializer(serializers.ModelSerializer):
+            text = serializers.CharField()
+
+            class Meta:
+                model = BasicModel
+                exclude = ('text')
+
+        class FieldsAndExcludeSerializer(serializers.ModelSerializer):
+            text = serializers.CharField()
+
+            class Meta:
+                model = BasicModel
+                fields = ('text',)
+                exclude = ('text',)
+
+        self.fields_serializer = FieldsSerializer
+        self.exclude_serializer = ExcludeSerializer
+        self.faeSerializer = FieldsAndExcludeSerializer
+
+    def test_meta_class_fields(self):
+        object = BasicModel(text="Hello World.")
+        serializer = self.fields_serializer(instance=object)
+
+        with self.assertRaises(TypeError) as result:
+            serializer.data
+
+        exception = result.exception
+        self.assertEqual(str(exception), "`fields` must be a list or tuple")
+
+    def test_meta_class_exclude(self):
+        object = BasicModel(text="Hello World.")
+        serializer = self.exclude_serializer(instance=object)
+
+        with self.assertRaises(TypeError) as result:
+            serializer.data
+
+        exception = result.exception
+        self.assertEqual(str(exception), "`exclude` must be a list or tuple")
+
+    def test_meta_class_fields_and_exclude(self):
+        object = BasicModel(text="Hello World.")
+        serializer = self.faeSerializer(instance=object)
+
+        with self.assertRaises(AssertionError) as result:
+            serializer.data
+
+        exception = result.exception
+        self.assertEqual(str(exception), "Cannot set both 'fields' and 'exclude'.")


### PR DESCRIPTION
Refs #2193 
