### PR TITLE
Generate schema with respect to http_method_names provided by CBV

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -247,7 +247,7 @@ class EndpointInspector(object):
         """
         if hasattr(callback, 'actions'):
             actions = set(callback.actions.keys())
-            http_method_names = set(callback.cls().http_method_names)
+            http_method_names = set(callback.cls.http_method_names)
             return [method.upper() for method in actions & http_method_names]
 
         return [

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -246,10 +246,9 @@ class EndpointInspector(object):
         Return a list of the valid HTTP methods for this endpoint.
         """
         if hasattr(callback, 'actions'):
-            return [
-                method.upper() for method in
-                set(callback.actions.keys()).intersection(set(callback.cls().http_method_names))
-            ]
+            actions = set(callback.actions.keys())
+            http_method_names = set(callback.cls().http_method_names)
+            return [method.upper() for method in actions & http_method_names]
 
         return [
             method for method in

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -246,7 +246,10 @@ class EndpointInspector(object):
         Return a list of the valid HTTP methods for this endpoint.
         """
         if hasattr(callback, 'actions'):
-            return [method.upper() for method in callback.actions.keys()]
+            return [
+                method.upper() for method in
+                set(callback.actions.keys()).intersection(set(callback.cls().http_method_names))
+            ]
 
         return [
             method for method in


### PR DESCRIPTION
## Description

This limits the schema generation by `http_method_names` attribute (Django CBV). I just updated `get_allowed_method` to have a set intersection check.

Closes #4691.