### PR TITLE
Call any zero-argument callable when accessing attributes

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -56,7 +56,7 @@ if six.PY3:
         """
         True if the object is a callable that takes no arguments.
         """
-        if not (inspect.isfunction(obj) or inspect.ismethod(obj)):
+        if not callable(obj):
             return False
 
         sig = inspect.signature(obj)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import os
 import re
 import unittest
@@ -68,12 +69,17 @@ class TestIsSimpleCallable:
         def valid_vargs_kwargs(*args, **kwargs):
             pass
 
+        @functools.lru_cache(None)
+        def wrapped_by_native_function():
+            pass
+
         def invalid(param, param2='value'):
             pass
 
         assert is_simple_callable(simple)
         assert is_simple_callable(valid)
         assert is_simple_callable(valid_vargs_kwargs)
+        assert is_simple_callable(wrapped_by_native_function)
         assert not is_simple_callable(invalid)
 
     def test_4602_regression(self):


### PR DESCRIPTION
Previously attributes would be explicitly checked using
inspect.isfunction/inspect.ismethod, which would miss some callables
(e.g. functions implemented in C).

refs #5114
