### PR TITLE
ListField data entered in HTML form view should be converted to list

### DIFF
--- a/tests/test_serializer_lists.py
+++ b/tests/test_serializer_lists.py
@@ -51,6 +51,16 @@ class TestListSerializer:
         serializer = self.Serializer(data=input_data)
         assert serializer.is_valid()
         assert serializer.validated_data == expected_output
+    
+    def test_validate_html_form_field_input(self):
+        """
+        HTML input should be able to mock list structures entered as an HTML text field.
+        """
+        input_data = "[123, 456]"
+        expected_output = [123, 456]
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == expected_output
 
 
 class TestListSerializerContainingNestedSerializer:


### PR DESCRIPTION
## Description

This initial PullRequest is just to start the conversation; at the moment this consists simply of a new test that fails until I have a better grasp on what all the right tests are and if this is being approached correctly.

If using the HTML view of the interface to the REST framework, it is not possible to enter ListField data (as far as I can tell). This test verifies that ListField fields can accept pure string input and convert them to a proper list prior to validation.

I am not very knowledgable in how all the testing is set up for DRF, so I might be putting the test in the wrong place. Similar tests should probably also be created for other complex field types. And if this is already supported and I just don't understand how to use the interface, then let me know so I can document the right way to enter ListField data using the HTML interface.
