### PR TITLE
[DONT MERGE] Failing test to illustrate #2333

### DIFF
--- a/tests/namespaced_urls.py
+++ b/tests/namespaced_urls.py
@@ -1,0 +1,32 @@
+from django.conf.urls import url, include
+from django.db import models
+
+from rest_framework import serializers, viewsets, routers
+
+
+class NamespacedRouterTestModel(models.Model):
+    uuid = models.CharField(max_length=20)
+    text = models.CharField(max_length=200)
+
+
+class NoteSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name='api-namespace:routertestmodel-detail', lookup_field='uuid')
+
+    class Meta:
+        model = NamespacedRouterTestModel
+        fields = ('url', 'uuid', 'text')
+
+
+class NoteViewSet(viewsets.ModelViewSet):
+    queryset = NamespacedRouterTestModel.objects.all()
+    serializer_class = NoteSerializer
+    lookup_field = 'uuid'
+
+router = routers.DefaultRouter()
+
+router.register(r'note', NoteViewSet)
+
+
+urlpatterns = [
+    url('^namespaced-api/', include(router.urls, namespace='api-namespace')),
+]

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -321,3 +321,13 @@ class TestRootWithAListlessViewset(TestCase):
         request = factory.get('/')
         response = self.view(request)
         self.assertEqual(response.data, {})
+
+
+class TestNamespacedDefaultRouter(TestCase):
+    urls = 'tests.namespaced_urls'
+
+    def test_api_root(self):
+        from django.core.urlresolvers import reverse
+        url = reverse('api-namespace:api-root')
+        response = self.client.get(url)
+        self.assertEqual(response.data['note'], 'http://testserver/namespaced-api/note/')


### PR DESCRIPTION
@thedrow asked me to provide a pull request with just the failing test case to illustrate the problem being discussed in #2333, namely that the DefaultRouter API Root does not support namespaced URLs.
