### PR TITLE
Support passing of "title" attribute from views to the generated schema Links

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -471,11 +471,7 @@ class SchemaGenerator(object):
 
         If the 'title' attribute is not set on the view, then an empty title is returned.
         """
-        title = ""
-        if hasattr(view, "title"):
-            title = view.title
-
-        return title
+        return getattr(view, 'title', '')
 
     def get_description(self, path, method, view):
         """

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -454,13 +454,28 @@ class SchemaGenerator(object):
         if self.url and path.startswith('/'):
             path = path[1:]
 
+        title = self.get_title(view)
+
         return coreapi.Link(
+            title=title,
             url=urlparse.urljoin(self.url, path),
             action=method.lower(),
             encoding=encoding,
             fields=fields,
             description=description
         )
+
+    def get_title(self, view):
+        """
+        Determine a title from a view instance.
+
+        If the 'title' attribute is not set on the view, then an empty title is returned.
+        """
+        title = ""
+        if hasattr(view, "title"):
+            title = view.title
+
+        return title
 
     def get_description(self, path, method, view):
         """


### PR DESCRIPTION
As described by core-api/python-openapi-codec#28, the "name" field of the generated Swagger JSON is currently hard-coded to "data".  When using swagger-codegen, the generated models are labeled \<Data*\> which breaks the reusability of the generated SDKs.  

The proposed solution allows a user to set a "title" property on a view (or viewset) which is then used to generate the "name" field in this format:  \<Title\>\<Action\>Params.  

For example, the "post" action of the following viewset will be given a name of "CommentPostParams" instead of "data".

```python
class CommentViewSet(viewsets.ModelViewSet):
    queryset = Comment.objects.all()
    serializer_class = CommentSerializer
    title = "comment"
```

This pull request has an associated pull request:  core-api/python-openapi-codec#42, both of which act to drive further discussion on core-api/python-openapi-codec#28.  

Assuming views and viewsets are named \<ViewName\>View and \<ViewSetName\>ViewSet, it would also be possible to extract the view name automatically with a small code change.

Related issue: marcgibbons/django-rest-swagger#595