### PR TITLE
WIP: Don't convert json to Infinity/NaN

### DIFF
--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -6,10 +6,10 @@ from __future__ import unicode_literals
 import datetime
 import decimal
 import json
-from json.encoder import (FLOAT_REPR, INFINITY, c_make_encoder, 
-                          encode_basestring_ascii, encode_basestring, 
-                          _make_iterencode)
 import uuid
+from json.encoder import (FLOAT_REPR, INFINITY, _make_iterencode,
+                          c_make_encoder, encode_basestring,
+                          encode_basestring_ascii)
 
 from django.db.models.query import QuerySet
 from django.utils import six, timezone
@@ -55,7 +55,7 @@ class JSONEncoder(json.JSONEncoder):
                 return _orig_encoder(o)
 
         def floatstr(o, allow_nan=self.allow_nan,
-                _repr=FLOAT_REPR, _inf=INFINITY, _neginf=-INFINITY):
+                     _repr=FLOAT_REPR, _inf=INFINITY, _neginf=-INFINITY):
             # Check for specials.  Note that this type of test is processor
             # and/or platform-specific, so do tests which don't depend on the
             # internals.
@@ -75,7 +75,6 @@ class JSONEncoder(json.JSONEncoder):
                     repr(o))
 
             return text
-
 
         if (_one_shot and c_make_encoder is not None
                 and self.indent is None):
@@ -124,7 +123,7 @@ class JSONEncoder(json.JSONEncoder):
         elif hasattr(obj, 'tolist'):
             # Numpy arrays and array scalars.
             return obj.tolist()
