### PR TITLE
Fix file closing at end of request

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -250,6 +250,11 @@ class Request(object):
             else:
                 self._full_data = self._data
 
+            # copy data & files refs to the underlying request so that closable
+            # objects are handled appropriately.
+            self._request._post = self._data
+            self._request._files = self._files
+
     def _load_stream(self):
         """
         Return the content body of the request, as a stream.


### PR DESCRIPTION
Maybe fixes #5209. 

The underlying Django request object automatically closes files, however file parsing is preempted by DRF's own parsing, so it's unaware of the files and so is unable to close them. IDK if there are any negative side effects here, but simply setting the references on the underlying request seems to fix this. 