### PR TITLE
When validating input prevent `serializer.data` being accessed until `.is_valid()` is called.

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -240,6 +240,12 @@ Serializer classes can also include reusable validators that are applied to the 
 
 For more information see the [validators documentation](validators.md).
 
+## Accessing the initial data and instance
+
+When passing an initial object or queryset to a serializer instance, the object will be made available as `.instance`. If no initial object is passed then the `.instance` attribute will be `None`.
+
+When passing data to a serializer instance, the unmodified data will be made available as `.initial_data`. If the data keyword argument is not passed then the `.initial_data` attribute will not exist.
+
 ## Partial updates
 
 By default, serializers must be passed values for all required fields or they will raise validation errors. You can use the `partial` argument in order to allow partial updates.

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -79,16 +79,14 @@ class GenericAPIView(views.APIView):
             'view': self
         }
 
-    def get_serializer(self, instance=None, data=None, many=False, partial=False):
+    def get_serializer(self, *args, **kwargs):
         """
         Return the serializer instance that should be used for validating and
         deserializing input, and for serializing output.
         """
         serializer_class = self.get_serializer_class()
-        context = self.get_serializer_context()
-        return serializer_class(
-            instance, data=data, many=many, partial=partial, context=context
-        )
+        kwargs['context'] = self.get_serializer_context()
+        return serializer_class(*args, **kwargs)
 
     def get_pagination_serializer(self, page):
         """

--- a/tests/test_bound_fields.py
+++ b/tests/test_bound_fields.py
@@ -22,7 +22,7 @@ class TestSimpleBoundField:
             amount = serializers.IntegerField()
 
         serializer = ExampleSerializer(data={'text': 'abc', 'amount': 123})
-
+        assert serializer.is_valid()
         assert serializer['text'].value == 'abc'
         assert serializer['text'].errors is None
         assert serializer['text'].name == 'text'


### PR DESCRIPTION
Closes #2289.

If `data=` is passed then ensure that user cannot access `.serializer.data` without first calling `.is_valid()`
