### PR TITLE
Fix #4965

### DIFF
--- a/rest_framework/static/rest_framework/docs/css/base.css
+++ b/rest_framework/static/rest_framework/docs/css/base.css
@@ -115,6 +115,13 @@ pre.highlight code {
   background-color: #020203;
 }
 
+.sidebar .menu-list li.collapsed + ul.menu-content {
+  height: 0;
+}
+
+.sidebar .menu-list li.collapsed + ul.menu-content li {
+  display: none;
+}
 
 .sidebar .menu-list ul .sub-menu li a,
 .sidebar .menu-list li .sub-menu li a {

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -1,0 +1,15 @@
+{% for section_key, section in items %}
+{% if section_key %}
+  <h{{level}} id="{{prefix}}-{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+  </a></h{{level}}>
+{% endif %}
+
+    {% if section.links.items %}
+        {% for link_key, link in section.links.items %}
+            {% include "rest_framework/docs/link.html" with prefix=prefix level=level|add:1%}
+        {% endfor %}
+    {% else %}
+        {% include 'rest_framework/docs/_recursive_document.html' with items=section.items prefix=prefix|add:section_key|add:'/' level=level|add:1 %}
+    {% endif %}
+{% endfor %}
+

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -1,6 +1,6 @@
 {% for section_key, section in items %}
 {% if section_key %}
-  <h{{level}} id="{{prefix}}-{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+  <h{{level}} id="{{prefix}}{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
   </a></h{{level}}>
 {% endif %}
 

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -6,11 +6,15 @@
         {% if section.links.items %}
             <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{prefix}}{{ section_key }}-dropdown">
                 {% for link_key, link in section.links.items %}
-                <li><a href="#{{prefix}}-{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
+                <li><a href="#{% if prefix %}{{prefix}}/{% endif %}{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
                 {% endfor %}
             </ul>
         {% else %}
-            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=prefix|add:section_key %}
+            {% if prefix %}
+                {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=prefix|add:'/'|add:section_key %}
+            {% else %}
+                {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=section_key %}
+            {% endif %}
         {% endif %}
     {% endfor %}
 </ul>

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -1,0 +1,17 @@
+<ul id="{% if prefix %}{{prefix}}-dropdown{% else %}menu-content{% endif %}" class="menu-content collapse out">
+    {% for section_key, section in items %}
+        <li data-toggle="collapse" data-target="#{{prefix}}{{ section_key }}-dropdown" class="collapsed">
+          <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if prefix %}{{prefix}}/{% endif %}{% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
+        </li>
+        {% if section.links.items %}
+            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{prefix}}{{ section_key }}-dropdown">
+                {% for link_key, link in section.links.items %}
+                <li><a href="#{{prefix}}-{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=prefix|add:section_key %}
+        {% endif %}
+    {% endfor %}
+</ul>
+

--- a/rest_framework/templates/rest_framework/docs/document.html
+++ b/rest_framework/templates/rest_framework/docs/document.html
@@ -14,16 +14,7 @@
 </div>
 </div>
 
-{% for section_key, section in document.data.items %}
-{% if section_key %}
-    <h2 id="{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
-</a></h2>
-{% endif %}
-
-    {% for link_key, link in section.links.items %}
-        {% include "rest_framework/docs/link.html" %}
-    {% endfor %}
-{% endfor %}
+{% include 'rest_framework/docs/_recursive_document.html' with items=document.data.items level=2 %}
 
 {% for link_key, link in document.links.items %}
     {% include "rest_framework/docs/link.html" %}

--- a/rest_framework/templates/rest_framework/docs/interact.html
+++ b/rest_framework/templates/rest_framework/docs/interact.html
@@ -16,7 +16,7 @@
 
     </div>
 
-    <form data-key='["{{ section_key }}", "{{ link_key }}"]' class="api-interaction">
+    <form data-key='[{{ prefix|split_keys }} "{{ section_key }}", "{{ link_key }}"]' class="api-interaction">
     <div class="modal-body">
       <div class="row">
         <div class="col-lg-6 request">

