### PR TITLE
Update existing vary headers in response instead of overwriting them.

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.http import Http404
 from django.http.response import HttpResponseBase
 from django.utils import six
+from django.utils.cache import cc_delim_re, patch_vary_headers
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -413,6 +414,11 @@ class APIView(View):
             response.accepted_renderer = request.accepted_renderer
             response.accepted_media_type = request.accepted_media_type
             response.renderer_context = self.get_renderer_context()
+
+        # Add new vary headers to the response instead of overwriting.
+        vary_headers = self.headers.pop('Vary', None)
+        if vary_headers is not None:
+            patch_vary_headers(response, cc_delim_re.split(vary_headers))
 
         for key, value in self.headers.items():
             response[key] = value


### PR DESCRIPTION
## Description
I've changed the behaviour of finalize_response to update vary headers in the response - previously, any existing vary headers would be wiped out going through DRF. Using patch_vary_headers assures that existing headers remain.

I ran the tests but am getting a bunch of (hopefully unrelated?) problems, so I'm passing the problem on to travis.

I'll happily add a test for this as well, some guidance on where it might best go would be good though :)