### PR TITLE
Fix issue when serializing certain foreign keys.

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -61,6 +61,19 @@ class ForeignKeySource(RESTFrameworkModel):
                                on_delete=models.CASCADE)
 
 
+class ForeignKeyInUniquenessConstraintSource(RESTFrameworkModel):
+    name = models.CharField(max_length=100)
+    target = models.ForeignKey(ForeignKeyTarget,
+                               related_name='sources_with_uniqueness',
+                               help_text='Target',
+                               verbose_name='Target',
+                               default=1,
+                               on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('name', 'target')
+
+
 # Nullable ForeignKey
 class NullableForeignKeySource(RESTFrameworkModel):
     name = models.CharField(max_length=100)


### PR DESCRIPTION
If a foreign key has a default value that is not an instance of the
related model (i.e. its a value for the primary key for that model),
the foreign key field has a uniqueness constraint, and the field was not
provided as data for the serializer, then we need to set that default
value to the attname of the field when creating the model instance.
Otherwise, a ValueError will be raised when creating the model instance,
saying `Cannot assign "<default value>": "<field>" must be a
"<related_model>" instance.`

This change ensures that the kwargs passed to model instance creation
are modified when appropriate to account for this.

Signed-off-by: Tommy Beadle <tbeadle@gmail.com>