### PR TITLE
Improve grammar in .force_authenticate() docs

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -162,7 +162,7 @@ The `credentials` method is appropriate for testing APIs that require authentica
 
 #### .force_authenticate(user=None, token=None)
 
-Sometimes you may want to bypass authentication, and simple force all requests by the test client to be automatically treated as authenticated.
+Sometimes you may want to bypass authentication entirely and force all requests by the test client to be automatically treated as authenticated.
 
 This can be a useful shortcut if you're testing the API but don't want to have to construct valid authentication credentials in order to make test requests.
 


### PR DESCRIPTION
* Remove unnecessary comma
* Remove the "and simple" copied from the line above.
* Add "entirely" to emphasize that this function bypasses the authentication step.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
