### PR TITLE
Documentation typo

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -104,7 +104,7 @@ This permission is suitable if you want your API to only be accessible to regist
 
 The `IsAdminUser` permission class will deny permission to any user, unless `user.is_staff` is `True` in which case permission will be allowed.
 
-This permission is suitable is you want your API to only be accessible to a subset of trusted administrators.
+This permission is suitable if you want your API to only be accessible to a subset of trusted administrators.
 
 ## IsAuthenticatedOrReadOnly
 


### PR DESCRIPTION
One more doc typo I noticed. You can tell I'm reading the documentation right now.
