### PR TITLE
add URL path unquote to HyperlinkedRelatedField.to_internal_value

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -7,7 +7,9 @@ from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db.models import Manager
 from django.db.models.query import QuerySet
 from django.utils import six
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.encoding import (
+    python_2_unicode_compatible, smart_text, uri_to_iri
+)
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
@@ -323,6 +325,8 @@ class HyperlinkedRelatedField(RelatedField):
             prefix = get_script_prefix()
             if data.startswith(prefix):
                 data = '/' + data[len(prefix):]
+
+        data = uri_to_iri(data)
 
         try:
             match = resolve(data)

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,7 +1,9 @@
 import uuid
 
 import pytest
+from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from django.utils.datastructures import MultiValueDict
 
 from rest_framework import serializers
@@ -87,16 +89,41 @@ class TestProxiedPrimaryKeyRelatedField(APISimpleTestCase):
         assert representation == self.instance.pk.int
 
 
+@override_settings(ROOT_URLCONF=[
+    url(r'^example/(?P<name>.+)/$', lambda: None, name='example'),
+])
 class TestHyperlinkedRelatedField(APISimpleTestCase):
     def setUp(self):
+        self.queryset = MockQueryset([
+            MockObject(pk=1, name='foobar'),
+            MockObject(pk=2, name='baz qux'),
+        ])
         self.field = serializers.HyperlinkedRelatedField(
-            view_name='example', read_only=True)
+            view_name='example',
+            lookup_field='name',
+            lookup_url_kwarg='name',
+            queryset=self.queryset,
+        )
         self.field.reverse = mock_reverse
         self.field._context = {'request': True}
 
     def test_representation_unsaved_object_with_non_nullable_pk(self):
         representation = self.field.to_representation(MockObject(pk=''))
         assert representation is None
+
+    def test_hyperlinked_related_lookup_exists(self):
+        instance = self.field.to_internal_value('http://example.org/example/foobar/')
+        assert instance is self.queryset.items[0]
+
+    def test_hyperlinked_related_lookup_url_encoded_exists(self):
+        instance = self.field.to_internal_value('http://example.org/example/baz%20qux/')
+        assert instance is self.queryset.items[1]
+
+    def test_hyperlinked_related_lookup_does_not_exist(self):
+        with pytest.raises(serializers.ValidationError) as excinfo:
+            self.field.to_internal_value('http://example.org/example/doesnotexist/')
+        msg = excinfo.value.detail[0]
+        assert msg == 'Invalid hyperlink - Object does not exist.'
 
 
 class TestHyperlinkedIdentityField(APISimpleTestCase):

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -156,6 +156,7 @@ class TestCustomLookupFields(TestCase):
     """
     def setUp(self):
         RouterTestModel.objects.create(uuid='123', text='foo bar')
+        RouterTestModel.objects.create(uuid='a b', text='baz qux')
 
     def test_custom_lookup_field_route(self):
         detail_route = notes_router.urls[-1]
@@ -164,11 +165,18 @@ class TestCustomLookupFields(TestCase):
 
     def test_retrieve_lookup_field_list_view(self):
         response = self.client.get('/example/notes/')
-        assert response.data == [{"url": "http://testserver/example/notes/123/", "uuid": "123", "text": "foo bar"}]
+        assert response.data == [
+            {"url": "http://testserver/example/notes/123/", "uuid": "123", "text": "foo bar"},
+            {"url": "http://testserver/example/notes/a%20b/", "uuid": "a b", "text": "baz qux"},
+        ]
 
     def test_retrieve_lookup_field_detail_view(self):
         response = self.client.get('/example/notes/123/')
         assert response.data == {"url": "http://testserver/example/notes/123/", "uuid": "123", "text": "foo bar"}
+
+    def test_retrieve_lookup_field_url_encoded_detail_view_(self):
+        response = self.client.get('/example/notes/a%20b/')
+        assert response.data == {"url": "http://testserver/example/notes/a%20b/", "uuid": "a b", "text": "baz qux"}
 
 
 class TestLookupValueRegex(TestCase):
@@ -209,6 +217,10 @@ class TestLookupUrlKwargs(TestCase):
 
     def test_retrieve_lookup_url_kwarg_detail_view(self):
         response = self.client.get('/example2/notes/fo/')
+        assert response.data == {"url": "http://testserver/example/notes/123/", "uuid": "123", "text": "foo bar"}
+
+    def test_retrieve_lookup_url_encoded_kwarg_detail_view(self):
+        response = self.client.get('/example2/notes/foo%20bar/')
         assert response.data == {"url": "http://testserver/example/notes/123/", "uuid": "123", "text": "foo bar"}
 
 


### PR DESCRIPTION
Fix for #4748 

I added couple tests, but in fact only one of them would fail without change introduced by this PR
`TestHyperlinkedRelatedField.test_hyperlinked_related_lookup_url_encoded_exists`
