### PR TITLE
Don't try to iterate Nonetype objects when serializing  many=True

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -571,7 +571,10 @@ class BaseSerializer(WritableField):
                                   DeprecationWarning, stacklevel=2)
 
             if many:
-                self._data = [self.to_native(item) for item in obj]
+                if hasattr(obj, '__iter__'):
+                    self._data = [self.to_native(item) for item in obj]
+                else:
+                    self._data = []
             else:
                 self._data = self.to_native(obj)
 

--- a/tests/test_serializer_empty.py
+++ b/tests/test_serializer_empty.py
@@ -13,3 +13,16 @@ class EmptySerializerTestCase(TestCase):
 
         serializer = FooBarSerializer()
         self.assertEquals(serializer.data, {'foo': 0})
+
+    def test_serializing_none(self):
+        class FooBarSerializer(serializers.Serializer):
+            foo = serializers.IntegerField()
+            bar = serializers.SerializerMethodField('get_bar')
+
+            def get_bar(self, obj):
+                return 'bar'
+
+        serializer = FooBarSerializer(None, many=True)
+        self.assertEquals(serializer.data, [])
+
+


### PR DESCRIPTION
  Added test for serializing None in a many=True situation.

Current 2.4.x code crashes if you try to serialize a model.objects.none() with many=True.  This corrects that and provides a test that fails with the existing code and passes with this PR.
