### PR TITLE
fix APIView.permission_denied : NotAuthenticated exception can use us…

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -167,7 +167,7 @@ class APIView(View):
         If request is not permitted, determine what kind of exception to raise.
         """
         if request.authenticators and not request.successful_authenticator:
-            raise exceptions.NotAuthenticated()
+            raise exceptions.NotAuthenticated(detail=message)
         raise exceptions.PermissionDenied(detail=message)
 
     def throttled(self, request, wait):


### PR DESCRIPTION
## Description

For custom permission, in ApiView.permission_denied, user defined message is not used when an NotAuthenticated exception is raised. This commit fix it.
