### PR TITLE
Add tests for M2M relations with inheritance and a through model

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -41,6 +41,24 @@ class ManyToManySource(RESTFrameworkModel):
     targets = models.ManyToManyField(ManyToManyTarget, related_name='sources')
 
 
+# ManyToMany with inheritance and a through model
+class ManyToManyThroughTarget(RESTFrameworkModel):
+    name = models.CharField(max_length=100)
+
+
+class ManyToManyThroughSource(ManyToManyThroughTarget):
+    name2 = models.CharField(max_length=100)
+    targets = models.ManyToManyField(ManyToManyThroughTarget,
+                                     through='ManyToManyThrough',
+                                     related_name='sources')
+
+
+class ManyToManyThrough(RESTFrameworkModel):
+    name = models.CharField(max_length=100)
+    source = models.ForeignKey(ManyToManyThroughSource, related_name='through')
+    target = models.ForeignKey(ManyToManyThroughTarget, related_name='through')
+
+
 # ForeignKey
 class ForeignKeyTarget(RESTFrameworkModel):
     name = models.CharField(max_length=100)


### PR DESCRIPTION
This particular setup worked fine up to DRF 3.2.5, but is broken in DRF
3.3.0.  Bisecting indicates that 322bda815969a49140ed02cab304e13e63b059d5
first introduced the regression.

This commit adds a few testcases that pass with DRF 3.2.5 but fail with
DRF 3.3.0 and newer.
