### PR TITLE
Nested interactive documentation (refs #4965, update of #4966)

### DIFF
--- a/rest_framework/static/rest_framework/docs/css/base.css
+++ b/rest_framework/static/rest_framework/docs/css/base.css
@@ -115,6 +115,13 @@ pre.highlight code {
   background-color: #020203;
 }
 
+.sidebar .menu-list li.collapsed + ul.menu-content {
+  height: 0;
+}
+
+.sidebar .menu-list li.collapsed + ul.menu-content li {
+  display: none;
+}
 
 .sidebar .menu-list ul .sub-menu li a,
 .sidebar .menu-list li .sub-menu li a {

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -1,0 +1,15 @@
+{% for section_key, section in items %}
+{% if section_key %}
+  <h{{level}} id="{{prefix}}-{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+  </a></h{{level}}>
+{% endif %}
+
+    {% if section.links.items %}
+        {% for link_key, link in section.links.items %}
+            {% include "rest_framework/docs/link.html" with prefix=prefix level=level|add:1%}
+        {% endfor %}
+    {% else %}
+        {% include 'rest_framework/docs/_recursive_document.html' with items=section.items prefix=prefix|add:section_key|add:'/' level=level|add:1 %}
+    {% endif %}
+{% endfor %}
+

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -1,6 +1,7 @@
+{% load rest_framework %}
 {% for section_key, section in items %}
 {% if section_key %}
-  <h{{level}} id="{{prefix}}{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+  <h{{level}} id="{{prefix}}{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ prefix }}{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
   </a></h{{level}}>
 {% endif %}
 
@@ -8,8 +9,7 @@
         {% for link_key, link in section.links|items %}
             {% include "rest_framework/docs/link.html" with prefix=prefix level=level|add:1%}
         {% endfor %}
-    {% else %}
-        {% include 'rest_framework/docs/_recursive_document.html' with items=section|items prefix=prefix|add:section_key|add:'/' level=level|add:1 %}
     {% endif %}
+    {% include 'rest_framework/docs/_recursive_document.html' with items=section.data|items prefix=prefix|add:section_key|add:'/' level=level|add:1 %}
 {% endfor %}
 

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -4,12 +4,12 @@
   </a></h{{level}}>
 {% endif %}
 
-    {% if section.links.items %}
-        {% for link_key, link in section.links.items %}
+    {% if section.links|items %}
+        {% for link_key, link in section.links|items %}
             {% include "rest_framework/docs/link.html" with prefix=prefix level=level|add:1%}
         {% endfor %}
     {% else %}
-        {% include 'rest_framework/docs/_recursive_document.html' with items=section.items prefix=prefix|add:section_key|add:'/' level=level|add:1 %}
+        {% include 'rest_framework/docs/_recursive_document.html' with items=section|items prefix=prefix|add:section_key|add:'/' level=level|add:1 %}
     {% endif %}
 {% endfor %}
 

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -1,15 +1,16 @@
 {% load rest_framework %}
 {% for section_key, section in items %}
-{% if section_key %}
-  <h{{level}} id="{{prefix}}{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ prefix }}{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
-  </a></h{{level}}>
-{% endif %}
+    {% if section_key %}
+        <h{{level}} id="{{ path|list_add:section_key|join:'-' }}" class="coredocs-section-title">
+            {{ section_key }}
+            <a href="#{{ path|list_add:section_key|join:'-' }}"><i class="fa fa-link" aria-hidden="true"></i></a>
+        </h{{level}}>
+    {% endif %}
 
     {% if section.links|items %}
         {% for link_key, link in section.links|items %}
-            {% include "rest_framework/docs/link.html" with prefix=prefix level=level|add:1%}
+            {% include "rest_framework/docs/link.html" with path=path %}
         {% endfor %}
     {% endif %}
-    {% include 'rest_framework/docs/_recursive_document.html' with items=section.data|items prefix=prefix|add:section_key|add:'/' level=level|add:1 %}
+    {% include 'rest_framework/docs/_recursive_document.html' with items=section.data|items path=path|list_add:section_key level=level|add:1 %}
 {% endfor %}
-

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -1,9 +1,9 @@
 {% load rest_framework %}
 {% for section_key, section in items %}
     {% if section_key %}
-        <h{{level}} id="{{ path|list_add:section_key|join:'-' }}" class="coredocs-section-title">
+        <h{{level}} id="{{ path|list_add:section_key|join:'-'|slugify }}" class="coredocs-section-title">
             {{ section_key }}
-            <a href="#{{ path|list_add:section_key|join:'-' }}"><i class="fa fa-link" aria-hidden="true"></i></a>
+            <a href="#{{ path|list_add:section_key|join:'-'|slugify }}"><i class="fa fa-link" aria-hidden="true"></i></a>
         </h{{level}}>
     {% endif %}
 

--- a/rest_framework/templates/rest_framework/docs/_recursive_document.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_document.html
@@ -1,6 +1,6 @@
 {% for section_key, section in items %}
 {% if section_key %}
-  <h{{level}} id="{{prefix}}-{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+  <h{{level}} id="{{prefix}}{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
   </a></h{{level}}>
 {% endif %}
 

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -1,22 +1,18 @@
 {% load rest_framework %}
 {% if items %}
-<ul id="{% if prefix %}{{prefix}}-dropdown{% else %}menu-content{% endif %}" class="menu-content collapse out">
+<ul id="{% if path %}{{ path|join:"-" }}-dropdown{% else %}menu-content{% endif %}" class="menu-content collapse out">
     {% for section_key, section in items %}
-        <li data-toggle="collapse" data-target="#{{prefix}}{{ section_key }}-dropdown" class="collapsed">
-          <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if prefix %}{{prefix}}/{% endif %}{% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
+        <li data-toggle="collapse" data-target="#{{ path|list_add:section_key|join:"-" }}-dropdown" class="collapsed">
+          <a><i class="fa fa-dot-circle-o fa-lg"></i> {% for p in path %}{{ p }}/{% endfor %}{% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
         </li>
         {% if section.links|items %}
-            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{prefix}}{{ section_key }}-dropdown">
+            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{ path|list_add:section_key|join:'-' }}-dropdown">
                 {% for link_key, link in section.links|items %}
-                <li><a href="#{% if prefix %}{{prefix}}/{% endif %}{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
+                <li><a href="#{{ path|list_add:section_key|list_add:link_key|join:"-" }}">{{ link.title|default:link_key }}</a></li>
                 {% endfor %}
             </ul>
         {% endif %}
-        {% if prefix %}
-            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.data|items prefix=prefix|add:'/'|add:section_key %}
-        {% else %}
-            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.data|items prefix=section_key %}
-        {% endif %}
+        {% include "rest_framework/docs/_recursive_menu.html" with items=section.data|items path=path|list_add:section_key %}
     {% endfor %}
 </ul>
 {% endif %}

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -6,11 +6,15 @@
         {% if section.links.items %}
             <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{prefix}}{{ section_key }}-dropdown">
                 {% for link_key, link in section.links.items %}
