### PR TITLE
Misleading ListField signature #5301

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -434,9 +434,9 @@ Requires either the `Pillow` package or `PIL` package.  The `Pillow` package is 
 
 A field class that validates a list of objects.
 
-**Signature**: `ListField(child, min_length=None, max_length=None)`
+**Signature**: `ListField(child=None, min_length=None, max_length=None)`
 
-- `child` - A field instance that should be used for validating the objects in the list. If this argument is not provided then objects in the list will not be validated.
+- `child` - A field instance that should be used for validating the objects in the list. If this argument is not provided or is `None then objects in the list will not be validated.
 - `min_length` - Validates that the list contains no fewer than this number of elements.
 - `max_length` - Validates that the list contains no more than this number of elements.
 
@@ -457,9 +457,9 @@ We can now reuse our custom `StringListField` class throughout our application, 
 
 A field class that validates a dictionary of objects. The keys in `DictField` are always assumed to be string values.
 
-**Signature**: `DictField(child)`
+**Signature**: `DictField(child=None)`
 
-- `child` - A field instance that should be used for validating the values in the dictionary. If this argument is not provided then values in the mapping will not be validated.
+- `child` - A field instance that should be used for validating the values in the dictionary. If this argument is not provided or is `None` then values in the mapping will not be validated.
 
 For example, to create a field that validates a mapping of strings to strings, you would write something like this:
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1522,7 +1522,10 @@ class ListField(Field):
     }
 
     def __init__(self, *args, **kwargs):
-        self.child = kwargs.pop('child', copy.deepcopy(self.child))
+        child = kwargs.pop('child')
+        if child is None:
+            child = copy.deepcopy(self.child)
+        self.child = child
         self.allow_empty = kwargs.pop('allow_empty', True)
         self.max_length = kwargs.pop('max_length', None)
         self.min_length = kwargs.pop('min_length', None)
@@ -1583,7 +1586,10 @@ class DictField(Field):
     }
 
     def __init__(self, *args, **kwargs):
-        self.child = kwargs.pop('child', copy.deepcopy(self.child))
+        child = kwargs.pop('child')
+        if child is None:
+            child = copy.deepcopy(self.child)
+        self.child = child
 
         assert not inspect.isclass(self.child), '`child` has not been instantiated.'
         assert self.child.source is None, (

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1522,7 +1522,7 @@ class ListField(Field):
     }
 
     def __init__(self, *args, **kwargs):
-        child = kwargs.pop('child')
+        child = kwargs.pop('child', None)
         if child is None:
             child = copy.deepcopy(self.child)
         self.child = child
@@ -1586,7 +1586,7 @@ class DictField(Field):
     }
 
     def __init__(self, *args, **kwargs):
-        child = kwargs.pop('child')
+        child = kwargs.pop('child', None)
         if child is None:
             child = copy.deepcopy(self.child)
         self.child = child

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1734,6 +1734,13 @@ class TestUnvalidatedListField(FieldValues):
     field = serializers.ListField()
 
 
+class TestUnvalidatedListFieldWithChildNone(TestUnvalidatedListField):
+    """
+        Values for `ListField` with `child=None`.
+    """
+    field = serializers.ListField(child=None)
+
+
 class TestDictField(FieldValues):
     """
     Values for `ListField` with CharField as child.
@@ -1797,6 +1804,13 @@ class TestUnvalidatedDictField(FieldValues):
         ({'a': 1, 'b': [4, 5, 6]}, {'a': 1, 'b': [4, 5, 6]}),
     ]
     field = serializers.DictField()
+
+
+class TestUnvalidatedDictFieldWithChildNone(TestUnvalidatedDictField):
+    """
+        Values for `ListField` with `child=None`.
+    """
+    field = serializers.DictField(child=None)
 
 
 class TestJSONField(FieldValues):


### PR DESCRIPTION
Fix for Issue #5301 
## Description

Composite fields can accept `child` kwarg as `child=None`. This will result in the use of `_UnvalidatedField` just as if no child argument was passed. This makes the documentation clearer with the `ListField`and `DictField` signatures as `ListField(child=None, min_length=None, max_length=None)`