### PR TITLE
Add pip cache to CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 python:
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-
 cache: pip
 
 python:
@@ -40,7 +39,7 @@ matrix:
 
 install:
     - pip install --upgrade pip
-    - pip install tox tox-travis
+    - pip install tox tox-travis wheel
 
 script:
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+
 cache: pip
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       - env: DJANGO=master
 
 install:
+    - pip install --upgrade pip
     - pip install tox tox-travis
 
 script:


### PR DESCRIPTION
Adding a `cache: pip` directive to travis [sped up the celery project build times](https://github.com/celery/celery/pull/3785) by a fair bit. It might be worth seeing if the same can be done here, if it's as simple as just adding a single line.