-                <li><a href="#{{prefix}}-{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
+                <li><a href="#{% if prefix %}{{prefix}}/{% endif %}{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
                 {% endfor %}
             </ul>
         {% else %}
-            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=prefix|add:section_key %}
+            {% if prefix %}
+                {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=prefix|add:'/'|add:section_key %}
+            {% else %}
+                {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=section_key %}
+            {% endif %}
         {% endif %}
     {% endfor %}
 </ul>

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -1,3 +1,5 @@
+{% load rest_framework %}
+{% if items %}
 <ul id="{% if prefix %}{{prefix}}-dropdown{% else %}menu-content{% endif %}" class="menu-content collapse out">
     {% for section_key, section in items %}
         <li data-toggle="collapse" data-target="#{{prefix}}{{ section_key }}-dropdown" class="collapsed">
@@ -9,13 +11,12 @@
                 <li><a href="#{% if prefix %}{{prefix}}/{% endif %}{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
                 {% endfor %}
             </ul>
+        {% endif %}
+        {% if prefix %}
+            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.data|items prefix=prefix|add:'/'|add:section_key %}
         {% else %}
-            {% if prefix %}
-                {% include 'rest_framework/docs/_recursive_menu.html' with items=section|items prefix=prefix|add:'/'|add:section_key %}
-            {% else %}
-                {% include 'rest_framework/docs/_recursive_menu.html' with items=section|items prefix=section_key %}
-            {% endif %}
+            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.data|items prefix=section_key %}
         {% endif %}
     {% endfor %}
 </ul>
