### PR TITLE
Add link to third-party package for LinkHeaderPagination.

### DIFF
--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -242,29 +242,6 @@ We'd then need to setup the custom class in our configuration:
 
 Note that if you care about how the ordering of keys is displayed in responses in the browsable API you might choose to use an `OrderedDict` when constructing the body of paginated responses, but this is optional.
 
-## Header based pagination
-
-Let's modify the built-in `PageNumberPagination` style, so that instead of include the pagination links in the body of the response, we'll instead include a `Link` header, in a [similar style to the GitHub API][github-link-pagination].
-
-    class LinkHeaderPagination(pagination.PageNumberPagination):
-        def get_paginated_response(self, data):
-            next_url = self.get_next_link()
-            previous_url = self.get_previous_link()
-
-            if next_url is not None and previous_url is not None:
-                link = '<{next_url}>; rel="next", <{previous_url}>; rel="prev"'
-            elif next_url is not None:
-                link = '<{next_url}>; rel="next"'
-            elif previous_url is not None:
-                link = '<{previous_url}>; rel="prev"'
-            else:
-                link = ''
-
-            link = link.format(next_url=next_url, previous_url=previous_url)
-            headers = {'Link': link} if link else {}
-
-            return Response(data, headers=headers)
-
 ## Using your custom pagination class
 
 To have your custom pagination class be used by default, use the `DEFAULT_PAGINATION_CLASS` setting:
@@ -328,10 +305,15 @@ The [`DRF-extensions` package][drf-extensions] includes a [`PaginateByMaxMixin` 
 
 The [`drf-proxy-pagination` package][drf-proxy-pagination] includes a `ProxyPagination` class which allows to choose pagination class with a query parameter.
 
+## link-header-pagination
+
+The [`django-rest-framework-link-header-pagination` package][drf-link-header-pagination] includes a `LinkHeaderPagination` class which provides pagination via an HTTP `Link` header as desribed in [Github's developer documentation](github-link-pagination).
+
 [cite]: https://docs.djangoproject.com/en/stable/topics/pagination/
 [github-link-pagination]: https://developer.github.com/guides/traversing-with-pagination/
 [link-header]: ../img/link-header-pagination.png
 [drf-extensions]: http://chibisov.github.io/drf-extensions/docs/
 [paginate-by-max-mixin]: http://chibisov.github.io/drf-extensions/docs/#paginatebymaxmixin
 [drf-proxy-pagination]: https://github.com/tuffnatty/drf-proxy-pagination
+[drf-link-header-pagination]: https://github.com/tbeadle/django-rest-framework-link-header-pagination
 [disqus-cursor-api]: http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api


### PR DESCRIPTION
A third-party package has been created for Link header pagination as requested in https://github.com/encode/django-rest-framework/pull/5268.