### PR TITLE
Link in the home page is broken

### DIFF
--- a/docs/api-guide/exceptions.md
+++ b/docs/api-guide/exceptions.md
@@ -230,5 +230,5 @@ The generic views use the `raise_exception=True` flag, which means that you can 
 
 By default this exception results in a response with the HTTP status code "400 Bad Request".
 
-[cite]: http://www.doughellmann.com/articles/how-tos/python-exception-handling/index.html
+[cite]: https://doughellmann.com/blog/2009/06/19/python-exception-handling-techniques/
 [authentication]: authentication.md


### PR DESCRIPTION
The link to the _Python Exception Handling Techniques_ article written by _Doug Hellmann_ is broken.

I could find the article in the URL I proposed in this PR.


*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
