### PR TITLE
Check source attrs when checking for nested writes.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -801,9 +801,8 @@ def raise_errors_on_nested_writes(method_name, serializer, validated_data):
     #     ...
     #     address = serializer.CharField('profile.address')
     assert not any(
-        '.' in field.source and
-        (key in validated_data) and
-        isinstance(validated_data[key], (list, dict))
+        len(field.source_attrs) and
+        (field.source_attrs[0] in validated_data)
         for key, field in serializer.fields.items()
     ), (
         'The `.{method_name}()` method does not support writable dotted-source '


### PR DESCRIPTION
## Description

When checking for 'dotted' source nested values prior to serializer create or update, the problematic fields are not being identified correctly.

In the example given in the code comment, the validated data would look like `{'profile': {'address': '10 downing street'}}` but the code is currently checking for key 'address' in the dict.
