### PR TITLE
Updated DjangoRestMulipleModel documentation to point to new repo loc…

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -390,4 +390,4 @@ The [django-rest-framework-bulk package][django-rest-framework-bulk] implements 
 [UpdateModelMixin]: #updatemodelmixin
 [DestroyModelMixin]: #destroymodelmixin
 [django-rest-framework-bulk]: https://github.com/miki725/django-rest-framework-bulk
-[django-rest-multiple-models]: https://github.com/Axiologue/DjangoRestMultipleModels
+[django-rest-multiple-models]: https://github.com/MattBroach/DjangoRestMultipleModels

--- a/docs/topics/third-party-packages.md
+++ b/docs/topics/third-party-packages.md
@@ -296,7 +296,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [drf-compound-fields]: https://github.com/estebistec/drf-compound-fields
 [django-extra-fields]: https://github.com/Hipo/drf-extra-fields
 [djangorestframework-bulk]: https://github.com/miki725/django-rest-framework-bulk
-[django-rest-multiple-models]: https://github.com/Axiologue/DjangoRestMultipleModels
+[django-rest-multiple-models]: https://github.com/MattBroach/DjangoRestMultipleModels
 [drf-nested-routers]: https://github.com/alanjds/drf-nested-routers
 [wq.db.rest]: http://wq.io/docs/about-rest
 [djangorestframework-msgpack]: https://github.com/juanriaza/django-rest-framework-msgpack


### PR DESCRIPTION
I moved a 3rd party package, DjangoRestMultipleModels, from an organization github repo to my personal repo.  This is just a quick update to the docs to make sure that the two places it's mentioned point to the new location.