-
+{% endif %}

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -3,17 +3,17 @@
         <li data-toggle="collapse" data-target="#{{prefix}}{{ section_key }}-dropdown" class="collapsed">
           <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if prefix %}{{prefix}}/{% endif %}{% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
         </li>
-        {% if section.links.items %}
+        {% if section.links|items %}
             <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{prefix}}{{ section_key }}-dropdown">
-                {% for link_key, link in section.links.items %}
+                {% for link_key, link in section.links|items %}
                 <li><a href="#{% if prefix %}{{prefix}}/{% endif %}{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
                 {% endfor %}
             </ul>
         {% else %}
             {% if prefix %}
-                {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=prefix|add:'/'|add:section_key %}
+                {% include 'rest_framework/docs/_recursive_menu.html' with items=section|items prefix=prefix|add:'/'|add:section_key %}
             {% else %}
-                {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=section_key %}
+                {% include 'rest_framework/docs/_recursive_menu.html' with items=section|items prefix=section_key %}
             {% endif %}
         {% endif %}
     {% endfor %}

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -1,14 +1,14 @@
 {% load rest_framework %}
 {% if items %}
-<ul id="{% if path %}{{ path|join:"-" }}-dropdown{% else %}menu-content{% endif %}" class="menu-content collapse out">
+<ul id="{% if path %}{{ path|join:"-"|slugify }}-dropdown{% else %}menu-content{% endif %}" class="menu-content collapse out">
     {% for section_key, section in items %}
-        <li data-toggle="collapse" data-target="#{{ path|list_add:section_key|join:"-" }}-dropdown" class="collapsed">
+        <li data-toggle="collapse" data-target="#{{ path|list_add:section_key|join:"-"|slugify }}-dropdown" class="collapsed">
           <a><i class="fa fa-dot-circle-o fa-lg"></i> {% for p in path %}{{ p }}/{% endfor %}{% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
         </li>
         {% if section.links|items %}
-            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{ path|list_add:section_key|join:'-' }}-dropdown">
+            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{ path|list_add:section_key|join:'-'|slugify }}-dropdown">
                 {% for link_key, link in section.links|items %}
-                <li><a href="#{{ path|list_add:section_key|list_add:link_key|join:"-" }}">{{ link.title|default:link_key }}</a></li>
+                <li><a href="#{{ path|list_add:section_key|list_add:link_key|join:"-"|slugify }}">{{ link.title|default:link_key }}</a></li>
                 {% endfor %}
             </ul>
         {% endif %}

--- a/rest_framework/templates/rest_framework/docs/_recursive_menu.html
+++ b/rest_framework/templates/rest_framework/docs/_recursive_menu.html
@@ -1,0 +1,17 @@
+<ul id="{% if prefix %}{{prefix}}-dropdown{% else %}menu-content{% endif %}" class="menu-content collapse out">
+    {% for section_key, section in items %}
+        <li data-toggle="collapse" data-target="#{{prefix}}{{ section_key }}-dropdown" class="collapsed">
+          <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if prefix %}{{prefix}}/{% endif %}{% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
+        </li>
+        {% if section.links.items %}
+            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{prefix}}{{ section_key }}-dropdown">
+                {% for link_key, link in section.links.items %}
+                <li><a href="#{{prefix}}-{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            {% include 'rest_framework/docs/_recursive_menu.html' with items=section.items prefix=prefix|add:section_key %}
+        {% endif %}
+    {% endfor %}
+</ul>
+

--- a/rest_framework/templates/rest_framework/docs/document.html
+++ b/rest_framework/templates/rest_framework/docs/document.html
@@ -14,8 +14,8 @@
 </div>
 </div>
 
-{% include 'rest_framework/docs/_recursive_document.html' with items=document.data|items level=2 %}
+{% include "rest_framework/docs/_recursive_document.html" with items=document.data|items path=""|make_list level=2 %}
 
 {% for link_key, link in document.links|items %}
-    {% include "rest_framework/docs/link.html" %}
+    {% include "rest_framework/docs/link.html" with path=""|make_list %}
 {% endfor %}

--- a/rest_framework/templates/rest_framework/docs/document.html
+++ b/rest_framework/templates/rest_framework/docs/document.html
@@ -14,16 +14,7 @@
 </div>
 </div>
 
