### PR TITLE
Clarify get_schema_fields signature

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -432,8 +432,11 @@ The method should return a rendered HTML string.
 ## Pagination & schemas
 
 You can also make the filter controls available to the schema autogeneration
-that REST framework provides, by implementing a `get_schema_fields()` method,
-which should return a list of `coreapi.Field` instances.
+that REST framework provides, by implementing a `get_schema_fields()` method. This method should have the following signature:
+
+`get_schema_fields(self, view)`
+
+The method should return a list of `coreapi.Field` instances.
 
 # Third party packages
 

--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -279,8 +279,11 @@ API responses for list endpoints will now include a `Link` header, instead of in
 ## Pagination & schemas
 
 You can also make the pagination controls available to the schema autogeneration
-that REST framework provides, by implementing a `get_schema_fields()` method,
-which should return a list of `coreapi.Field` instances.
+that REST framework provides, by implementing a `get_schema_fields()` method. This method should have the following signature:
+
+`get_schema_fields(self, view)`
+
+The method should return a list of `coreapi.Field` instances.
 
 ---
 


### PR DESCRIPTION
## Description
I had to look for the signature of `get_schema_fields()`in source code for my custom filter.