### PR TITLE
Fix token param in force_authenticate example

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -82,7 +82,7 @@ For example, when forcibly authenticating using a token, you might do something 
 
     user = User.objects.get(username='olivia')
     request = factory.get('/accounts/django-superstars/')
-    force_authenticate(request, user=user, token=user.token)
+    force_authenticate(request, user=user, token=user.auth_token)
 
 ---
 


### PR DESCRIPTION
Minor fix in the Testing API Guide.