### PR TITLE
Fixed a deprecation warning

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1773,7 +1773,7 @@ class ModelField(Field):
     def to_internal_value(self, data):
         rel = get_remote_field(self.model_field, default=None)
         if rel is not None:
-            return rel.to._meta.get_field(rel.field_name).to_python(data)
+            return rel.model._meta.get_field(rel.field_name).to_python(data)
         return self.model_field.to_python(data)
 
     def get_attribute(self, obj):


### PR DESCRIPTION
Simple fix that's using deprecated django api.
was getting "/usr/local/filewave/python/lib/python3.6/site-packages/djangorestframework-3.6.1-py3.6.egg/rest_framework/fields.py:1774: RemovedInDjango20Warning: Usage of ForeignObjectRel.to attribute has been deprecated. Use the model attribute instead."