### PR TITLE
Compatibility / feature request : replacement for get_default_fields()?

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -974,10 +974,7 @@ class ModelSerializer(Serializer):
                 kwargs = get_url_kwargs(model)
 
             else:
-                raise ImproperlyConfigured(
-                    'Field name `%s` is not valid for model `%s`.' %
-                    (field_name, model.__class__.__name__)
-                )
+                field_cls, kwargs = self.get_extra_field(field_name, model)
 
             # Check that any fields declared on the class are
             # also explicitly included in `Meta.fields`.
@@ -1012,6 +1009,12 @@ class ModelSerializer(Serializer):
             ret[field_name] = field
 
         return ret
+
+    def get_extra_field(self, field_name, model):
+        raise ImproperlyConfigured(
+            'Field name `%s` is not valid for model `%s`.' %
+            (field_name, model.__class__.__name__)
+        )
 
     def _include_additional_options(self, extra_kwargs):
         read_only_fields = getattr(self.Meta, 'read_only_fields', None)


### PR DESCRIPTION
Hello,

I am using [django-hvad](https://github.com/KristianOellegaard/django-hvad/) in my projects and used to have some glue code to make it work with restframework version 2. I used to be able to do this:

``` python
class TranslatableModelSerializer(ModelSerializer):
    # other stuff
    def get_default_fields(self):
        fields = super(TranslatableModelMixin, self).get_default_fields()
        fields.update(self._get_translated_fields())
        return fields
```

I am now in the process of switching to restframework v3. Unfortunately, it seems this method disappeared. The new way of getting serializer fields is a huge monolithic method, which is completely impossible to customize, as far as I see it.

I tried overriding `_get_default_field_names`, but it fails at a later point, because additional field names are not known to the new `get_fields` method, causing it to raise an `ImproperlyConfigured('Field name`%s`is not valid for model`%s`.')` exception.

What I would love to see is a that the `get_fields` method from `ModelSerializer` gives a chance for a derived class to provide info (namely, `field_cls` and `kwargs`) for custom fields before raising.

I attached a PR to show what I have in mind.
