### PR TITLE
allow custom authentication and permission classes for docs view

### DIFF
--- a/rest_framework/documentation.py
+++ b/rest_framework/documentation.py
@@ -4,11 +4,14 @@ from rest_framework.renderers import (
     CoreJSONRenderer, DocumentationRenderer, SchemaJSRenderer
 )
 from rest_framework.schemas import SchemaGenerator, get_schema_view
+from rest_framework.settings import api_settings
 
 
 def get_docs_view(
         title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator):
+        patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     renderer_classes = [DocumentationRenderer, CoreJSONRenderer]
 
     return get_schema_view(
@@ -19,12 +22,16 @@ def get_docs_view(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
 
 
 def get_schemajs_view(
         title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator):
+        patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     renderer_classes = [SchemaJSRenderer]
 
     return get_schema_view(
@@ -35,12 +42,16 @@ def get_schemajs_view(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
 
 
 def include_docs_urls(
         title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator):
+        patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     docs_view = get_docs_view(
         title=title,
         description=description,
@@ -48,6 +59,8 @@ def include_docs_urls(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
     schema_js_view = get_schemajs_view(
         title=title,
@@ -56,6 +69,8 @@ def include_docs_urls(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
     urls = [
         url(r'^$', docs_view, name='docs-index'),

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -698,7 +698,9 @@ class SchemaView(APIView):
 
 def get_schema_view(
         title=None, url=None, description=None, urlconf=None, renderer_classes=None,
-        public=False, patterns=None, generator_class=SchemaGenerator):
+        public=False, patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     """
     Return a schema view.
     """
@@ -710,4 +712,6 @@ def get_schema_view(
         renderer_classes=renderer_classes,
         schema_generator=generator,
         public=public,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )


### PR DESCRIPTION
Currently (in 3.6.3) no authentication or permission classes can be supplied to the SchemaView, so it always uses the defaults.

This is a problem if, for example, the default is token authentication but the docs should be exposed on the web, or if permissions to access the API docs should be different from permissions to make requests to the API.

This PR allows the authentication and permission classes to be explicitly specified as kwargs to `include_docs_urls`.