### PR TITLE
Failing tests: `Meta.view_name` not heeded in HyperlinkedModelSerializer

### DIFF
--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -680,7 +680,6 @@ class TestRelationalFieldMappings(TestCase):
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 
 
-
 class DisplayValueTargetModel(models.Model):
     name = models.CharField(max_length=100)
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -639,6 +639,47 @@ class TestRelationalFieldMappings(TestCase):
         """)
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 
+    def test_view_url_custom_view_name(self):
+        class TestSerializer(serializers.HyperlinkedModelSerializer):
+            class Meta:
+                model = RelationalModel
+                fields = ('url', )
+                view_name = 'custom_view_name'
+
+        expected = dedent("""
+            TestSerializer():
+                url = HyperlinkedIdentityField(view_name='custom_view_name')
+        """)
+        self.assertEqual(unicode_repr(TestSerializer()), expected)
+
+    def test_view_url_namespaced(self):
+        class TestSerializer(serializers.HyperlinkedModelSerializer):
+            class Meta:
+                model = RelationalModel
+                fields = ('url', )
+                namespace = 'api'
+
+        expected = dedent("""
+            TestSerializer():
+                url = HyperlinkedIdentityField(view_name='api:relationalmodel-detail')
+        """)
+        self.assertEqual(unicode_repr(TestSerializer()), expected)
+
+    def test_view_url_namespaced_custom_view_name(self):
+        class TestSerializer(serializers.HyperlinkedModelSerializer):
+            class Meta:
+                model = RelationalModel
+                fields = ('url', )
+                view_name = 'custom_view_name'
+                namespace = 'api'
+
+        expected = dedent("""
+            TestSerializer():
+                url = HyperlinkedIdentityField(view_name='api:custom_view_name')
+        """)
+        self.assertEqual(unicode_repr(TestSerializer()), expected)
+
+
 
 class DisplayValueTargetModel(models.Model):
     name = models.CharField(max_length=100)


### PR DESCRIPTION
Failing tests for issue #5291

## Description

There is perhaps slightly too much in this PR, in that I'm testing for both "the `view_name` doesn't work" issue, as well as "Serializer Meta classes should support namespaces" issue, which is tangential, but out-of-scope to the filed issue.

I'm happy to remove the namespace tests if it's determined that those changes actually shouldn't be in the library.

In any event, it seems like the appropriate solution here is to pass the meta-class of the serializer into the [`get_url_kwargs` function](https://github.com/encode/django-rest-framework/blob/master/rest_framework/utils/field_mapping.py#L292) so that namespace and `view_name` can be made available.