### PR TITLE
Update exceptions.py

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -39,10 +39,10 @@ class APIException(Exception):
     default_detail = _('A server error occured')
 
     def __init__(self, detail=None):
-        if detail is not None:
-            self.detail = force_text(detail)
-        else:
+        if detail is None:
             self.detail = force_text(self.default_detail)
+        elif isinstance(detail, basestring):
+            self.detail = force_text(detail)
 
     def __str__(self):
         return self.detail


### PR DESCRIPTION
Call force_text() only if detail is a string, if detail is other data type better leave raw. The idea is give the programmer the possibility to manage other detail data type when catch the exception
