### PR TITLE
Don't needlessly call `.all()` when following queryset relationships.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -517,7 +517,7 @@ class ListSerializer(BaseSerializer):
         """
         List of object instances -> List of dicts of primitive datatypes.
         """
-        # Dealing with nested relationships, data can be a Manager, 
+        # Dealing with nested relationships, data can be a Manager,
         # so, first get a queryset from the Manager if needed
         iterable = data.all() if isinstance(data, models.Manager) else data
         return [


### PR DESCRIPTION
Treat the input queryset as it comes (maybe it has been changed in a higher level). Evaluating .all() does nothing if or if not is a queryset.
