### PR TITLE
Fix exception when HTML_CUTOFF is set to None

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -75,7 +75,8 @@ class PKOnlyObject(object):
 # rather than the parent serializer.
 MANY_RELATION_KWARGS = (
     'read_only', 'write_only', 'required', 'default', 'initial', 'source',
-    'label', 'help_text', 'style', 'error_messages', 'allow_empty'
+    'label', 'help_text', 'style', 'error_messages', 'allow_empty',
+    'html_cutoff', 'html_cutoff_text'
 )
 
 
@@ -86,10 +87,12 @@ class RelatedField(Field):
 
     def __init__(self, **kwargs):
         self.queryset = kwargs.pop('queryset', self.queryset)
-        self.html_cutoff = kwargs.pop(
-            'html_cutoff',
-            self.html_cutoff or int(api_settings.HTML_SELECT_CUTOFF)
-        )
+
+        cutoff_from_settings = api_settings.HTML_SELECT_CUTOFF
+        if cutoff_from_settings is not None:
+            cutoff_from_settings = int(cutoff_from_settings)
+        self.html_cutoff = kwargs.pop('html_cutoff', cutoff_from_settings)
+
         self.html_cutoff_text = kwargs.pop(
             'html_cutoff_text',
             self.html_cutoff_text or _(api_settings.HTML_SELECT_CUTOFF_TEXT)
@@ -466,10 +469,12 @@ class ManyRelatedField(Field):
     def __init__(self, child_relation=None, *args, **kwargs):
         self.child_relation = child_relation
         self.allow_empty = kwargs.pop('allow_empty', True)
-        self.html_cutoff = kwargs.pop(
-            'html_cutoff',
-            self.html_cutoff or int(api_settings.HTML_SELECT_CUTOFF)
-        )
+
+        cutoff_from_settings = api_settings.HTML_SELECT_CUTOFF
+        if cutoff_from_settings is not None:
+            cutoff_from_settings = int(cutoff_from_settings)
+        self.html_cutoff = kwargs.pop('html_cutoff', cutoff_from_settings)
+
         self.html_cutoff_text = kwargs.pop(
             'html_cutoff_text',
             self.html_cutoff_text or _(api_settings.HTML_SELECT_CUTOFF_TEXT)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,6 +20,9 @@ class MockQueryset(object):
     def __init__(self, iterable):
         self.items = iterable
 
+    def __getitem__(self, val):
+        return self.items[val]
+
     def get(self, **lookup):
         for item in self.items:
             if all([


### PR DESCRIPTION
Add tests for HTML_CUTOFF setting and fix issue where setting it to None would raise an exception.

Fixes https://github.com/encode/django-rest-framework/issues/5140