-        elif (coreapi is not None) and isinstance(obj, (coreapi.Document, 
+        elif (coreapi is not None) and isinstance(obj, (coreapi.Document,
                                                         coreapi.Error)):
             raise RuntimeError(
                 'Cannot return a coreapi object from a JSON view. '

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -7,7 +7,7 @@ import datetime
 import decimal
 import json
 import uuid
-from json.encoder import (FLOAT_REPR, INFINITY, _make_iterencode,
+from json.encoder import (INFINITY, _make_iterencode,
                           encode_basestring, encode_basestring_ascii)
 
 from django.db.models.query import QuerySet
@@ -16,6 +16,11 @@ from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
 from rest_framework.compat import coreapi, total_seconds
+
+try:
+    from json.encoder import FLOAT_REPR
+except:
+    FLOAT_REPR = float.__repr__
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -46,12 +51,6 @@ class JSONEncoder(json.JSONEncoder):
                     if isinstance(o, str):
                         o = o.decode(_encoding)
                     return _orig_encoder(o)
-
-        if self.encoding != 'utf-8':
-            def _encoder(o, _orig_encoder=_encoder, _encoding=self.encoding):
-                if isinstance(o, str):
-                    o = o.decode(_encoding)
-                return _orig_encoder(o)
 
         def floatstr(o, allow_nan=self.allow_nan,
                      _repr=FLOAT_REPR, _inf=INFINITY, _neginf=-INFINITY):

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -8,8 +8,7 @@ import decimal
 import json
 import uuid
 from json.encoder import (FLOAT_REPR, INFINITY, _make_iterencode,
-                          c_make_encoder, encode_basestring,
-                          encode_basestring_ascii)
+                          encode_basestring, encode_basestring_ascii)
 
 from django.db.models.query import QuerySet
 from django.utils import six, timezone
@@ -76,18 +75,10 @@ class JSONEncoder(json.JSONEncoder):
 
             return text
 
-        if (_one_shot and c_make_encoder is not None
-                and self.indent is None):
-            _iterencode = c_make_encoder(
-                markers, self.default, _encoder, self.indent,
-                self.key_separator, self.item_separator, self.sort_keys,
-                self.skipkeys, self.allow_nan)
-        else:
-            _iterencode = _make_iterencode(
-                markers, self.default, _encoder, self.indent, floatstr,
-                self.key_separator, self.item_separator, self.sort_keys,
-                self.skipkeys, _one_shot)
-        return _iterencode(o, 0)
+        return _make_iterencode(markers, self.default, _encoder, self.indent,
+                                floatstr, self.key_separator,
+                                self.item_separator, self.sort_keys,
+                                self.skipkeys, _one_shot)(o, 0)
 
     def default(self, obj):
         # For Date Time string spec, see ECMA 262

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -6,6 +6,9 @@ from __future__ import unicode_literals
 import datetime
 import decimal
 import json
+from json.encoder import (FLOAT_REPR, INFINITY, c_make_encoder, 
+                          encode_basestring_ascii, encode_basestring, 
+                          _make_iterencode)
 import uuid
 
 from django.db.models.query import QuerySet
@@ -21,6 +24,72 @@ class JSONEncoder(json.JSONEncoder):
     JSONEncoder subclass that knows how to encode date/time/timedelta,
     decimal types, generators and other basic python objects.
     """
+
+    def iterencode(self, o, _one_shot=False):
+        """Encode the given object and yield each string
+        representation as available.
+        For example::
+            for chunk in JSONEncoder().iterencode(bigobject):
+                mysocket.write(chunk)
+        """
+        if self.check_circular:
+            markers = {}
+        else:
+            markers = None
+        if self.ensure_ascii:
+            _encoder = encode_basestring_ascii
+        else:
+            _encoder = encode_basestring
+        if six.PY2:
+            if self.encoding != 'utf-8':
+                def _encoder(o, _orig_encoder=_encoder,
+                             _encoding=self.encoding):
+                    if isinstance(o, str):
+                        o = o.decode(_encoding)
+                    return _orig_encoder(o)
+
+        if self.encoding != 'utf-8':
+            def _encoder(o, _orig_encoder=_encoder, _encoding=self.encoding):
+                if isinstance(o, str):
+                    o = o.decode(_encoding)
+                return _orig_encoder(o)
+
+        def floatstr(o, allow_nan=self.allow_nan,
+                _repr=FLOAT_REPR, _inf=INFINITY, _neginf=-INFINITY):
+            # Check for specials.  Note that this type of test is processor
+            # and/or platform-specific, so do tests which don't depend on the
+            # internals.
+
+            if o != o:
+                text = 'null'
+            elif o == _inf:
+                text = 'null'
+            elif o == _neginf:
+                text = 'null'
+            else:
+                return _repr(o)
+
+            if not allow_nan:
+                raise ValueError(
+                    "Out of range float values are not JSON compliant: " +
+                    repr(o))
+
+            return text
+
+
+        if (_one_shot and c_make_encoder is not None
+                and self.indent is None):
+            _iterencode = c_make_encoder(
+                markers, self.default, _encoder, self.indent,
+                self.key_separator, self.item_separator, self.sort_keys,
+                self.skipkeys, self.allow_nan)
+        else:
+            _iterencode = _make_iterencode(
+                markers, self.default, _encoder, self.indent, floatstr,
+                self.key_separator, self.item_separator, self.sort_keys,
+                self.skipkeys, _one_shot)
+        return _iterencode(o, 0)
+
     def default(self, obj):
         # For Date Time string spec, see ECMA 262
         # http://ecma-international.org/ecma-262/5.1/#sec-15.9.1.15
@@ -55,7 +124,8 @@ class JSONEncoder(json.JSONEncoder):
         elif hasattr(obj, 'tolist'):
             # Numpy arrays and array scalars.
             return obj.tolist()
-        elif (coreapi is not None) and isinstance(obj, (coreapi.Document, coreapi.Error)):
+        elif (coreapi is not None) and isinstance(obj, (coreapi.Document, 
+                                                        coreapi.Error)):
             raise RuntimeError(
                 'Cannot return a coreapi object from a JSON view. '
                 'You should be using a schema renderer instead for this view.'

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -59,11 +59,11 @@ class JSONEncoder(json.JSONEncoder):
             # internals.
 
             if o != o:
-                text = 'null'
+                text = '"NaN"'
             elif o == _inf:
-                text = 'null'
+                text = '"Infinity"'
             elif o == _neginf:
-                text = 'null'
+                text = '"-Infinity"'
             else:
                 return _repr(o)
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from uuid import uuid4
@@ -92,3 +93,11 @@ class JSONEncoderTests(TestCase):
         """
         foo = MockList()
         assert self.encoder.default(foo) == [1, 2, 3]
+
+    def test_encode_float(self):
+        """
+        Tests encoding floats with special values
+        """
+
+        f = [3.141592653, float('inf'), float('-inf'), float('nan')]
+        assert json.dumps(f, cls=JSONEncoder) == '[3.141592653, "Infinity", "-Infinity", "NaN"]'

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,10 +1,12 @@
-import json
+# -*- coding: utf-8 -*-
+
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from uuid import uuid4
 
 import pytest
 from django.test import TestCase
+from django.utils import six
 from django.utils.timezone import utc
 
 from rest_framework.compat import coreapi
@@ -100,4 +102,21 @@ class JSONEncoderTests(TestCase):
         """
 
         f = [3.141592653, float('inf'), float('-inf'), float('nan')]
-        assert json.dumps(f, cls=JSONEncoder) == '[3.141592653, "Infinity", "-Infinity", "NaN"]'
+        assert self.encoder.encode(f) == '[3.141592653, "Infinity", "-Infinity", "NaN"]'
+
+        encoder = JSONEncoder(allow_nan=False)
+        try:
+            encoder.encode(f)
+        except ValueError:
+            pass
+        else:
+            assert False
+
+    def test_encode_string(self):
+        """
+        Tests encoding string
+        """
+
+        if six.PY2:
+            encoder2 = JSONEncoder(encoding='latin_1', check_circular=False)
+            assert encoder2.encode(['foo☺']) == '["foo\\u00e2\\u0098\\u00ba"]'


### PR DESCRIPTION
## Problem

By design, json.dumps extends json

```python
>>> json.dumps({'x': float('inf')})
'{"x": Infinity}’
```

However when you tell it to disable allow_nan, it throws an exception instead

```python
>>> json.dumps({'x': float('inf')}, allow_nan=False)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/json/__init__.py", line 251, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant
```

## Desired result

I choose the [Same as Chrome/Firefox](#Other_possibility) route, so,

```python
>>> json.dumps({'x': float('inf')}, cls=rest_framework.utils.encoder.JSONEncoder)
'{"x": null}’
```

## Importance

It is mentioned in getsentry/sentry#1979, but from my experience I used ajax to GET on a DRF endpoint, and it fails because there was an invalid. this possible outcome or an unhandled exception with allow_nan=False means that a valid infinity in the django database becomes an invalid ajax call. 

## Solution

After looking at python's json documentation, there is no good/easy way to change exactly how it handles floats to handle exactly what we'd want. "Don't create invalid JSON or throw an exception." [Similar SO](http://stackoverflow.com/questions/1447287/format-floats-with-standard-json-module) Most of these involve monkey patching which could easily have unforeseen consequences.

I went ahead and just overrode the iterencode function by combining encoder.py from [2.7](https://github.com/python/cpython/blob/e6239a3ab3e009a1b15918c1b8182290bb8a2e91/Lib/json/encoder.py#L212), [3.2](https://github.com/python/cpython/blob/dd246171e483afa21f12e2a961a461e0d5119ea3/Lib/json/encoder.py#L196) and [3.6](https://github.com/python/cpython/blob/aacd53f6cb96fe8c4fe9ce894f22e25f356a97c3/Lib/json/encoder.py#L204) to make a version that should support all supported of python without difference.

## Other possibility

Instead of returning null every time, it should also be possible to return the string `"Infinity"` instead of trying to return the number `Infinity`. I have no grips with this solution, I just went with the "How does Firefox/Chrome do it"

```javascript
q={x: 1e309, y:-1e309, z:0/0}
Object { x: Infinity, y: -Infinity, z: NaN }
JSON.stringify(q)
"{"x":null,"y":null,"z":null}"
```

But I believe that it should be ok to say

```python
>>> json.dumps({'x': float('inf')}, cls=rest_framework.utils.encoder.JSONEncoder)
'{"x": "Infinity"}’
```

If you would rather do that, where the quotes will make it just a normal string that will never be reinterpreted as a number again (using the standards).