### PR TITLE
Update Django Filter requirement

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,6 +1,6 @@
 # Optional packages which may be used with REST framework.
 markdown==2.6.4
 django-guardian==1.4.8
-django-filter==1.0.2
+django-filter==1.0.3
 coreapi==2.2.4
 coreschema==0.0.4


### PR DESCRIPTION
Latest is [v1.0.3](https://github.com/carltongibson/django-filter/releases/tag/1.0.3) — improving support for schema generation