### PR TITLE
Use stacklevel=2 with DeprecationWarnings

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -48,7 +48,7 @@ if django_filters:
             warnings.warn(
                 "The built in 'rest_framework.filters.FilterSet' is deprecated. "
                 "You should use 'django_filters.rest_framework.FilterSet' instead.",
-                DeprecationWarning
+                DeprecationWarning, stacklevel=2
             )
             return super(FilterSet, self).__init__(*args, **kwargs)
 
@@ -72,7 +72,7 @@ class DjangoFilterBackend(DFBase):
         warnings.warn(
             "The built in 'rest_framework.filters.DjangoFilterBackend' is deprecated. "
             "You should use 'django_filters.rest_framework.DjangoFilterBackend' instead.",
-            DeprecationWarning
+            DeprecationWarning, stacklevel=2
         )
 
         return super(DjangoFilterBackend, cls).__new__(cls, *args, **kwargs)

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -333,7 +333,7 @@ class DefaultRouter(SimpleRouter):
             warnings.warn(
                 "Including a schema directly via a router is now deprecated. "
                 "Use `get_schema_view()` instead.",
-                DeprecationWarning
+                DeprecationWarning, stacklevel=2
             )
         if 'schema_renderers' in kwargs:
             assert 'schema_title' in kwargs, 'Missing "schema_title" argument.'


### PR DESCRIPTION
This makes the warnings refer to the code where it is used, which makes
it easier to find and fix.