### PR TITLE
add the namespace when rendering related fields

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -271,6 +271,11 @@ class HyperlinkedRelatedField(RelatedField):
 
         lookup_value = getattr(obj, self.lookup_field)
         kwargs = {self.lookup_url_kwarg: lookup_value}
+
+        namespace = request.resolver_match.namespace
+        if namespace and not view_name.startswith(namespace + ':'):
+            view_name = namespace + ':' + view_name
+
         return self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
     def get_name(self, obj):


### PR DESCRIPTION
I ran into the HyperlinkedRelationField / url namespace bug (#3291 #2760), and I wondered if it couldn't be fixed in a simple way. [The routers.py](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/routers.py#L289) file already does this. Off the top of my head I'm not sure when this might break.

Thinking about it I expect the namespaced view name should be passed via the constructor. Still, would be good to have some progress on this, and a hint as to where the tests would belong and what additional documentation is appropriate would be appreciated.
