### PR TITLE
Fixes #5172 Fix curly bracket in regexp of @list_route

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -35,6 +35,12 @@ DynamicDetailRoute = namedtuple('DynamicDetailRoute', ['url', 'name', 'initkwarg
 DynamicListRoute = namedtuple('DynamicListRoute', ['url', 'name', 'initkwargs'])
 
 
+def replace_curly_brackets(url_path):
+    if ('{' and '}') in url_path:
+        url_path = url_path.replace('{', '{{').replace('}', '}}')
+    return url_path
+
+
 def replace_methodname(format_string, methodname):
     """
     Partially format a format_string, swapping out any
@@ -178,6 +184,7 @@ class SimpleRouter(BaseRouter):
                 initkwargs = route.initkwargs.copy()
                 initkwargs.update(method_kwargs)
                 url_path = initkwargs.pop("url_path", None) or methodname
+                url_path = replace_curly_brackets(url_path)
                 url_name = initkwargs.pop("url_name", None) or url_path
                 ret.append(Route(
                     url=replace_methodname(route.url, url_path),


### PR DESCRIPTION
Fixes [#5172](https://github.com/encode/django-rest-framework/issues/5172)

if url_path contains curly brackets, these raise error while url_path.format() .

ex.
`
'{router_url}/(?P<year>[0-9]{4}){trailing_slash}'.format(router_url='some_url', trailing_slash='/')
`
{4} inside regex raise IndexError

so it need to replace single curly bracket to double.