### PR TITLE
Raise 401 error when login failed

### DIFF
--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -18,10 +18,10 @@ class AuthTokenSerializer(serializers.Serializer):
             if user:
                 if not user.is_active:
                     msg = _('User account is disabled.')
-                    raise exceptions.ValidationError(msg)
+                    raise exceptions.AuthenticationFailed(msg)
             else:
                 msg = _('Unable to log in with provided credentials.')
-                raise exceptions.ValidationError(msg)
+                raise exceptions.AuthenticationFailed(msg)
         else:
             msg = _('Must include "username" and "password"')
             raise exceptions.ValidationError(msg)


### PR DESCRIPTION
Authtoken was raising a 400 error code when trying to log in with invalid username/password when it should raise a 401 error (Unauthorized)
