### PR TITLE
Change serializers.Field to serializers.ReadOnlyField for 3.x compatibility

### DIFF
--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -128,7 +128,7 @@ For example, to nest a pair of links labelled 'prev' and 'next', and set the nam
 
     class CustomPaginationSerializer(pagination.BasePaginationSerializer):
         links = LinksSerializer(source='*')  # Takes the page object as the source
-        total_results = serializers.Field(source='paginator.count')
+        total_results = serializers.ReadOnlyField(source='paginator.count')
 
         results_field = 'objects'
 


### PR DESCRIPTION
Using this code snippet as-is on DRF 3.0.1 results in a NotImplementedError
being raised for `to_representation` due to 3.0's changed behavior with
serializers.Field. The code snippet should be updated to use
serializers.ReadOnlyField instead.

Further discussion here:
https://groups.google.com/forum/?fromgroups=#!topic/django-rest-framework/aX8mLT_v3yc
