### PR TITLE
Fixed ListField validation for POST request with content-type form-data.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1551,7 +1551,8 @@ class ListField(Field):
             if len(val) > 0:
                 # Support QueryDict lists in HTML input.
                 return val
-            return html.parse_html_list(dictionary, prefix=self.field_name)
+            parsed_list = html.parse_html_list(dictionary, prefix=self.field_name)
+            return parsed_list if parsed_list else empty
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1547,12 +1547,13 @@ class ListField(Field):
         # We override the default field access in order to support
         # lists in HTML forms.
         if html.is_html_input(dictionary):
-            val = dictionary.getlist(self.field_name, [])
+            val = dictionary.getlist(self.field_name, empty)
+            if val == empty:
+                return val
             if len(val) > 0:
                 # Support QueryDict lists in HTML input.
                 return val
-            parsed_list = html.parse_html_list(dictionary, prefix=self.field_name)
-            return parsed_list if parsed_list else empty
+            return html.parse_html_list(dictionary, prefix=self.field_name)
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):


### PR DESCRIPTION
I found an incorrect DRF behavior when validating a ListField:
If you write the following serializer

```
SomeSerializer(ModelSerialiser):
    some_field = ListField()
```

Then make a request to create an object using the JSON format, filling in all the fields except some_field, DRF will return an error {"some_field": ["This field is required."]}, But if you make the same request with the content-type: form-data, then the object will be Successfully created. As far as I understand, the problem is that in rest_framework/fields.py:497, when POSTing with the content-type: form-data, the variable data is not empty. I have refactored get_value method for getting empty type if is html input and val is empty.