### PR TITLE
Use strict float handling in JSON functions

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -362,6 +362,14 @@ The default style is to return minified responses, in line with [Heroku's API de
 
 Default: `True`
 
+#### STRICT_JSON
+
+When set to `True`, JSON rendering and parsing will only observe syntactically valid JSON, raising an exception for the extended float values (`nan`, `inf`, `-inf`) accepted by Python's `json` module. This is the recommended setting, as these values are not generally supported. e.g., neither Javascript's `JSON.Parse` nor PostgreSQL's JSON data type accept these values.
+
+When set to `False`, JSON rendering and parsing will be permissive. However, these values are still invalid and will need to be specially handled in your code.
+
+Default: `True`
+
 #### COERCE_DECIMAL_TO_STRING
 
 When returning decimal objects in API representations that do not support a native decimal type, it is normally best to return the value as a string. This avoids the loss of precision that occurs with binary floating point implementations.

--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,5 +1,6 @@
 # PEP8 code linting, which we run on all commits.
 flake8==2.4.0
+flake8-tidy-imports==1.1.0
 pep8==1.5.7
 
 # Sort and lint imports

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -5,7 +5,6 @@ import copy
 import datetime
 import decimal
 import inspect
-import json
 import re
 import uuid
 from collections import OrderedDict
@@ -38,7 +37,7 @@ from rest_framework.compat import (
 )
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.settings import api_settings
-from rest_framework.utils import html, humanize_datetime, representation
+from rest_framework.utils import html, humanize_datetime, json, representation
 
 
 class empty:

--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -22,6 +22,7 @@ from django.utils.six.moves.urllib import parse as urlparse
 
 from rest_framework import renderers
 from rest_framework.exceptions import ParseError
+from rest_framework.settings import api_settings
 from rest_framework.utils import json
 
 
@@ -53,6 +54,7 @@ class JSONParser(BaseParser):
     """
     media_type = 'application/json'
     renderer_class = renderers.JSONRenderer
+    strict = api_settings.STRICT_JSON
 
     def parse(self, stream, media_type=None, parser_context=None):
         """
@@ -63,7 +65,8 @@ class JSONParser(BaseParser):
 
         try:
             decoded_stream = codecs.getreader(encoding)(stream)
-            return json.load(decoded_stream)
+            parse_constant = json.strict_constant if self.strict else None
+            return json.load(decoded_stream, parse_constant=parse_constant)
         except ValueError as exc:
             raise ParseError('JSON parse error - %s' % six.text_type(exc))
 

--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -7,7 +7,6 @@ on the request, such as form content or json encoded data.
 from __future__ import unicode_literals
 
 import codecs
-import json
 
 from django.conf import settings
 from django.core.files.uploadhandler import StopFutureHandlers
@@ -23,6 +22,7 @@ from django.utils.six.moves.urllib import parse as urlparse
 
 from rest_framework import renderers
 from rest_framework.exceptions import ParseError
+from rest_framework.utils import json
 
 
 class DataAndFiles(object):

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -9,7 +9,6 @@ REST framework also provides an HTML renderer that renders the browsable API.
 from __future__ import unicode_literals
 
 import base64
-import json
 from collections import OrderedDict
 
 from django import forms
@@ -30,7 +29,7 @@ from rest_framework.compat import (
 from rest_framework.exceptions import ParseError
 from rest_framework.request import is_form_media_type, override_method
 from rest_framework.settings import api_settings
-from rest_framework.utils import encoders
+from rest_framework.utils import encoders, json
 from rest_framework.utils.breadcrumbs import get_breadcrumbs
 from rest_framework.utils.field_mapping import ClassLookupDict
 

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -61,6 +61,7 @@ class JSONRenderer(BaseRenderer):
     encoder_class = encoders.JSONEncoder
     ensure_ascii = not api_settings.UNICODE_JSON
     compact = api_settings.COMPACT_JSON
+    strict = api_settings.STRICT_JSON
 
     # We don't set a charset because JSON is a binary encoding,
     # that can be encoded as utf-8, utf-16 or utf-32.
@@ -101,7 +102,7 @@ class JSONRenderer(BaseRenderer):
         ret = json.dumps(
             data, cls=self.encoder_class,
             indent=indent, ensure_ascii=self.ensure_ascii,
-            separators=separators
+            allow_nan=not self.strict, separators=separators
         )
 
         # On python 2.x json.dumps() returns bytestrings if ensure_ascii=True,

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -110,6 +110,7 @@ DEFAULTS = {
     # Encoding
     'UNICODE_JSON': True,
     'COMPACT_JSON': True,
+    'STRICT_JSON': True,
     'COERCE_DECIMAL_TO_STRING': True,
     'UPLOADED_FILES_USE_URL': True,
 

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -1,7 +1,7 @@
 """
 Helper classes for parsers.
 """
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 import decimal

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 import decimal
-import json
+import json  # noqa
 import uuid
 
 from django.db.models.query import QuerySet

--- a/rest_framework/utils/json.py
+++ b/rest_framework/utils/json.py
@@ -1,3 +1,10 @@
+"""
+Wrapper for the builtin json module that ensures compliance with the JSON spec.
+
+REST framework should always import this wrapper module in order to maintain
+spec-compliant encoding/decoding. Support for non-standard features should be
+handled by users at the renderer and parser layer.
+"""
 
 from __future__ import absolute_import
 

--- a/rest_framework/utils/json.py
+++ b/rest_framework/utils/json.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 import functools
-import json
+import json  # noqa
 
 
 def strict_constant(o):

--- a/rest_framework/utils/json.py
+++ b/rest_framework/utils/json.py
@@ -1,0 +1,33 @@
+
+from __future__ import absolute_import
+
+import functools
+import json
+
+
+def strict_constant(o):
+    raise ValueError('Out of range float values are not JSON compliant: ' + repr(o))
+
+
+@functools.wraps(json.dump)
+def dump(*args, **kwargs):
+    kwargs.setdefault('allow_nan', False)
+    return json.dump(*args, **kwargs)
+
+
+@functools.wraps(json.dumps)
+def dumps(*args, **kwargs):
+    kwargs.setdefault('allow_nan', False)
+    return json.dumps(*args, **kwargs)
+
+
+@functools.wraps(json.load)
+def load(*args, **kwargs):
+    kwargs.setdefault('parse_constant', strict_constant)
+    return json.load(*args, **kwargs)
+
+
+@functools.wraps(json.loads)
+def loads(*args, **kwargs):
+    kwargs.setdefault('parse_constant', strict_constant)
+    return json.loads(*args, **kwargs)

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -88,7 +88,7 @@ class JSONBoundField(BoundField):
         value = self.value
         try:
             value = json.dumps(self.value, sort_keys=True, indent=4)
-        except TypeError:
+        except (TypeError, ValueError):
             pass
         return self.__class__(self._field, value, self.errors, self._prefix)
 

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 
 import collections
-import json
 from collections import OrderedDict
 
 from django.utils.encoding import force_text
 
 from rest_framework.compat import unicode_to_repr
+from rest_framework.utils import json
 
 
 class ReturnDict(OrderedDict):

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ license_file = LICENSE.md
 
 [flake8]
 ignore = E501
+banned-modules = json = use from rest_framework.utils import json!

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1811,6 +1811,7 @@ class TestJSONField(FieldValues):
     ]
     invalid_inputs = [
         ({'a': set()}, ['Value must be valid JSON.']),
+        ({'a': float('inf')}, ['Value must be valid JSON.']),
     ]
     outputs = [
         ({

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import json
 import re
 from collections import MutableMapping, OrderedDict
 
@@ -24,6 +23,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
+from rest_framework.utils import json
 from rest_framework.views import APIView
 
 DUMMYSTATUS = status.HTTP_200_OK

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -357,6 +357,19 @@ class JSONRendererTests(TestCase):
         with self.assertRaises(TypeError):
             JSONRenderer().render(x)
 
+    def test_float_strictness(self):
+        renderer = JSONRenderer()
+
+        # Default to strict
+        for value in [float('inf'), float('-inf'), float('nan')]:
+            with pytest.raises(ValueError):
+                renderer.render(value)
+
+        renderer.strict = False
+        assert renderer.render(float('inf')) == b'Infinity'
+        assert renderer.render(float('-inf')) == b'-Infinity'
+        assert renderer.render(float('nan')) == b'NaN'
+
     def test_without_content_type_args(self):
         """
         Test basic JSON rendering.

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import json
 from collections import namedtuple
 
 import pytest
@@ -15,6 +14,7 @@ from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
 from rest_framework.routers import DefaultRouter, SimpleRouter
 from rest_framework.test import APIRequestFactory
+from rest_framework.utils import json
 
 factory = APIRequestFactory()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -198,3 +198,10 @@ class JsonFloatTests(TestCase):
 
         with self.assertRaises(ValueError):
             json.loads("NaN")
+
+
+@override_settings(STRICT_JSON=False)
+class NonStrictJsonFloatTests(JsonFloatTests):
+    """
+    'STRICT_JSON = False' should not somehow affect internal json behavior
+    """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ import rest_framework.utils.model_meta
 from rest_framework.compat import _resolve_model
 from rest_framework.routers import SimpleRouter
 from rest_framework.serializers import ModelSerializer
+from rest_framework.utils import json
 from rest_framework.utils.breadcrumbs import get_breadcrumbs
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
@@ -177,3 +178,23 @@ class ResolveModelWithPatchedDjangoTests(TestCase):
     def test_blows_up_if_model_does_not_resolve(self):
         with self.assertRaises(ImproperlyConfigured):
             _resolve_model('tests.BasicModel')
+
+
+class JsonFloatTests(TestCase):
+    """
+    Internaly, wrapped json functions should adhere to strict float handling
+    """
+
+    def test_dumps(self):
+        with self.assertRaises(ValueError):
+            json.dumps(float('inf'))
+
+        with self.assertRaises(ValueError):
+            json.dumps(float('nan'))
+
+    def test_loads(self):
+        with self.assertRaises(ValueError):
+            json.loads("Infinity")
+
+        with self.assertRaises(ValueError):
+            json.loads("NaN")


### PR DESCRIPTION
Resolve #4918, fix #5235. The important bits that I gathered from the discussion were:

- DRF should internally encode/decode only strict JSON, since other modules (eg, postgres's `JSONField`) may not be compatible with the extended float values (`Infinity`, `NaN`). Incompatible values should raise an exception.
- Users may still want to render/parse extended JSON. 

This PR does the following:
- Adds an internal `rest_framework.utils.json` module that defaults to strict JSON encoding/decoding. 
- All imports have been changed to `rest_framework.utils.json`, so they obey the stricter behavior. 
- Adds flake8-tidy-imports, which allows us direct users to import the json wrapper module. 
- Adds `settings.STRICT_JSON`, which controls the strictness of `JSONParser` & `JSONRenderer`. This defaults to `True`, but users can revert to the old extended behavior by setting this to `False`