### PR TITLE
serializers: fix ListSerializer.get_value

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -545,6 +545,10 @@ class ListSerializer(BaseSerializer):
         # We override the default field access in order to support
         # lists in HTML forms.
         if html.is_html_input(dictionary):
+            if self.field_name not in dictionary:
+                if getattr(self.root, 'partial', False):
+                    return empty
+
             return html.parse_html_list(dictionary, prefix=self.field_name)
         return dictionary.get(self.field_name, empty)
 


### PR DESCRIPTION
It should return `empty` for non present field on partial updates when using
HTML input.
