### PR TITLE
Fixed #5228 Set ViewSet args/kwargs/request before dispatch

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -82,6 +82,10 @@ class ViewSetMixin(object):
             if hasattr(self, 'get') and not hasattr(self, 'head'):
                 self.head = self.get
 
+            self.request = request
+            self.args = args
+            self.kwargs = kwargs
+
             # And continue as usual
             return self.dispatch(request, *args, **kwargs)
 

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -13,6 +13,15 @@ class BasicViewSet(GenericViewSet):
         return Response({'ACTION': 'LIST'})
 
 
+class InstanceViewSet(GenericViewSet):
+
+    def dispatch(self, request, *args, **kwargs):
+        return self.dummy(request, *args, **kwargs)
+
+    def dummy(self, request, *args, **kwargs):
+        return Response({'view': self})
+
+
 class InitializeViewSetsTestCase(TestCase):
     def test_initialize_view_set_with_actions(self):
         request = factory.get('/', '', content_type='application/json')
@@ -42,3 +51,17 @@ class InitializeViewSetsTestCase(TestCase):
                               "For example `.as_view({'get': 'list'})`")
         else:
             self.fail("actions must not be empty.")
+
+    def test_args_kwargs_request_action_map_on_self(self):
+        """
+        Test a view only has args, kwargs, request, action_map
+        once `as_view` has been called.
+        """
+        bare_view = InstanceViewSet()
+        view = InstanceViewSet.as_view(actions={
+            'get': 'dummy',
+        })(factory.get('/')).data['view']
+
+        for attribute in ('args', 'kwargs', 'request', 'action_map'):
+            self.assertNotIn(attribute, dir(bare_view))
+            self.assertIn(attribute, dir(view))


### PR DESCRIPTION
This fixes issue #5228

Actually I didn't find when `args`, `kwargs` and `request` are set in the dispatch and just set them before that as Django does.

P.S.
I found where "the magic happens". If we want restframework's request to be available as early as possible (before `dispatch` as is with Django's request object), even on normal API views then setting of djangorestframework's request can be done in `as_view` method (but should be done twice - once for `APIView` and once for `ViewSet`).
Even If we decided that it's not a problem django's request object to be available before `dispatch` (as is right now for APIView) because RestFramework supports Django 1.8+ we can remove  setting of `args` and `kwargs` in dispatch, because they are already set by `as_view` decorator.

I can update the PR with these changes if you want?