### PR TITLE
Assert fields in `exclude` are model fields

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -880,6 +880,10 @@ class ModelSerializer(Serializer):
             exclude = getattr(self.Meta, 'exclude', None)
             if exclude is not None:
                 for field_name in exclude:
+                    assert field_name in fields, (
+                        'The field in the `exclude` option must be a model field. Got %s.' %
+                        field_name
+                    )
                     fields.remove(field_name)
 
         # Determine the set of model fields, and the fields that they map to.


### PR DESCRIPTION
I guess something changed in the way DRF 3 includes default many-to-many fields for `ModelSerializer`, because as soon as I upgraded I got this unhelpful stack-trace:

```
Traceback:
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/django/core/handlers/base.py" in get_response
  111.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/django/views/decorators/csrf.py" in wrapped_view
  57.         return view_func(*args, **kwargs)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/viewsets.py" in view
  85.             return self.dispatch(request, *args, **kwargs)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/views.py" in dispatch
  407.             response = self.handle_exception(exc)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/views.py" in dispatch
  404.             response = handler(request, *args, **kwargs)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/mixins.py" in list
  46.         return Response(serializer.data)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in data
  422.         ret = super(Serializer, self).data
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in data
  177.                 self._data = self.to_representation(self.instance)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in to_representation
  391.                 ret[field.field_name] = field.to_representation(attribute)
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in to_representation
  524.             self.child.to_representation(item) for item in iterable
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in <listcomp>
  524.             self.child.to_representation(item) for item in iterable
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in to_representation
  384.         fields = [field for field in self.fields.values() if not field.write_only]
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in fields
  277.             for key, value in self.get_fields().items():
File "/Users/maryokhin/.virtualenvs/backend-drf3/lib/python3.4/site-packages/rest_framework/serializers.py" in get_fields
  846.                     fields.remove(field_name)

Exception Type: ValueError at /channels/
Exception Value: list.remove(x): x not in list
```

Before I had to exclude this field specifically, now it's not even there.
