### PR TITLE
Allow to customize the dictionary class used by the serializers

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -79,6 +79,7 @@ class BaseSerializer(Field):
     .errors - Not available.
     .data - Available.
     """
+    _dict_class = OrderedDict
 
     def __init__(self, instance=None, data=empty, **kwargs):
         self.instance = instance
@@ -268,7 +269,7 @@ class SerializerMetaclass(type):
             if hasattr(base, '_declared_fields'):
                 fields = list(base._declared_fields.items()) + fields
 
-        return OrderedDict(fields)
+        return attrs.get('_dict_class', OrderedDict)(fields)
 
     def __new__(cls, name, bases, attrs):
         attrs['_declared_fields'] = cls._get_declared_fields(bases, attrs)
@@ -358,14 +359,14 @@ class Serializer(BaseSerializer):
 
     def get_initial(self):
         if hasattr(self, 'initial_data'):
-            return OrderedDict([
+            return self._dict_class([
                 (field_name, field.get_value(self.initial_data))
                 for field_name, field in self.fields.items()
                 if (field.get_value(self.initial_data) is not empty) and
                 not field.read_only
             ])
 
-        return OrderedDict([
+        return self._dict_class([
             (field.field_name, field.get_initial())
             for field in self.fields.values()
             if not field.read_only
@@ -410,8 +411,8 @@ class Serializer(BaseSerializer):
                 api_settings.NON_FIELD_ERRORS_KEY: [message]
             })
 
-        ret = OrderedDict()
-        errors = OrderedDict()
+        ret = self._dict_class()
+        errors = self._dict_class()
         fields = self._writable_fields
 
         for field in fields:
@@ -439,7 +440,7 @@ class Serializer(BaseSerializer):
         """
         Object instance -> Dict of primitive datatypes.
         """
-        ret = OrderedDict()
+        ret = self._dict_class()
         fields = self._readable_fields
 
         for field in fields:
@@ -904,7 +905,7 @@ class ModelSerializer(Serializer):
         )
 
         # Determine the fields that should be included on the serializer.
-        fields = OrderedDict()
+        fields = self._dict_class()
 
         for field_name in field_names:
             # If the field is explicitly declared on the class then use that.


### PR DESCRIPTION
This used to be available in DRF 2.x but isn't anymore.
There is value in allowing people to pick regular dicts over oredered dicts or even other mapping types which work better.
