### PR TITLE
Added documentation from where to import get_schema_view

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -107,6 +107,8 @@ add a schema to your API, depending on exactly what you need.
 The simplest way to include a schema in your project is to use the
 `get_schema_view()` function.
 
+    from rest_framework.schemas import get_schema_view
+
     schema_view = get_schema_view(title="Server Monitoring API")
 
     urlpatterns = [
@@ -161,6 +163,7 @@ ROOT_URLCONF setting.
 
 May be used to pass the set of renderer classes that can be used to render the API root endpoint.
 
+    from rest_framework.schemas import get_schema_view
     from rest_framework.renderers import CoreJSONRenderer
     from my_custom_package import APIBlueprintRenderer
 


### PR DESCRIPTION
In actual [documentation for schemas](http://www.django-rest-framework.org/api-guide/schemas/) i did't found from where i should import the `get_schema_view` shortcut. So i found it in [DRF 3.5 Announcement Page](http://www.django-rest-framework.org/topics/3.5-announcement/).

In this pull request i putted two imports to documentation to clarify from where to import the `get_schema_view` shortcut.

```
from rest_framework.schemas import get_schema_view
```