### PR TITLE
Customizable schema generator classes

### DIFF
--- a/rest_framework/documentation.py
+++ b/rest_framework/documentation.py
@@ -3,10 +3,10 @@ from django.conf.urls import include, url
 from rest_framework.renderers import (
     CoreJSONRenderer, DocumentationRenderer, SchemaJSRenderer
 )
-from rest_framework.schemas import get_schema_view
+from rest_framework.schemas import SchemaGenerator, get_schema_view
 
 
-def get_docs_view(title=None, description=None, schema_url=None, public=True):
+def get_docs_view(title=None, description=None, schema_url=None, public=True, generator_class=SchemaGenerator):
     renderer_classes = [DocumentationRenderer, CoreJSONRenderer]
 
     return get_schema_view(
@@ -14,11 +14,12 @@ def get_docs_view(title=None, description=None, schema_url=None, public=True):
         url=schema_url,
         description=description,
         renderer_classes=renderer_classes,
-        public=public
+        public=public,
+        generator_class=generator_class,
     )
 
 
-def get_schemajs_view(title=None, description=None, schema_url=None, public=True):
+def get_schemajs_view(title=None, description=None, schema_url=None, public=True, generator_class=SchemaGenerator):
     renderer_classes = [SchemaJSRenderer]
 
     return get_schema_view(
@@ -26,22 +27,25 @@ def get_schemajs_view(title=None, description=None, schema_url=None, public=True
         url=schema_url,
         description=description,
         renderer_classes=renderer_classes,
-        public=public
+        public=public,
+        generator_class=generator_class,
     )
 
 
-def include_docs_urls(title=None, description=None, schema_url=None, public=True):
+def include_docs_urls(title=None, description=None, schema_url=None, public=True, generator_class=SchemaGenerator):
     docs_view = get_docs_view(
         title=title,
         description=description,
         schema_url=schema_url,
-        public=public
+        public=public,
+        generator_class=generator_class,
     )
     schema_js_view = get_schemajs_view(
         title=title,
         description=description,
         schema_url=schema_url,
-        public=public
+        public=public,
+        generator_class=generator_class,
     )
     urls = [
         url(r'^$', docs_view, name='docs-index'),

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -316,6 +316,7 @@ class DefaultRouter(SimpleRouter):
     default_schema_renderers = None
     APIRootView = APIRootView
     APISchemaView = SchemaView
+    SchemaGenerator = SchemaGenerator
 
     def __init__(self, *args, **kwargs):
         if 'schema_title' in kwargs:
@@ -342,7 +343,7 @@ class DefaultRouter(SimpleRouter):
         """
         Return a schema root view.
         """
-        schema_generator = SchemaGenerator(
+        schema_generator = self.SchemaGenerator(
             title=self.schema_title,
             url=self.schema_url,
             patterns=api_urls

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -694,11 +694,19 @@ class SchemaView(APIView):
         return Response(schema)
 
 
-def get_schema_view(title=None, url=None, description=None, urlconf=None, renderer_classes=None, public=False):
+def get_schema_view(
+    title=None,
+    url=None,
+    description=None,
+    urlconf=None,
+    renderer_classes=None,
+    public=False,
+    generator_class=SchemaGenerator,
+):
     """
     Return a schema view.
     """
-    generator = SchemaGenerator(title=title, url=url, description=description, urlconf=urlconf)
+    generator = generator_class(title=title, url=url, description=description, urlconf=urlconf)
     return SchemaView.as_view(
         renderer_classes=renderer_classes,
         schema_generator=generator,


### PR DESCRIPTION
## Description

This PR makes it possible to override which `SchemaGenerator` class is used, both in Routers and the browseable documentation.

I have a slightly extended/improved SchemaGenerator in my project, but actually using it means having to copy-paste code since the class is not currently injectable.