### PR TITLE
If pagination class, include the schema generation

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -606,7 +606,7 @@ class SchemaGenerator(object):
             return []
 
         pagination = getattr(view, 'pagination_class', None)
-        if not pagination or not getattr(pagination, 'page_size', None):
+        if not pagination:
             return []
 
         paginator = view.pagination_class()


### PR DESCRIPTION
Refs https://github.com/encode/django-rest-framework/issues/5144

## Description
This fixes a bug that was introduced in commit:  https://github.com/encode/django-rest-framework/commit/6ad0be44d3275b10ad69ae60167db144b620e7ca#diff-eae91da078f88bdb425b240be0ee5487
Then was mutated by this followup commit:  https://github.com/encode/django-rest-framework/commit/72da73310d6da11e4beeba815498fa4aecc6635a

I change the logic back to not consider the page_size attribute at all as it is irrelevant for generating the schema -- should have nothing to do with the actual page size. 
