### PR TITLE
Tutorial text consistency for Requests and Responses

### DIFF
--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -181,7 +181,7 @@ Similarly, we can control the format of the request that we send, using the `Con
         "id": 4,
         "title": "",
         "code": "print 456",
-        "linenos": true,
+        "linenos": false,
         "language": "python",
         "style": "friendly"
     }


### PR DESCRIPTION
If you look at the tutorial for Requests and Responses the tutorial creates a snippet via httpie as an example, but the default value for the second created snippet is not consistent with the tutorial's snippet model where lineno is false by default.

See here... http://www.django-rest-framework.org/tutorial/2-requests-and-responses/
