### PR TITLE
Fix browsable API not supporting multipart/form-data correctly

### DIFF
--- a/rest_framework/static/rest_framework/js/ajax-form.js
+++ b/rest_framework/static/rest_framework/js/ajax-form.js
@@ -42,7 +42,7 @@ function doAjaxSubmit(e) {
       // We need to add a boundary parameter to the header
       // We assume the first valid-looking boundary line in the body is correct
       // regex is from RFC 2046 appendix A
-      var boundaryCharNoSpace = "[0-9A-Z'()+_,-./:=?";
+      var boundaryCharNoSpace = "0-9A-Z'()+_,-./:=?";
       var boundaryChar = boundaryCharNoSpace + ' ';
       var re = new RegExp('^--([' + boundaryChar + ']{0,69}[' + boundaryCharNoSpace + '])[\\s]*?$', 'im');
       var boundary = data.match(re);

--- a/rest_framework/static/rest_framework/js/ajax-form.js
+++ b/rest_framework/static/rest_framework/js/ajax-form.js
@@ -37,6 +37,17 @@ function doAjaxSubmit(e) {
 
   if (contentType) {
     data = form.find('[data-override="content"]').val() || ''
+
+    if (contentType === 'multipart/form-data') {
+      // We need to add a boundary parameter to the header
+      var re = /^--([0-9A-Z'()+_,-./:=?]{1,70})[ \f\t\v\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*$/im;
+      var boundary = re.exec(data);
+      if (boundary !== null) {
+        contentType += '; boundary="' + boundary[1] + '"';
+      }
+      // Fix textarea.value EOL normalisation (multipart/form-data should use CR+NL, not NL)
+      data = data.replace(/\n/g, '\r\n');
+    }
   } else {
     contentType = form.attr('enctype') || form.attr('encoding')
 

--- a/rest_framework/static/rest_framework/js/ajax-form.js
+++ b/rest_framework/static/rest_framework/js/ajax-form.js
@@ -42,7 +42,9 @@ function doAjaxSubmit(e) {
       // We need to add a boundary parameter to the header
       // We assume the first valid-looking boundary line in the body is correct
       // regex is from RFC 2046 appendix A
-      var re = /^--([0-9A-Z'()+_,-./:=?]{1,70})[ \f\t\v\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*$/im;
+      var boundaryCharNoSpace = "[0-9A-Z'()+_,-./:=?";
+      var boundaryChar = boundaryCharNoSpace + ' ';
+      var re = new RegExp('^--([' + boundaryChar + ']{0,69}[' + boundaryCharNoSpace + '])[\\s]*?$', 'im');
       var boundary = data.match(re);
       if (boundary !== null) {
         contentType += '; boundary="' + boundary[1] + '"';

--- a/rest_framework/static/rest_framework/js/ajax-form.js
+++ b/rest_framework/static/rest_framework/js/ajax-form.js
@@ -40,8 +40,10 @@ function doAjaxSubmit(e) {
 
     if (contentType === 'multipart/form-data') {
       // We need to add a boundary parameter to the header
+      // We assume the first valid-looking boundary line in the body is correct
+      // regex is from RFC 2046 appendix A
       var re = /^--([0-9A-Z'()+_,-./:=?]{1,70})[ \f\t\v\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*$/im;
-      var boundary = re.exec(data);
+      var boundary = data.match(re);
       if (boundary !== null) {
         contentType += '; boundary="' + boundary[1] + '"';
       }


### PR DESCRIPTION
- Autodetect missing boundary parameter for Content-Type header
- textarea value normalises EOL chars to \n when multipart/form-data requires \r\n

Fixes #1579