### PR TITLE
fix source code repo link

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -373,7 +373,7 @@ Our API views don't do anything particularly special at the moment, beyond servi
 We'll see how we can start to improve things in [part 2 of the tutorial][tut-2].
 
 [quickstart]: quickstart.md
-[repo]: https://github.com/encode/rest-framework-tutorial
+[repo]: https://github.com/tomchristie/rest-framework-tutorial
 [sandbox]: http://restframework.herokuapp.com/
 [virtualenv]: http://www.virtualenv.org/en/latest/index.html
 [tut-2]: 2-requests-and-responses.md


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

This fixes issue https://github.com/encode/django-rest-framework/issues/5178 to point to the correct repo URL.

I see that that issue suggests a different solution (moving the repo), but for now it seems more useful to have a working link :)