### PR TITLE
Patch for NestedBoundField.

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -100,19 +100,25 @@ class NestedBoundField(BoundField):
 
     def __getitem__(self, key):
         field = self.fields[key]
-        value = self.value.get(key) if self.value else None
+        if isinstance(self.value, dict):
+            value = self.value.get(key) if self.value else None
+        else:
+            value = self.value if self.value else None
         error = self.errors.get(key) if self.errors else None
         if hasattr(field, 'fields'):
             return NestedBoundField(field, value, error, prefix=self.name + '.')
         return BoundField(field, value, error, prefix=self.name + '.')
 
     def as_form_field(self):
-        values = {}
-        for key, value in self.value.items():
-            if isinstance(value, (list, dict)):
-                values[key] = value
-            else:
-                values[key] = '' if (value is None or value is False) else force_text(value)
+        if isinstance(self.value, dict):
+            values = {}
+            for key, value in self.value.items():
+                if isinstance(value, (list, dict)):
+                    values[key] = value
+                else:
+                    values[key] = '' if (value is None or value is False) else force_text(value)
+        else:
+            values = self.value
         return self.__class__(self._field, values, self.errors, self._prefix)
 
 


### PR DESCRIPTION

## Description

When nested field uses custom to_representation and to_internal_value methods, then self.value of NestedBoundField can be direct object, not a dict. For example, to_representation can convert an object to a string. Previous implementation didn't cover such use-cases.