### PR TITLE
Custom trailing_slash

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -128,7 +128,7 @@ class SimpleRouter(BaseRouter):
     def __init__(self, trailing_slash=True):
         if isinstance(trailing_slash, str):
             self.trailing_slash = trailing_slash
-        else: 
+        else:
             self.trailing_slash = trailing_slash and '/' or ''
         super(SimpleRouter, self).__init__()
 

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -126,7 +126,10 @@ class SimpleRouter(BaseRouter):
     ]
 
     def __init__(self, trailing_slash=True):
-        self.trailing_slash = trailing_slash and '/' or ''
+        if isinstance(trailing_slash, str):
+            self.trailing_slash = trailing_slash
+        else: 
+            self.trailing_slash = trailing_slash and '/' or ''
         super(SimpleRouter, self).__init__()
 
     def get_default_base_name(self, viewset):


### PR DESCRIPTION
If a string is passed into the SimpleRouter, append that to the regex determining the route. This will prevent unnecessary confusion when a PATCH/PUT request is made to a given endpoint and a slash is omitted. Lost a bit of dev time figuring out where the `request.data` has gone because the endpoint was right, but the slash was missing.

With this change, one can use  `SimpleRouter(trailing_slash='/?')` to direct to any of the given endpoints, while not losing any of the prior functionality.