### PR TITLE
Pass extra fields to paginated HTTP Response

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -172,12 +172,12 @@ class GenericAPIView(views.APIView):
             return None
         return self.paginator.paginate_queryset(queryset, self.request, view=self)
 
-    def get_paginated_response(self, data):
+    def get_paginated_response(self, data, extra_fields={}):
         """
         Return a paginated style `Response` object for the given output data.
         """
         assert self.paginator is not None
-        return self.paginator.get_paginated_response(data)
+        return self.paginator.get_paginated_response(data, extra_fields)
 
 
 # Concrete view classes that provide method handlers

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -42,7 +42,11 @@ class ListModelMixin(object):
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+            if 'extra_fields' in kwargs:
+                extra_fields = kwargs['extra_fields']
+            else:
+                extra_fields = {}
+            return self.get_paginated_response(serializer.data, extra_fields)
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -232,7 +232,7 @@ class PageNumberPagination(BasePagination):
             ('previous', self.get_previous_link()),
             ('results', data)
         ])
-    
+
     def get_paginated_response(self, data, extra_fields={}):
         ordered_dict = self.get_paginated_dictionary(data)
         for key in extra_fields:

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -225,13 +225,16 @@ class PageNumberPagination(BasePagination):
         self.request = request
         return list(self.page)
 
-    def get_paginated_response(self, data):
-        return Response(OrderedDict([
+    def get_paginated_dictionary(self, data):
+        return OrderedDict([
             ('count', self.page.paginator.count),
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),
             ('results', data)
-        ]))
+        ])
+    
+    def get_paginated_response(self, data, extra_fields={}):
+        return Response(self.get_paginated_dictionary(data).update(extra_fields))
 
     def get_page_size(self, request):
         if self.page_size_query_param:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

This patch allows the developers to pass extra fields to a paginated HTTP Response by adding a dictionary of the extra fields to the `extra_fields` Keyword arguments of the **list** method.
for example, they can use it by modifying the get method of a ListAPIView:
```
class SampleListAPI(generics.ListAPIView):

    def get(self, request, *args, **kwargs):
        kwargs['extra_fields'] = {'foo': 'bar'}
        return self.list(request, *args, **kwargs)
```
