### PR TITLE
Add QueryParamField support to auto-generated documentation

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '3.6.2'
+__version__ = '3.6.3'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2017 Tom Christie'

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -767,6 +767,10 @@ class CharField(Field):
         return six.text_type(value)
 
 
+class QueryParamField(CharField):
+    pass
+
+
 class EmailField(CharField):
     default_error_messages = {
         'invalid': _('Enter a valid email address.')

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -590,10 +590,12 @@ class SchemaGenerator(object):
             if field.read_only or isinstance(field, serializers.HiddenField):
                 continue
 
+            location = 'query' if isinstance(field, serializers.QueryParamField) else 'form'
+
             required = field.required and method != 'PATCH'
             field = coreapi.Field(
                 name=field.field_name,
-                location='form',
+                location=location,
                 required=required,
                 schema=field_to_schema(field)
             )

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -564,7 +564,7 @@ class SchemaGenerator(object):
         Return a list of `coreapi.Field` instances corresponding to any
         request body input, as determined by the serializer class.
         """
-        if method not in ('PUT', 'PATCH', 'POST'):
+        if method not in ('PUT', 'GET', 'PATCH', 'POST'):
             return []
 
         if not hasattr(view, 'get_serializer'):

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -564,8 +564,12 @@ class SchemaGenerator(object):
         Return a list of `coreapi.Field` instances corresponding to any
         request body input, as determined by the serializer class.
         """
-        if method not in ('PUT', 'GET', 'PATCH', 'POST'):
-            return []
+
+        if hasattr(view, 'action') and view.action == 'add_item':
+            pass
+
+        body_allowed_methods = ('PUT', 'PATCH', 'POST')
+        method_allow_body = method in body_allowed_methods
 
         if not hasattr(view, 'get_serializer'):
             return []
@@ -591,6 +595,9 @@ class SchemaGenerator(object):
                 continue
 
             location = 'query' if isinstance(field, serializers.QueryParamField) else 'form'
+
+            if not method_allow_body and location != 'query':
+                continue
 
             required = field.required and method != 'PATCH'
             field = coreapi.Field(

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -57,7 +57,7 @@ from rest_framework.fields import (  # NOQA # isort:skip
     DictField, DurationField, EmailField, Field, FileField, FilePathField, FloatField,
     HiddenField, IPAddressField, ImageField, IntegerField, JSONField, ListField,
     ModelField, MultipleChoiceField, NullBooleanField, ReadOnlyField, RegexField,
-    SerializerMethodField, SlugField, TimeField, URLField, UUIDField,
+    SerializerMethodField, SlugField, TimeField, URLField, UUIDField, QueryParamField,
 )
 from rest_framework.relations import (  # NOQA # isort:skip
     HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField,


### PR DESCRIPTION
Add a ```QueryParamField``` to enable the auto-generated doc's to read a custom query parameter fields.

Example:
```python

class ShoppingCardChooseSerializer(serializers.Serializer):
    promotion_id = serializers.QueryParamField()

class ShoppingCartViewSet(viewsets.ReadOnlyModelViewSet):
    permission_classes = (IsAuthenticated, )
    queryset = ShoppingCart.objects.all()
    serializer_class = ShoppingCartSerializer

    @list_route(methods=['GET'],
                serializer_class=ShoppingCardChooseSerializer)
    def list_promotional_itens(self, request, *args, **kwargs):
        # apply filter with promotion
        return Response(status=200)
```
