### PR TITLE
Add Django 1.11 into *.md and setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 # Requirements
 
 * Python (2.7, 3.2, 3.3, 3.4, 3.5)
-* Django (1.8, 1.9, 1.10)
+* Django (1.8, 1.9, 1.10, 1.11)
 
 # Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ continued development by **[signing up for a paid plan][funding]**.
 REST framework requires the following:
 
 * Python (2.7, 3.2, 3.3, 3.4, 3.5)
-* Django (1.8, 1.9, 1.10)
+* Django (1.8, 1.9, 1.10, 1.11)
 
 The following packages are optional:
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
DRF was tested on Django 1.11 and has green builds on Travis, but README file and `setup.py` doesn't have this information. 

This pull request adds 1.11 to the list of supported Django versions. 