-{% for section_key, section in document.data|items %}
-{% if section_key %}
-    <h2 id="{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
-</a></h2>
-{% endif %}
-
-    {% for link_key, link in section.links|items %}
-        {% include "rest_framework/docs/link.html" %}
-    {% endfor %}
-{% endfor %}
+{% include 'rest_framework/docs/_recursive_document.html' with items=document.data|items level=2 %}
 
 {% for link_key, link in document.links|items %}
     {% include "rest_framework/docs/link.html" %}

--- a/rest_framework/templates/rest_framework/docs/interact.html
+++ b/rest_framework/templates/rest_framework/docs/interact.html
@@ -16,7 +16,7 @@
 
     </div>
 
-    <form data-key='[{{ prefix|split_keys }} "{{ section_key }}", "{{ link_key }}"]' class="api-interaction">
+    <form data-key='[{% for p in path %}"{{ p }}", {% endfor %}"{{ section_key }}", "{{ link_key }}"]' class="api-interaction">
     <div class="modal-body">
       <div class="row">
         <div class="col-lg-6 request">

--- a/rest_framework/templates/rest_framework/docs/interact.html
+++ b/rest_framework/templates/rest_framework/docs/interact.html
@@ -16,7 +16,7 @@
 
     </div>
 
-    <form data-key='["{{ section_key }}", "{{ link_key }}"]' class="api-interaction">
+    <form data-key='[{{ prefix|split_keys }} "{{ section_key }}", "{{ link_key }}"]' class="api-interaction">
     <div class="modal-body">
       <div class="row">
         <div class="col-lg-6 request">

--- a/rest_framework/templates/rest_framework/docs/langs/javascript.html
+++ b/rest_framework/templates/rest_framework/docs/langs/javascript.html
@@ -6,7 +6,7 @@ var schema = window.schema    // Loaded by `schema.js`
 var client = new coreapi.Client()
 
 // Interact with the API endpoint
