### PR TITLE
Set self.count before self.limit in LimitOffsetPagination

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -303,12 +303,12 @@ class LimitOffsetPagination(BasePagination):
     template = 'rest_framework/pagination/numbers.html'
 
     def paginate_queryset(self, queryset, request, view=None):
+        self.count = _get_count(queryset)
         self.limit = self.get_limit(request)
         if self.limit is None:
             return None
 
         self.offset = self.get_offset(request)
-        self.count = _get_count(queryset)
         self.request = request
         if self.count > self.limit and self.template is not None:
             self.display_page_controls = True


### PR DESCRIPTION
Just a minor change.
## Description

By setting **self.count** before **self.limit** in the **LimitOffsetPagination** it is possible, if one wants, to override **get_limit** in order to return all records if the request has a predefined param.

For example, if one wants that all records are retrieved if url has &limit=-1, in this case, **get_limit** could return **self.count**.

Otherwise, if **self.count** is set after **self.limit** then, to achieve the same result, one has to override **get_limit** and **paginate_queryset**, or run **get_limit** twice.
