### PR TITLE
Serializer - one level copy instead of deepcopy

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -14,6 +14,7 @@ from __future__ import unicode_literals
 
 import traceback
 
+import six
 from django.db import models
 from django.db.models import DurationField as ModelDurationField
 from django.db.models.fields import Field as DjangoModelField
@@ -358,7 +359,7 @@ class Serializer(BaseSerializer):
         # Every new serializer is created with a clone of the field instances.
         # This allows users to dynamically modify the fields on a serializer
         # instance without affecting every other serializer class.
-        return copy.deepcopy(self._declared_fields)
+        return OrderedDict((k, copy.copy(v)) for k, v in six.iteritems(self._declared_fields))
 
     def get_validators(self):
         """


### PR DESCRIPTION
Hi Tom, This is Lavender from Monetate; we met at DjangoCon earlier this year.  
## Description

Small change to address some performance issues with serialisers.  `deepcopy` seems to be a fairly expensive operation during initialisation, and it appears that you don't need a `deepcopy` (which may contain nested fields), just a copy of the first level of fields.  

I'm seeing about a 30% improvement with this change (Python 2.7.11; Django 1.8.13; DRF 3.4.7; Mac Book Pro 2015, El Capitan):

``` python
from rest_framework import serializers

class TestSerializer(serializers.Serializer):
    char_field = serializers.CharField(max_length=30, required=True)
    float_field = serializers.FloatField(required=True)
    bool_field = serializers.BooleanField(required=True)
    list_field = serializers.ListField(child=serializers.IntegerField(), required=True)

good_data = {
    "char_field": "hello world",
    "float_field": "1234.5678",
    "bool_field": "true",
    "list_field": [1, 2, 3, 4, 5]

}

bad_data = {
    "char_field": ["not", "a", "string"],
    "float_field": "yeah, whatev",
    "bool_field": None,
    "list_field": {"its": "not", "a": "list"}
}
```

``` python
%%timeit

ser1 = TestSerializer(data=good_data)
ser1.is_valid()
ser1.data
ser1.errors

ser2 = TestSerializer(data=bad_data)
ser2.is_valid()
ser2.data
ser2.errors
```

Before change:
`1000 loops, best of 3: 826 µs per loop`
After change:
`1000 loops, best of 3: 568 µs per loop`
