### PR TITLE
return object after saving in perform_create and perform_update

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -23,7 +23,7 @@ class CreateModelMixin(object):
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     def perform_create(self, serializer):
-        serializer.save()
+        return serializer.save()
 
     def get_success_headers(self, data):
         try:
@@ -77,7 +77,7 @@ class UpdateModelMixin(object):
         return Response(serializer.data)
 
     def perform_update(self, serializer):
-        serializer.save()
+        return serializer.save()
 
     def partial_update(self, request, *args, **kwargs):
         kwargs['partial'] = True


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

There are times when the overloaded perform_create() or perform_update() calls it's parent super method. It is nice to have the object returned from these two methods, so that the overloaded methods - 
1. Do not need to query the db to retrieve the object that was created.

2. Can have added/more functionality in perform_create() and perform_update() that are dependent on the object.