### PR TITLE
KeyError in a property should propogate

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -100,7 +100,10 @@ def get_attribute(instance, attrs):
             if isinstance(instance, collections.Mapping):
                 instance = instance[attr]
             else:
-                instance = getattr(instance, attr)
+                try:
+                    instance = getattr(instance, attr)
+                except KeyError as exc:
+                    raise ValueError('Exception raised in property attribute "{0}"; original exception was: {1}'.format(attr, exc))
         except ObjectDoesNotExist:
             return None
         if is_simple_callable(instance):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -344,6 +344,23 @@ class TestUnicodeRepr:
 
 
 class TestNotRequiredOutput:
+    def test_not_required_property_exception(self):
+        """
+        A KeyError should propogate when it is thrown in a property attribute.
+        """
+        class ExampleSerializer(serializers.Serializer):
+            raises_key_error = serializers.CharField(required=False)
+
+        class ExampleObject:
+            @property
+            def raises_key_error(self):
+                raise KeyError()
+
+        instance = ExampleObject()
+        serializer = ExampleSerializer(instance)
+        with pytest.raises(ValueError):
+            serializer.data
+
     def test_not_required_output_for_dict(self):
         """
         'required=False' should allow a dictionary key to be missing in output.


### PR DESCRIPTION
When a KeyError is thrown in a property attribute, it should propogate as a ValueError. Please see the test i've written as an example. If this is a valid case, I think the opposite should be done for instance[attr] case as well, i.e. cathing a AttributeError there, and throwing it as a ValueError.