### PR TITLE
Fix list_route, detail_route with kwargs contains curly bracket in url_path

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -35,7 +35,10 @@ DynamicDetailRoute = namedtuple('DynamicDetailRoute', ['url', 'name', 'initkwarg
 DynamicListRoute = namedtuple('DynamicListRoute', ['url', 'name', 'initkwargs'])
 
 
-def replace_curly_brackets(url_path):
+def escape_curly_brackets(url_path):
+    """
+    Double brackets in regex of url_path for escape string formatting
+    """
     if ('{' and '}') in url_path:
         url_path = url_path.replace('{', '{{').replace('}', '}}')
     return url_path
@@ -184,7 +187,7 @@ class SimpleRouter(BaseRouter):
                 initkwargs = route.initkwargs.copy()
                 initkwargs.update(method_kwargs)
                 url_path = initkwargs.pop("url_path", None) or methodname
-                url_path = replace_curly_brackets(url_path)
+                url_path = escape_curly_brackets(url_path)
                 url_name = initkwargs.pop("url_name", None) or url_path
                 ret.append(Route(
                     url=replace_methodname(route.url, url_path),

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -35,6 +35,12 @@ DynamicDetailRoute = namedtuple('DynamicDetailRoute', ['url', 'name', 'initkwarg
 DynamicListRoute = namedtuple('DynamicListRoute', ['url', 'name', 'initkwargs'])
 
 
+def replace_curly_brackets(url_path):
+    if ('{' and '}') in url_path:
+        url_path = url_path.replace('{', '{{').replace('}', '}}')
+    return url_path
+
+
 def replace_methodname(format_string, methodname):
     """
     Partially format a format_string, swapping out any
@@ -178,6 +184,7 @@ class SimpleRouter(BaseRouter):
                 initkwargs = route.initkwargs.copy()
                 initkwargs.update(method_kwargs)
                 url_path = initkwargs.pop("url_path", None) or methodname
+                url_path = replace_curly_brackets(url_path)
                 url_name = initkwargs.pop("url_name", None) or url_path
                 ret.append(Route(
                     url=replace_methodname(route.url, url_path),


### PR DESCRIPTION
refs : [#5172](https://github.com/encode/django-rest-framework/issues/5172)

before: [#5177](https://github.com/encode/django-rest-framework/pull/5177)

when list_route and detail_route's url_path contains curly brackets, it raise IndexError
as we can see at [#5172](https://github.com/encode/django-rest-framework/issues/5172).

added test code ensure that when I escape curly bracket it works fine.

I think list_route and detail_route need url_path with regex lookup for making restful url
unless we can use nested route on list_route and detail_route.