### PR TITLE
Quote nested API parameters in api.js

### DIFF
--- a/rest_framework/static/rest_framework/docs/js/api.js
+++ b/rest_framework/static/rest_framework/docs/js/api.js
@@ -102,7 +102,7 @@ $(function () {
       var entry = entries[i]
       var paramKey = entry[0]
       var paramValue = entry[1]
-      var $elem = $form.find('[name=' + paramKey + ']')
+      var $elem = $form.find('[name="' + paramKey + '"]')
       var dataType = $elem.data('type') || 'string'
 
       if (dataType === 'integer' && paramValue) {


### PR DESCRIPTION
I sometimes have parameter names with a period (.) in them, to represent nested objects, e.g. containerobj.inner_param. The Javascript was throwing an error in the browsable API when interacting with those parameters.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
