### PR TITLE
SchemaGenerator: Avoid crashing with pagesizeless paginators

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -604,7 +604,7 @@ class SchemaGenerator(object):
             return []
 
         pagination = getattr(view, 'pagination_class', None)
-        if not pagination or not pagination.page_size:
+        if not pagination or not getattr(pagination, 'page_size', None):
             return []
 
         paginator = view.pagination_class()


### PR DESCRIPTION
When using master (bd768d62) with `LimitOffsetPagination`, `SchemaGenerator` crashes:

```
  File "rest_framework/schemas.py", line 607, in get_pagination_fields
    if not pagination or not pagination.page_size:
AttributeError: type object 'LimitOffsetPagination' has no attribute 'page_size'
```

This is related to #4998.