### PR TITLE
Serializer must have data when calling is_valid

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -61,7 +61,6 @@ class BaseSerializer(Field):
     """
 
     def __init__(self, instance=None, data=None, **kwargs):
-        assert data is not None
         self.instance = instance
         self._initial_data = data
         self.partial = kwargs.pop('partial', False)
@@ -150,6 +149,7 @@ class BaseSerializer(Field):
         return self.instance
 
     def is_valid(self, raise_exception=False):
+        assert self._initial_data is not None
         assert not hasattr(self, 'restore_object'), (
             'Serializer `%s.%s` has old-style version 2 `.restore_object()` '
             'that is no longer compatible with REST framework 3. '

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -34,6 +34,11 @@ class TestSerializer:
         serializer = self.Serializer()
         assert serializer.data == {'char': '', 'integer': None}
 
+    def test_empty_serializer_validity(self):
+        serializer = self.Serializer()
+        with pytest.raises(AssertionError):
+            serializer.is_valid()
+
     def test_missing_attribute_during_serialization(self):
         class MissingAttributes:
             pass


### PR DESCRIPTION
@tomchristie this is the start of addressing this issue:
https://github.com/tomchristie/django-rest-framework/issues/2228
