### PR TITLE
Use overridden settings exception handler

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -290,7 +290,7 @@ class APIView(View):
         """
         Returns the exception handler that this view uses.
         """
-        return api_settings.EXCEPTION_HANDLER
+        return self.settings.EXCEPTION_HANDLER
 
     # API policy implementation methods
 


### PR DESCRIPTION
Instead of using the api_settings exception handler, we use the
overridden settings attribute to find the correct handler.

Closes #5054 