-var action = [{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+var action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}var params = {
 {% for field in link.fields %}    {{ field.name }}: ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/javascript.html
+++ b/rest_framework/templates/rest_framework/docs/langs/javascript.html
@@ -6,7 +6,7 @@ var schema = window.schema    // Loaded by `schema.js`
 var client = new coreapi.Client()
 
 // Interact with the API endpoint
-var action = [{{ prefix|split_keys }}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+var action = [{% for p in path %}"{{ p }}", {% endfor %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}var params = {
 {% for field in link.fields %}    {{ field.name }}: ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/javascript.html
+++ b/rest_framework/templates/rest_framework/docs/langs/javascript.html
@@ -6,7 +6,7 @@ var schema = window.schema    // Loaded by `schema.js`
 var client = new coreapi.Client()
 
 // Interact with the API endpoint
-var action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+var action = [{{ prefix|split_keys }}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}var params = {
 {% for field in link.fields %}    {{ field.name }}: ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/python.html
+++ b/rest_framework/templates/rest_framework/docs/langs/python.html
@@ -6,7 +6,7 @@ client = coreapi.Client()
 schema = client.get("{{ document.url }}"{% if schema_format %}, format="{{ schema_format }}"{% endif %})
 
 # Interact with the API endpoint
-action = [{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}params = {
 {% for field in link.fields %}    "{{ field.name }}": ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/python.html
+++ b/rest_framework/templates/rest_framework/docs/langs/python.html
@@ -6,7 +6,7 @@ client = coreapi.Client()
 schema = client.get("{{ document.url }}"{% if schema_format %}, format="{{ schema_format }}"{% endif %})
 
 # Interact with the API endpoint
-action = [{{ prefix|split_keys }}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+action = [{% for p in path %}"{{ p }}", {% endfor %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}params = {
 {% for field in link.fields %}    "{{ field.name }}": ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/python.html
+++ b/rest_framework/templates/rest_framework/docs/langs/python.html
@@ -6,7 +6,7 @@ client = coreapi.Client()
 schema = client.get("{{ document.url }}"{% if schema_format %}, format="{{ schema_format }}"{% endif %})
 
 # Interact with the API endpoint
-action = [{% if prefix %}{{ prefix|split_keys }} {% endif %}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
+action = [{{ prefix|split_keys }}{% if section_key %}"{{ section_key }}", {% endif %}"{{ link_key }}"]
 {% if link.fields %}params = {
 {% for field in link.fields %}    "{{ field.name }}": ...{% if not loop.last %},{% endif %}
 {% endfor %}}

--- a/rest_framework/templates/rest_framework/docs/langs/shell.html
+++ b/rest_framework/templates/rest_framework/docs/langs/shell.html
@@ -3,4 +3,4 @@
 $ coreapi get {{ document.url }}{% if schema_format %} --format {{ schema_format }}{% endif %}
 
 # Interact with the API endpoint
-$ coreapi action {% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>
+$ coreapi action {% if prefix %}{{ prefix|split_keys:'cmd' }} {% endif %}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>

--- a/rest_framework/templates/rest_framework/docs/langs/shell.html
+++ b/rest_framework/templates/rest_framework/docs/langs/shell.html
@@ -3,4 +3,4 @@
 $ coreapi get {{ document.url }}{% if schema_format %} --format {{ schema_format }}{% endif %}
 
 # Interact with the API endpoint
-$ coreapi action {% if prefix %}{{ prefix|split_keys:'cmd' }} {% endif %}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>
+$ coreapi action {{ prefix|split_keys:'cmd' }}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>

--- a/rest_framework/templates/rest_framework/docs/langs/shell.html
+++ b/rest_framework/templates/rest_framework/docs/langs/shell.html
@@ -3,4 +3,4 @@
 $ coreapi get {{ document.url }}{% if schema_format %} --format {{ schema_format }}{% endif %}
 
 # Interact with the API endpoint
-$ coreapi action {{ prefix|split_keys:'cmd' }}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>
+$ coreapi action {% for p in path %}{{ p }} {% endfor %}{% if section_key %}{{ section_key }} {% endif %}{{ link_key }}{% for field in link.fields %} -p {{ field.name }}=...{% endfor %}{% endcode %}</code></pre>

--- a/rest_framework/templates/rest_framework/docs/link.html
+++ b/rest_framework/templates/rest_framework/docs/link.html
@@ -10,7 +10,7 @@
         <i class="fa fa-exchange"></i> Interact
     </button>
 
-    <h3 id="{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+    <h3 id="{{prefix}}-{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{prefix}}-{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h3>
 
     <div class="meta">

--- a/rest_framework/templates/rest_framework/docs/link.html
+++ b/rest_framework/templates/rest_framework/docs/link.html
@@ -10,8 +10,10 @@
         <i class="fa fa-exchange"></i> Interact
     </button>
 
-    <h3 id="{{prefix}}{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{prefix}}{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
-</a></h3>
+    <h3 id="{{ path|list_add:section_key|list_add:link_key|join:"-" }}" class="coredocs-link-title">
+        {{ link.title|default:link_key }}
+        <a href="#{{ path|list_add:section_key|list_add:link_key|join:"-" }}"><i class="fa fa-link" aria-hidden="true"></i></a>
+    </h3>
 
     <div class="meta">
         <span class="label label-primary">{{ link.action|upper }}</span>

--- a/rest_framework/templates/rest_framework/docs/link.html
+++ b/rest_framework/templates/rest_framework/docs/link.html
@@ -10,9 +10,9 @@
         <i class="fa fa-exchange"></i> Interact
     </button>
 
-    <h3 id="{{ path|list_add:section_key|list_add:link_key|join:"-" }}" class="coredocs-link-title">
+    <h3 id="{{ path|list_add:section_key|list_add:link_key|join:"-"|slugify }}" class="coredocs-link-title">
         {{ link.title|default:link_key }}
-        <a href="#{{ path|list_add:section_key|list_add:link_key|join:"-" }}"><i class="fa fa-link" aria-hidden="true"></i></a>
+        <a href="#{{ path|list_add:section_key|list_add:link_key|join:"-"|slugify }}"><i class="fa fa-link" aria-hidden="true"></i></a>
     </h3>
 
     <div class="meta">

--- a/rest_framework/templates/rest_framework/docs/link.html
+++ b/rest_framework/templates/rest_framework/docs/link.html
@@ -10,7 +10,7 @@
         <i class="fa fa-exchange"></i> Interact
     </button>
 
-    <h3 id="{{prefix}}-{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{prefix}}-{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+    <h3 id="{{prefix}}{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default:link_key }} <a href="#{{prefix}}{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h3>
 
     <div class="meta">

--- a/rest_framework/templates/rest_framework/docs/sidebar.html
+++ b/rest_framework/templates/rest_framework/docs/sidebar.html
@@ -4,7 +4,7 @@
 
     <i class="fa fa-bars fa-2x toggle-btn" data-toggle="collapse" data-target="#menu-content"></i>
     <div class="menu-list">
-        {% include 'rest_framework/docs/_recursive_menu.html' with items=document.data|items %}
+        {% include "rest_framework/docs/_recursive_menu.html" with items=document.data|items path=""|make_list %}
 
         <ul class="menu-list menu-list-bottom">
             <li data-toggle="collapse" data-target="#auth-control" class="collapsed">

--- a/rest_framework/templates/rest_framework/docs/sidebar.html
+++ b/rest_framework/templates/rest_framework/docs/sidebar.html
@@ -4,18 +4,7 @@
 
     <i class="fa fa-bars fa-2x toggle-btn" data-toggle="collapse" data-target="#menu-content"></i>
     <div class="menu-list">
-        <ul id="menu-content" class="menu-content collapse out">
-            {% for section_key, section in document.data|items %}
-            <li data-toggle="collapse" data-target="#{{ section_key }}-dropdown" class="collapsed">
-                <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
-            </li>
-            <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{ section_key }}-dropdown">
-                {% for link_key, link in section.links|items %}
-                    <li><a href="#{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
-                {% endfor %}
-            </ul>
-            {% endfor %}
-        </ul>
+        {% include 'rest_framework/docs/_recursive_menu.html' with items=document.data|items %}
 
         <ul class="menu-list menu-list-bottom">
             <li data-toggle="collapse" data-target="#auth-control" class="collapsed">

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -362,3 +362,22 @@ def break_long_headers(header):
     if len(header) > 160 and ',' in header:
         header = mark_safe('<br> ' + ', <br>'.join(header.split(',')))
     return header
+
+
+@register.filter
+def split_keys(keys, cmd_type='script'):
+    if not keys:
+        return ''
+
+    if cmd_type == 'script':
+        joiner = ', '
+        wrapper = '"'
+    else:
+        joiner = ' '
+        wrapper = ''
+
+    return joiner.join([
+        '{wrapper}{k}{wrapper}'.format(k=k, wrapper=wrapper)
+        if k != '' else ''
+        for k in keys.split('/')
+    ])

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -365,19 +365,14 @@ def break_long_headers(header):
 
 
 @register.filter
-def split_keys(keys, cmd_type='script'):
-    if not keys:
-        return ''
+def list_add(lst, item):
+    """
+    Appends a item to a list or a tuple. Original value is not modified.
 
-    if cmd_type == 'script':
-        joiner = ', '
-        wrapper = '"'
-    else:
-        joiner = ' '
-        wrapper = ''
-
-    return joiner.join([
-        '{wrapper}{k}{wrapper}'.format(k=k, wrapper=wrapper)
-        if k != '' else ''
-        for k in keys.split('/')
-    ])
+    Can be only applied to lists or tuples, raises TypeError otherwise.
+    """
+    if isinstance(lst, list):
+        return lst + [item]
+    elif isinstance(lst, tuple):
+        return lst + (item,)
+    raise TypeError("list_add only accepts lists or tuples")

--- a/tests/interactive_doc/data.py
+++ b/tests/interactive_doc/data.py
@@ -1,5 +1,6 @@
 from django.db import models
 from rest_framework import serializers, viewsets
+from rest_framework.decorators import detail_route
 
 
 class DummyModel(models.Model):
@@ -16,3 +17,7 @@ class DummySerializer(serializers.ModelSerializer):
 class DummyViewSet(viewsets.ModelViewSet):
     serializer_class = DummySerializer
     queryset = DummyModel.objects.all()
+
+    @detail_route(methods=['get', 'post'])
+    def retrieve_alt(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)

--- a/tests/interactive_doc/data.py
+++ b/tests/interactive_doc/data.py
@@ -1,0 +1,18 @@
+from django.db import models
+from rest_framework import serializers, viewsets
+
+
+class DummyModel(models.Model):
+    pass
+
+
+class DummySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = DummyModel
+        fields = ('id', )
+
+
+class DummyViewSet(viewsets.ModelViewSet):
+    serializer_class = DummySerializer
+    queryset = DummyModel.objects.all()

--- a/tests/interactive_doc/test_recursive_url.py
+++ b/tests/interactive_doc/test_recursive_url.py
@@ -32,7 +32,7 @@ class TestRecursiveUrlViewSets(TestCase):
         for route in (('not_dummies',), ('dummy', 'aaaas'), ('dummy', 'bbbbs')):
             path = "-".join(route)
             self.assertTrue(
-                re.search(header_re.format(level=1+len(route), path=path, title=route[-1]), self.content),
+                re.search(header_re.format(level=1 + len(route), path=path, title=route[-1]), self.content),
                 'unable to find documentation section for {}'.format(path)
             )
             for method in ('read', 'create'):

--- a/tests/interactive_doc/test_recursive_url.py
+++ b/tests/interactive_doc/test_recursive_url.py
@@ -27,16 +27,16 @@ class TestRecursiveUrlViewSets(TestCase):
             )
 
     def test_documentation(self):
-        header_re = 'h{level}\s+id="{path}".*>{title} <a href="#{path}"'
+        header_re = 'h{level}\s+id="{path}".*>\s*{title}\s*<a href="#{path}"'
 
         for route in (('not_dummies',), ('dummy', 'aaaas'), ('dummy', 'bbbbs')):
-            path = "/".join(route)
+            path = "-".join(route)
             self.assertTrue(
                 re.search(header_re.format(level=1+len(route), path=path, title=route[-1]), self.content),
                 'unable to find documentation section for {}'.format(path)
             )
             for method in ('read', 'create'):
-                subpath = "{}/retrieve_alt-{}".format(path, method)
+                subpath = "{}-retrieve_alt-{}".format(path, method)
                 self.assertTrue(
                     re.search(header_re.format(level=3, path=subpath, title=method), self.content),
                     'unable to find documentation section for {}'.format(subpath)

--- a/tests/interactive_doc/test_recursive_url.py
+++ b/tests/interactive_doc/test_recursive_url.py
@@ -27,12 +27,17 @@ class TestRecursiveUrlViewSets(TestCase):
             )
 
     def test_documentation(self):
-        self.assertTrue(
-            re.search('h2.*>not_dummies <a', self.content),
-            'unable to find documentation section for not_dummies'
-        )
-        for model_type in ['aaaa', 'bbbb']:
+        header_re = 'h{level}\s+id="{path}".*>{title} <a href="#{path}"'
+
+        for route in (('not_dummies',), ('dummy', 'aaaas'), ('dummy', 'bbbbs')):
+            path = "/".join(route)
             self.assertTrue(
-                re.search('h3.*>{}s <a'.format(model_type), self.content),
-                'unable to find documentation section for dummy/{}'.format(model_type)
+                re.search(header_re.format(level=1+len(route), path=path, title=route[-1]), self.content),
+                'unable to find documentation section for {}'.format(path)
             )
+            for method in ('read', 'create'):
+                subpath = "{}/retrieve_alt-{}".format(path, method)
+                self.assertTrue(
+                    re.search(header_re.format(level=3, path=subpath, title=method), self.content),
+                    'unable to find documentation section for {}'.format(subpath)
+                )

--- a/tests/interactive_doc/test_recursive_url.py
+++ b/tests/interactive_doc/test_recursive_url.py
@@ -53,3 +53,7 @@ class TestRecursiveUrlViewSets(TestCase):
                     '$ coreapi action {} retrieve_alt {}'.format(' '.join(route), method) in self.content,
                     'unable to find shell code snippet for {}'.format(subpath)
                 )
+                self.assertTrue(
+                    re.search('<li><a href="#{}"[^>]*>\s*{}'.format(subpath, method), self.content),
+                    'unable to find sidebar link for {}'.format(subpath)
+                )

--- a/tests/interactive_doc/test_recursive_url.py
+++ b/tests/interactive_doc/test_recursive_url.py
@@ -41,3 +41,15 @@ class TestRecursiveUrlViewSets(TestCase):
                     re.search(header_re.format(level=3, path=subpath, title=method), self.content),
                     'unable to find documentation section for {}'.format(subpath)
                 )
+                action_code = 'action = [{}, "retrieve_alt", "{}"]'.format(
+                    ", ".join('"{}"'.format(r) for r in route),
+                    method
+                )
+                self.assertTrue(
+                    action_code in self.content.replace('&quot;', '"'),
+                    'unable to find code snippet for {}'.format(subpath)
+                )
+                self.assertTrue(
+                    '$ coreapi action {} retrieve_alt {}'.format(' '.join(route), method) in self.content,
+                    'unable to find shell code snippet for {}'.format(subpath)
+                )

--- a/tests/interactive_doc/test_recursive_url.py
+++ b/tests/interactive_doc/test_recursive_url.py
@@ -1,0 +1,38 @@
+from __future__ import unicode_literals
+
+import re
+
+from django.test import TestCase, override_settings
+
+from rest_framework.test import APIClient
+
+
+@override_settings(ROOT_URLCONF='tests.interactive_doc.urls')
+class TestRecursiveUrlViewSets(TestCase):
+
+    def setUp(self):
+        client = APIClient()
+        response = client.get('/docs/')
+        self.content = response.content.decode('utf-8')
+
+    def test_menu(self):
+        self.assertTrue(
+            re.search('a href="#.*not_dummies\-list">', self.content),
+            'unable to find menu item for not_dummies'
+        )
+        for model_type in ['aaaa', 'bbbb']:
+            self.assertTrue(
+                re.search('a href="#.*{}s\-list">'.format(model_type), self.content),
+                'unable to find menu item for dummy/{}'.format(model_type)
+            )
+
+    def test_documentation(self):
+        self.assertTrue(
+            re.search('h2.*>not_dummies <a', self.content),
+            'unable to find documentation section for not_dummies'
+        )
+        for model_type in ['aaaa', 'bbbb']:
+            self.assertTrue(
+                re.search('h3.*>{}s <a'.format(model_type), self.content),
+                'unable to find documentation section for dummy/{}'.format(model_type)
+            )

--- a/tests/interactive_doc/urls.py
+++ b/tests/interactive_doc/urls.py
@@ -1,0 +1,18 @@
+from django.conf.urls import include, url
+
+from rest_framework.documentation import include_docs_urls
+from rest_framework.routers import DefaultRouter
+
+from .data import DummyViewSet
+
+
+router = DefaultRouter()
+
+router.register(r'dummy/aaaas', DummyViewSet)
+router.register(r'dummy/bbbbs', DummyViewSet)
+router.register(r'not_dummies', DummyViewSet)
+
+urlpatterns = [
+    url(r'', include(router.urls)),
+    url(r'^docs/', include_docs_urls())
+]


### PR DESCRIPTION
Hi! I thought I'd take a stab at improving https://github.com/encode/django-rest-framework/pull/4966. I've rebased that PR's code upon the current `master` and made some fixes and changes I've mentioned in comments there.

Differences from #4966:

1. Commits are rebased upon the current `master`. Merge conflicts (use of `items` filter) resolved.
2. Updated code to handles cases when there are both sub-documents and links at the same level. I've added a test case for this, with `@detail_route()`.
3. Ensures all HTML IDs only consist of alphanumerics and minus-dashes, so JS won't choke on something unexpected with `#some-id` lookups (e.g. it had failed on `#spam/eggs`). I recognize this may be a problem with non-ASCII routes, but I'm not sure how to deal with those. I can think of either using [unicode-slugify](https://pypi.python.org/pypi/unicode-slugify) as an optional dependency, or using hashes instead of human-readable strings. Both options have their downsides, though. Any suggestions?
4. Adds some tests (a bit dirty, as they parse HTML with regexes and assume a particular structure) that ensure links are consistent and snippet code has correct action lists. If desirable, I can probably add a test-time-only BeautifulSoup dependency, and update tests accordingly, so one would be able to update HTML templates without having to worry about tests. But I feel this is probably an overkill.
5. I've updated the code to pass paths as lists rather than strings (`prefix`es), joining them as necessary. I believe this is a a more flexible approach. This still requires a custom template filter (`list_add`), but it's a more generic one than `split_keys`.

I've tested this code in a project I work on, and it seems to work nicely, without any issues. Please review this. I'll be glad to hear any suggestions on possible improvements!

Thanks!