### PR TITLE
Fixed render error of required nested serializer.

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -101,7 +101,7 @@ class NestedBoundField(BoundField):
     def __getitem__(self, key):
         field = self.fields[key]
         value = self.value.get(key) if self.value else None
-        error = self.errors.get(key) if self.errors else None
+        error = self.errors.get(key) if isinstance(self.errors, dict) else None
         if hasattr(field, 'fields'):
             return NestedBoundField(field, value, error, prefix=self.name + '.')
         return BoundField(field, value, error, prefix=self.name + '.')


### PR DESCRIPTION
Fixes an error that occurs on rendering response with error that says that required nested serializer field must be specified in data.

## Description

When viewset receives a data without field that specified in used serializer as nested serializer with **required**=**True**, response fails to render correctly because of occured AttributeError in **NestedBoundField** class, `__getitem__` method (_/rest_framework/utils/serializer_helpers.py_).

That happens because 'required' error was saved in parent serializer and passed as list but used as dict in NestedBoundField that expects errors from fields of nested serializer, not from serializer itself. 

## Repro
1. Create simple model structures.
```python
from django.db import models


class Data(models.Model):
    name = models.CharField(max_length=50)


class Tag(models.Model):
    slug = models.SlugField()
```

2. Create serializers for new models. One serializer must include the other one as nested serializer and must be **required**.
```python
from rest_framework.fields import CharField, SlugField
from rest_framework.serializers import Serializer


class TagSerializer(Serializer):
    slug = SlugField()


class DataSerializer(Serializer):
    name = CharField(max_length=50)
    tag = TagSerializer()
```

3. Add a viewset that will use DataSerializer as serializer class.
```python
from rest_framework.viewsets import ModelViewSet

from .models import Data
from .serializers import DataSerializer


class DataViewSet(ModelViewSet):
    serializer_class = DataSerializer
    queryset = Data.objects.all()
```
4. Register DataViewSet in urls.
5. Try to create a new Data model instance through created API with the next JSON data:
```python
{
   "name": "Test"
}
```

As a result you will see the page with list of previously saved Data model instances if you're testing it through your browser and setting `DEBUG=True` or will receive error 500 instead of JSON object with errors and error 400. In console or logs you can see the next error:
```
AttributeError: 'list' object has no attribute 'get'
```