### PR TITLE
Add support for namespaces in APIRoot.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -189,6 +189,15 @@ class RequestFactory(DjangoRequestFactory):
         return self.request(**r)
 
 
+# request only provides `resolver_match` from 1.5 onwards.
+def get_resolver_match(request):
+    try:
+        return request.resolver_match
+    except AttributeError:  # Django < 1.5
+        from django.core.urlresolvers import resolve
+        return resolve(request.path_info)
+
+
 # Markdown is optional
 try:
     import markdown

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -21,7 +21,7 @@ from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 from rest_framework import views
-from rest_framework.compat import OrderedDict
+from rest_framework.compat import OrderedDict, get_resolver_match
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.urlpatterns import format_suffix_patterns
@@ -290,9 +290,19 @@ class DefaultRouter(SimpleRouter):
         class APIRoot(views.APIView):
             _ignore_model_permissions = True
 
+            def get_namespace(self):
+                """
+                Attempt to retrieve the namespace of the current router.
+                """
+                resolver_match = get_resolver_match(self.request)
+                return resolver_match.namespace
+
             def get(self, request, *args, **kwargs):
                 ret = OrderedDict()
+                namespace = self.get_namespace()
                 for key, url_name in api_root_dict.items():
+                    if namespace:
+                        url_name = namespace + ':' + url_name
                     try:
                         ret[key] = reverse(
                             url_name,

--- a/tests/router_test_urls.py
+++ b/tests/router_test_urls.py
@@ -1,0 +1,32 @@
+from django.conf.urls import url, include
+
+from rest_framework import viewsets, mixins, routers
+
+from .test_routers import APIRootTestModel
+
+
+class APIRootTestViewSet(viewsets.ModelViewSet):
+    model = APIRootTestModel
+
+
+class ListlessViewSet(mixins.RetrieveModelMixin,
+                      viewsets.GenericViewSet):
+    model = APIRootTestModel
+
+
+router = routers.DefaultRouter()
+router.register(r'test-model', APIRootTestViewSet)
+
+
+listless_router = routers.DefaultRouter()
+# Avoid conflict with the api/ route.
+listless_router.root_view_name = 'listless-api-root'
+listless_router.register(r'full', APIRootTestViewSet, 'full')
+listless_router.register(r'listless', ListlessViewSet, 'listless')
+
+
+urlpatterns = [
+    url(r'^api/', include(router.urls)),
+    url(r'^namespaced-api/', include(router.urls, namespace='api-namespace')),
+    url(r'^listless/', include(listless_router.urls)),
+]


### PR DESCRIPTION
This pull request supercedes #2333, #2350 and is in response to #2351.
## Problem

The DefaultRouter API Root does not support namespaced URLs.
## How this PR attempts to resolve it

[@tomchristie recommended this](https://github.com/tomchristie/django-rest-framework/issues/2351#issuecomment-68061984)

> The API root view can inspect the incoming request, determine the namespace if there is one on the request object, and modify the view names accordingly if so.

So that's how this pull request attempts to resolve the issue.
## Things I'm not satisfied with about this PR

The implementation of `get_namespace` is more complicated than it should be, but only because it has to support tests in two ways:
1. The default Django request handlers add a resolver_match object to the request, but the tests don't provide that
2. Some tests send requests to the APIRoot using a fake request with the url `'/'`, which triggers a Resolver404.

Were it not for those two problems, the implementation would simply be `namespace = request.resolver_match.namespace`.

Thank you for your time and patience with this series of pull requests.
