### PR TITLE
PoC Add JSONBoundField to serializers (Fixes #4999)

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -38,7 +38,8 @@ from rest_framework.utils.field_mapping import (
     get_relation_kwargs, get_url_kwargs
 )
 from rest_framework.utils.serializer_helpers import (
-    BindingDict, BoundField, NestedBoundField, ReturnDict, ReturnList
+    BindingDict, BoundField, JSONBoundField, NestedBoundField, ReturnDict,
+    ReturnList
 )
 from rest_framework.validators import (
     UniqueForDateValidator, UniqueForMonthValidator, UniqueForYearValidator,
@@ -521,6 +522,8 @@ class Serializer(BaseSerializer):
         error = self.errors.get(key) if hasattr(self, '_errors') else None
         if isinstance(field, Serializer):
             return NestedBoundField(field, value, error)
+        if isinstance(field, JSONField):
+            return JSONBoundField(field, value, error)
         return BoundField(field, value, error)
 
     # Include a backlink to the serializer class on return objects.

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -8,7 +8,7 @@ from django.core import validators
 from django.db import models
 from django.utils.text import capfirst
 
-from rest_framework.compat import DecimalValidator
+from rest_framework.compat import DecimalValidator, JSONField
 from rest_framework.validators import UniqueValidator
 
 NUMERIC_FIELD_TYPES = (
@@ -88,7 +88,7 @@ def get_field_kwargs(field_name, model_field):
     if decimal_places is not None:
         kwargs['decimal_places'] = decimal_places
 
-    if isinstance(model_field, models.TextField):
+    if isinstance(model_field, models.TextField) or (JSONField and isinstance(model_field, JSONField)):
         kwargs['style'] = {'base_template': 'textarea.html'}
 
     if isinstance(model_field, models.AutoField) or not model_field.editable:

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -85,7 +85,11 @@ class BoundField(object):
 
 class JSONBoundField(BoundField):
     def as_form_field(self):
-        value = json.dumps(self.value, sort_keys=True, indent=4)
+        value = self.value
+        try:
+            value = json.dumps(self.value, sort_keys=True, indent=4)
+        except TypeError:
+            pass
         return self.__class__(self._field, value, self.errors, self._prefix)
 
 

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import collections
+import json
 from collections import OrderedDict
 
 from django.utils.encoding import force_text
@@ -79,6 +80,12 @@ class BoundField(object):
 
     def as_form_field(self):
         value = '' if (self.value is None or self.value is False) else self.value
+        return self.__class__(self._field, value, self.errors, self._prefix)
+
+
+class JSONBoundField(BoundField):
+    def as_form_field(self):
+        value = json.dumps(self.value)
         return self.__class__(self._field, value, self.errors, self._prefix)
 
 

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -85,7 +85,7 @@ class BoundField(object):
 
 class JSONBoundField(BoundField):
     def as_form_field(self):
-        value = json.dumps(self.value)
+        value = json.dumps(self.value, sort_keys=True, indent=4)
         return self.__class__(self._field, value, self.errors, self._prefix)
 
 


### PR DESCRIPTION
Per issue #4999, JSONFields are not rendered properly in the DRF
browsable API HTML forms.  This patch attempts to fix that behavior by
introducing a JSONBoundField helper similar to the NestedBoundField
helper.

## Description
I experienced #4999 today and put together this patch as an attempt to fix it.  I'd appreciate any feedback as to whether this approach makes sense as this is my first dive into the DRF code.  I could particularly use some guidance on what tests, documentation, etc. I should add.

./runtests.py reports all tests pass.  tox reports failures in py35-djangomaster and py36-djangomaster, but those are present in my environment without this patch also.  All other tox tests pass.