### PR TITLE
add import get_schema_view to schema documentation

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -107,6 +107,8 @@ add a schema to your API, depending on exactly what you need.
 The simplest way to include a schema in your project is to use the
 `get_schema_view()` function.
 
+    from rest_framework.documentation import get_schema_view
+    
     schema_view = get_schema_view(title="Server Monitoring API")
 
     urlpatterns = [


### PR DESCRIPTION
It was missing the information about from where we can import the get_schema_view function