### PR TITLE
Check source attrs when checking for nested writes

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -802,7 +802,8 @@ def raise_errors_on_nested_writes(method_name, serializer, validated_data):
     #     address = serializer.CharField('profile.address')
     assert not any(
         len(field.source_attrs) > 1 and
-        (field.source_attrs[0] in validated_data)
+        (field.source_attrs[0] in validated_data) and
+        isinstance(validated_data[field.source_attrs[0]], (list, dict))
         for key, field in serializer.fields.items()
     ), (
         'The `.{method_name}()` method does not support writable dotted-source '

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -801,9 +801,8 @@ def raise_errors_on_nested_writes(method_name, serializer, validated_data):
     #     ...
     #     address = serializer.CharField('profile.address')
     assert not any(
-        '.' in field.source and
-        (key in validated_data) and
-        isinstance(validated_data[key], (list, dict))
+        len(field.source_attrs) > 1 and
+        (field.source_attrs[0] in validated_data)
         for key, field in serializer.fields.items()
     ), (
         'The `.{method_name}()` method does not support writable dotted-source '

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -1,3 +1,5 @@
+import pytest
+from django.db import models
 from django.http import QueryDict
 
 from rest_framework import serializers
@@ -202,3 +204,23 @@ class TestNestedSerializerWithList:
 
         assert serializer.is_valid()
         assert serializer.validated_data['nested']['example'] == set([1, 2])
+
+
+class TestNestedWrites:
+    def test_nested_source_attr_write(self):
+        class NestedSourceModel(models.Model):
+            profile = models.CharField()
+
+        class NestedSourceSerializer(serializers.ModelSerializer):
+            address = serializers.CharField(source='profile.address')
+
+            class Meta:
+                model = NestedSourceModel
+                fields = ('address',)
+
+        data = QueryDict('address=52 festive road')
+        serializer = NestedSourceSerializer(data=data)
+        serializer.is_valid()
+        assert serializer.validated_data == {'profile': {'address': '52 festive road'}}
+        with pytest.raises(AssertionError):
+            serializer.save()


### PR DESCRIPTION
## Description

When checking for 'dotted' source nested values prior to serializer create or update, the problematic fields are not being identified correctly.

In the example given in the code comment, the validated data would look like `{'profile': {'address': '10 downing street'}}` but the code is currently checking for key 'address' in the dict.

## Test case

The issue can be seen currently with the following test (which will fail):
```
import pytest
from django.contrib.postgres.fields import JSONField
from django.db import models
from rest_framework import serializers

class NestedSourceModel(models.Model):
    profile = JSONField()

class NestedSourceSerializer(serializers.ModelSerializer):
    address = serializers.CharField(source='profile.address')

    class Meta:
        model = NestedSourceModel
        fields = ('address',)

data = QueryDict('address=10 downing street')
serializer = NestedSourceSerializer(data=data)
serializer.is_valid()
assert serializer.validated_data == {'profile': {'address': '10 downing street'}}
with pytest.raises(AssertionError):
    serializer.save()
```