--- a/rest_framework/templates/rest_framework/docs/langs/javascript.html
+++ b/rest_framework/templates/rest_framework/docs/langs/javascript.html
@@ -6,7 +6,7 @@ var schema = window.schema    // Loaded by `schema.js`
 var client = new coreapi.Client()
 
 // Interact with the API endpoint
-var action = [{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+var action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}var params = {
 {% for field in link.fields %}    {{ field.name }}: ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/javascript.html
+++ b/rest_framework/templates/rest_framework/docs/langs/javascript.html
@@ -6,7 +6,7 @@ var schema = window.schema    // Loaded by `schema.js`
 var client = new coreapi.Client()
 
 // Interact with the API endpoint
-var action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+var action = [{{ prefix|split_keys }}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}var params = {
 {% for field in link.fields %}    {{ field.name }}: ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/python.html
+++ b/rest_framework/templates/rest_framework/docs/langs/python.html
@@ -6,7 +6,7 @@ client = coreapi.Client()
 schema = client.get("{{ document.url }}"{% if schema_format %}, format="{{ schema_format }}"{% endif %})
 
 # Interact with the API endpoint
-action = [{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}params = {
 {% for field in link.fields %}    "{{ field.name }}": ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/python.html
+++ b/rest_framework/templates/rest_framework/docs/langs/python.html
@@ -6,7 +6,7 @@ client = coreapi.Client()
 schema = client.get("{{ document.url }}"{% if schema_format %}, format="{{ schema_format }}"{% endif %})
 
 # Interact with the API endpoint
-action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+action = [{{ prefix|split_keys }}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}params = {
 {% for field in link.fields %}    "{{ field.name }}": ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/shell.html
+++ b/rest_framework/templates/rest_framework/docs/langs/shell.html
@@ -3,4 +3,4 @@
 $ coreapi get {{ document.url }}{% if schema_format %} --format {{ schema_format }}{% endif %}
 
 # Interact with the API endpoint
-$ coreapi action {% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>
+$ coreapi action {% if prefix %}{{ prefix|split_keys:'cmd' }} {% endif %}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>

--- a/rest_framework/templates/rest_framework/docs/langs/shell.html
+++ b/rest_framework/templates/rest_framework/docs/langs/shell.html
@@ -3,4 +3,4 @@
 $ coreapi get {{ document.url }}{% if schema_format %} --format {{ schema_format }}{% endif %}
 
 # Interact with the API endpoint
-$ coreapi action {% if prefix %}{{ prefix|split_keys:'cmd' }} {% endif %}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>
+$ coreapi action {{ prefix|split_keys:'cmd' }}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>

--- a/rest_framework/templates/rest_framework/docs/link.html
+++ b/rest_framework/templates/rest_framework/docs/link.html
@@ -10,7 +10,7 @@
         <i class="fa fa-exchange"></i> Interact
     </button>
 
-    <h3 id="{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+    <h3 id="{{prefix}}-{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{prefix}}-{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h3>
 
     <div class="meta">

--- a/rest_framework/templates/rest_framework/docs/link.html
+++ b/rest_framework/templates/rest_framework/docs/link.html
@@ -10,7 +10,7 @@
         <i class="fa fa-exchange"></i> Interact
     </button>
 
-    <h3 id="{{prefix}}-{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{prefix}}-{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+    <h3 id="{{prefix}}{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{prefix}}{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h3>
 
     <div class="meta">

--- a/rest_framework/templates/rest_framework/docs/sidebar.html
+++ b/rest_framework/templates/rest_framework/docs/sidebar.html
@@ -3,18 +3,7 @@
 
     <i class="fa fa-bars fa-2x toggle-btn" data-toggle="collapse" data-target="#menu-content"></i>
     <div class="menu-list">
-        <ul id="menu-content" class="menu-content collapse out">
-            {% for section_key, section in document.data.items %}
-            <li data-toggle="collapse" data-target="#{{ section_key }}-dropdown" class="collapsed">
-                <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
-            </li>
-            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{ section_key }}-dropdown">
-                {% for link_key, link in section.links.items %}
-                    <li><a href="#{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
-                {% endfor %}
-            </ul>
-            {% endfor %}
-        </ul>
+        {% include 'rest_framework/docs/_recursive_menu.html' with items=document.data.items %}
 
         <ul class="menu-list menu-list-bottom">
             <li data-toggle="collapse" data-target="#auth-control" class="collapsed">

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -362,3 +362,22 @@ def break_long_headers(header):
     if len(header) > 160 and ',' in header:
         header = mark_safe('<br> ' + ', <br>'.join(header.split(',')))
     return header
+
+
+@register.filter
+def split_keys(keys, cmd_type='script'):
+    if not keys:
+        return ''
+
+    if cmd_type == 'script':
+        joiner = ', '
+        wrapper = '"'
+    else:
+        joiner = ' '
+        wrapper = ''
+
+    return joiner.join([
+        '{wrapper}{k}{wrapper}'.format(k=k, wrapper=wrapper)
+        if k != '' else ''
+        for k in keys.split('/')
+    ])

--- a/tests/interactive_doc/data.py
+++ b/tests/interactive_doc/data.py
@@ -1,0 +1,18 @@
+from django.db import models
+from rest_framework import serializers, viewsets
+
+
+class DummyModel(models.Model):
+    pass
+
+
+class DummySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = DummyModel
+        fields = ('id', )
+
+
+class DummyViewSet(viewsets.ModelViewSet):
+    serializer_class = DummySerializer
+    queryset = DummyModel.objects.all()

--- a/tests/interactive_doc/test_recursive_url.py
+++ b/tests/interactive_doc/test_recursive_url.py
@@ -1,0 +1,38 @@
+from __future__ import unicode_literals
+
+import re
+
+from django.test import TestCase, override_settings
+
+from rest_framework.test import APIClient
+
+
+@override_settings(ROOT_URLCONF='tests.interactive_doc.urls')
+class TestRecursiveUrlViewSets(TestCase):
+
+    def setUp(self):
+        client = APIClient()
+        response = client.get('/docs/')
+        self.content = response.content.decode('utf-8')
+
+    def test_menu(self):
+        self.assertTrue(
+            re.search('a href="#.*not_dummies\-list">', self.content),
+            'unable to find menu item for not_dummies'
+        )
+        for model_type in ['aaaa', 'bbbb']:
+            self.assertTrue(
+                re.search('a href="#.*{}s\-list">'.format(model_type), self.content),
+                'unable to find menu item for dummy/{}'.format(model_type)
+            )
+
+    def test_documentation(self):
+        self.assertTrue(
+            re.search('h2.*>not_dummies <a', self.content),
+            'unable to find documentation section for not_dummies'
+        )
+        for model_type in ['aaaa', 'bbbb']:
+            self.assertTrue(
+                re.search('h3.*>{}s <a'.format(model_type), self.content),
+                'unable to find documentation section for dummy/{}'.format(model_type)
+            )

--- a/tests/interactive_doc/urls.py
+++ b/tests/interactive_doc/urls.py
@@ -1,0 +1,18 @@
+from django.conf.urls import include, url
+
+from rest_framework.documentation import include_docs_urls
+from rest_framework.routers import DefaultRouter
+
+from .data import DummyViewSet
+
+
+router = DefaultRouter()
+
+router.register(r'dummy/aaaas', DummyViewSet)
+router.register(r'dummy/bbbbs', DummyViewSet)
+router.register(r'not_dummies', DummyViewSet)
+
+urlpatterns = [
+    url(r'', include(router.urls)),
+    url(r'^docs/', include_docs_urls())
+]


### PR DESCRIPTION
This PR fixes #4965 by adding recursive-enabled menu-tree and well as recursive-enabled documentation. It also makes sure that code-snippets and interact dialog are working with multi-level document (by using a new templatetag)