### PR TITLE
Add allow_blank for ChoiceField #2184

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -958,9 +958,14 @@ class ChoiceField(Field):
             (six.text_type(key), key) for key in self.choices.keys()
         ])
 
+        self.allow_blank = kwargs.pop('allow_blank', False)
+
         super(ChoiceField, self).__init__(**kwargs)
 
     def to_internal_value(self, data):
+        if data == '' and self.allow_blank:
+            return ''
+
         try:
             return self.choice_strings_to_values[six.text_type(data)]
         except KeyError:

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -942,7 +942,7 @@ class ModelSerializer(Serializer):
                     # `ModelField`, which is used when no other typed field
                     # matched to the model field.
                     kwargs.pop('model_field', None)
-                if not issubclass(field_cls, CharField):
+                if not issubclass(field_cls, CharField) and not issubclass(field_cls, ChoiceField):
                     # `allow_blank` is only valid for textual fields.
                     kwargs.pop('allow_blank', None)
 

--- a/rest_framework/templates/rest_framework/horizontal/select.html
+++ b/rest_framework/templates/rest_framework/horizontal/select.html
@@ -4,7 +4,7 @@
     {% endif %}
     <div class="col-sm-10">
         <select class="form-control" name="{{ field.name }}">
-        {% if field.allow_null %}
+        {% if field.allow_null or field.allow_blank %}
             <option value="" {% if not field.value %}selected{% endif %}>--------</option>
         {% endif %}
         {% for key, text in field.choices.items %}

--- a/rest_framework/templates/rest_framework/inline/select.html
+++ b/rest_framework/templates/rest_framework/inline/select.html
@@ -3,7 +3,7 @@
         <label class="sr-only">{{ field.label }}</label>
     {% endif %}
     <select class="form-control" name="{{ field.name }}">
-        {% if field.allow_null %}
+        {% if field.allow_null or field.allow_blank %}
             <option value="" {% if not field.value %}selected{% endif %}>--------</option>
         {% endif %}
         {% for key, text in field.choices.items %}

--- a/rest_framework/templates/rest_framework/vertical/select.html
+++ b/rest_framework/templates/rest_framework/vertical/select.html
@@ -3,7 +3,7 @@
         <label {% if style.hide_label %}class="sr-only"{% endif %}>{{ field.label }}</label>
     {% endif %}
     <select class="form-control" name="{{ field.name }}">
-        {% if field.allow_null %}
+        {% if field.allow_null or field.allow_blank %}
             <option value="" {% if not field.value %}selected{% endif %}>--------</option>
         {% endif %}
         {% for key, text in field.choices.items %}

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -91,17 +91,17 @@ def get_field_kwargs(field_name, model_field):
     if model_field.has_default() or model_field.blank or model_field.null:
         kwargs['required'] = False
 
-    if model_field.flatchoices:
-        # If this model field contains choices, then return early.
-        # Further keyword arguments are not valid.
-        kwargs['choices'] = model_field.flatchoices
-        return kwargs
-
     if model_field.null and not isinstance(model_field, models.NullBooleanField):
         kwargs['allow_null'] = True
 
     if model_field.blank:
         kwargs['allow_blank'] = True
+
+    if model_field.flatchoices:
+        # If this model field contains choices, then return early.
+        # Further keyword arguments are not valid.
+        kwargs['choices'] = model_field.flatchoices
+        return kwargs
 
     # Ensure that max_length is passed explicitly as a keyword arg,
     # rather than as a validator.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -804,6 +804,21 @@ class TestChoiceField(FieldValues):
         ]
     )
 
+    def test_allow_blank(self):
+        """
+        If `allow_blank=True` then '' is a valid input.
+        """
+        field = serializers.ChoiceField(
+            allow_blank=True,
+            choices=[
+                ('poor', 'Poor quality'),
+                ('medium', 'Medium quality'),
+                ('good', 'Good quality'),
+            ]
+        )
+        output = field.run_validation('')
+        assert output is ''
+
 
 class TestChoiceFieldWithType(FieldValues):
     """


### PR DESCRIPTION
This makes a ChoiceField optional in HTML if model field has `blank=True` set.

Closes #2184.
