### PR TITLE
Update API guide section referring to DOT

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -300,7 +300,7 @@ Add the package to your `INSTALLED_APPS` and modify your REST framework settings
 
     REST_FRAMEWORK = {
         'DEFAULT_AUTHENTICATION_CLASSES': (
-            'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+            'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         )
     }
 


### PR DESCRIPTION
DOT renamed `ext` to `contrib` on their new release `1.0.0`

https://github.com/evonove/django-oauth-toolkit/commit/cdc00603e738fdf78a217754196113cadc000f4f
