### PR TITLE
Add `generator_class` parameter to `get_schema_view` docs.

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -185,6 +185,12 @@ to be exposed in the schema:
         patterns=schema_url_patterns,
     )
 
+#### `generator_class`
+
+May be used to specify a `SchemaGenerator` subclass to be passed to the
+`SchemaView`.
+
+
 
 ## Using an explicit schema view
 


### PR DESCRIPTION
[`get_schema_view` accepts `generator_class` parameter](https://github.com/encode/django-rest-framework/blob/master/rest_framework/schemas.py#L701)

Was added in 51a6c076e27931c89a37d76301975e7e548e3324 (tagged in [3.6.3](https://github.com/encode/django-rest-framework/tree/3.6.3))