### PR TITLE
[don't merge] TestRootWithAListlessViewset problem

### DIFF
--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -309,15 +309,20 @@ class TestDynamicListAndDetailRouter(TestCase):
 
 class TestRootWithAListlessViewset(TestCase):
     def setUp(self):
-        class NoteViewSet(mixins.RetrieveModelMixin,
-                          viewsets.GenericViewSet):
+        class ListlessNoteViewSet(mixins.RetrieveModelMixin,
+                                  viewsets.GenericViewSet):
+            model = RouterTestModel
+
+        class FullNoteViewSet(viewsets.ModelViewSet):
             model = RouterTestModel
 
         self.router = DefaultRouter()
-        self.router.register(r'notes', NoteViewSet)
+        self.router.register(r'listless', ListlessNoteViewSet, 'listless')
+        self.router.register(r'listfull', ListlessNoteViewSet, 'listfull')
         self.view = self.router.urls[0].callback
 
     def test_api_root(self):
         request = factory.get('/')
         response = self.view(request)
-        self.assertEqual(response.data, {})
+        self.assertIn('listfull', response.data)
+        self.assertNotIn('listless', response.data)


### PR DESCRIPTION
This modifies the TestDynamicListAndDetailRouter testcase to demonstrate
that the way it is written is broken. Fortunately it is just the test
that is broken and not the actual APIRoot code.

The reason this test fails is that router created in
TestRootWithAListlessViewset.setUp is never installed into the URLs.
When APIRoot attempts to reverse the URLs in APIRoot.get. The URL
reversal for the ListlessNoteViewSet should fail because it doesn't have
a list action, but the FullNoteViewSet does have a list action, the
reason it fails is that the URLs were never installed.

The easiest way to resolve this would be to move the Router declaration to a separate URLs file like in #2354. I don't know if I should do that in the same PR though.
