### PR TITLE
Improve memory footprint when reading large JSON requests.

### DIFF
--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -7,6 +7,7 @@ on the request, such as form content or json encoded data.
 from __future__ import unicode_literals
 
 import json
+import codecs
 
 from django.conf import settings
 from django.core.files.uploadhandler import StopFutureHandlers
@@ -22,7 +23,6 @@ from django.utils.six.moves.urllib import parse as urlparse
 
 from rest_framework import renderers
 from rest_framework.exceptions import ParseError
-import codecs
 
 
 class DataAndFiles(object):
@@ -62,7 +62,7 @@ class JSONParser(BaseParser):
         encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
 
         try:
-            decoded_stream = codecs.decode(stream, encoding)
+            decoded_stream = codecs.getreader(encoding)(stream)
             return json.load(decoded_stream)
         except ValueError as exc:
             raise ParseError('JSON parse error - %s' % six.text_type(exc))

--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -6,8 +6,8 @@ on the request, such as form content or json encoded data.
 """
 from __future__ import unicode_literals
 
-import json
 import codecs
+import json
 
 from django.conf import settings
 from django.core.files.uploadhandler import StopFutureHandlers

--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -22,6 +22,7 @@ from django.utils.six.moves.urllib import parse as urlparse
 
 from rest_framework import renderers
 from rest_framework.exceptions import ParseError
+import codecs
 
 
 class DataAndFiles(object):
@@ -61,8 +62,8 @@ class JSONParser(BaseParser):
         encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
 
         try:
-            data = stream.read().decode(encoding)
-            return json.loads(data)
+            decoded_stream = codecs.decode(stream, encoding)
+            return json.load(decoded_stream)
         except ValueError as exc:
             raise ParseError('JSON parse error - %s' % six.text_type(exc))
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Large encoded string take a very long time to to release from memory, but if we just pass the stream directly into json.load we get much better memory performance. refs #5146
