### PR TITLE
Ignore any invalidly formed query parameters for OrderingFilter.

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -11,6 +11,7 @@ from functools import reduce
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.sql.constants import ORDER_PATTERN
 from django.template import loader
 from django.utils import six
 from django.utils.encoding import force_text
@@ -268,7 +269,7 @@ class OrderingFilter(BaseFilterBackend):
 
     def remove_invalid_fields(self, queryset, fields, view, request):
         valid_fields = [item[0] for item in self.get_valid_fields(queryset, view, {'request': request})]
-        return [term for term in fields if term.lstrip('-') in valid_fields]
+        return [term for term in fields if term.lstrip('-') in valid_fields and ORDER_PATTERN.match(term)]
 
     def filter_queryset(self, request, queryset, view):
         ordering = self.get_ordering(request, queryset, view)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -773,13 +773,14 @@ class OrderingFilterTests(TestCase):
             ordering_fields = ('text',)
 
         view = OrderingListView.as_view()
-        request = factory.get('/', {'ordering':'--text'})
+        request = factory.get('/', {'ordering': '--text'})
         response = view(request)
         assert response.data == [
             {'id': 3, 'title': 'xwv', 'text': 'cde'},
             {'id': 2, 'title': 'yxw', 'text': 'bcd'},
             {'id': 1, 'title': 'zyx', 'text': 'abc'},
         ]
+
     def test_incorrectfield_ordering(self):
         class OrderingListView(generics.ListAPIView):
             queryset = OrderingFilterModel.objects.all()
@@ -899,6 +900,7 @@ class OrderingFilterTests(TestCase):
             queryset = OrderingFilterModel.objects.all()
             filter_backends = (filters.OrderingFilter,)
             ordering = ('title',)
+
             # note: no ordering_fields and serializer_class specified
 
             def get_serializer_class(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -764,6 +764,22 @@ class OrderingFilterTests(TestCase):
             {'id': 1, 'title': 'zyx', 'text': 'abc'},
         ]
 
+    def test_incorrecturl_extrahyphens_ordering(self):
+        class OrderingListView(generics.ListAPIView):
+            queryset = OrderingFilterModel.objects.all()
+            serializer_class = OrderingFilterSerializer
+            filter_backends = (filters.OrderingFilter,)
+            ordering = ('title',)
+            ordering_fields = ('text',)
+
+        view = OrderingListView.as_view()
+        request = factory.get('/', {'ordering':'--text'})
+        response = view(request)
+        assert response.data == [
+            {'id': 3, 'title': 'xwv', 'text': 'cde'},
+            {'id': 2, 'title': 'yxw', 'text': 'bcd'},
+            {'id': 1, 'title': 'zyx', 'text': 'abc'},
+        ]
     def test_incorrectfield_ordering(self):
         class OrderingListView(generics.ListAPIView):
             queryset = OrderingFilterModel.objects.all()


### PR DESCRIPTION
Closes #4989. 

For using ordering filters, parameters are added to the URL in the following manner and the output is the listed in the increasing order of the passed parameter. 

`http://example.com/api/users?ordering=username`


For decreasing order, the following URL is used: 

`http://example.com/api/users?ordering=-username`


If multiple hyphens are added, it should be treated as an invalid ordering parameter and should be discarded. The failing testcase's error traceback is as follows: 

```
 tests/test_filters.py:778: in test_incorrecturl_ordering
    response = view(request)
../venv-test/lib/python2.7/site-packages/django/views/decorators/csrf.py:58: in wrapped_view
    return view_func(*args, **kwargs)
../venv-test/lib/python2.7/site-packages/django/views/generic/base.py:68: in view
    return self.dispatch(request, *args, **kwargs)
rest_framework/views.py:489: in dispatch
    response = self.handle_exception(exc)
rest_framework/views.py:449: in handle_exception
    self.raise_uncaught_exception(exc)
rest_framework/views.py:486: in dispatch
    response = handler(request, *args, **kwargs)
rest_framework/generics.py:201: in get
    return self.list(request, *args, **kwargs)
rest_framework/mixins.py:40: in list
    queryset = self.filter_queryset(self.get_queryset())
rest_framework/generics.py:152: in filter_queryset
    queryset = backend().filter_queryset(self.request, queryset, self)
rest_framework/filters.py:277: in filter_queryset
    return queryset.order_by(*ordering)
../venv-test/lib/python2.7/site-packages/django/db/models/query.py:950: in order_by
    obj.query.add_ordering(*field_names)
../venv-test/lib/python2.7/site-packages/django/db/models/sql/query.py:1691: in add_ordering
    raise FieldError('Invalid order_by arguments: %s' % errors)
E   FieldError: Invalid order_by arguments: [u'--text']


```

