### PR TITLE
default value for path field should be empty string instead of None

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -553,7 +553,7 @@ class SchemaGenerator(object):
                 name=variable,
                 location='path',
                 required=True,
-                schema=schema_cls(title=title, description=description, **kwargs)
+                schema=schema_cls(title=title, description=description, default='', **kwargs)
             )
             fields.append(field)
 


### PR DESCRIPTION
## Description
the schema_cls doesn't pass the default value for the field, so it will be None, meaning swagger ui will show 'null' when it should be empty
