### PR TITLE
Revert 3288

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -26,7 +26,6 @@ from django.utils.dateparse import (
 from django.utils.duration import duration_string
 from django.utils.encoding import is_protected_type, smart_text
 from django.utils.formats import localize_input, sanitize_separators
-from django.utils.functional import cached_property
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.timezone import utc
 from django.utils.translation import ugettext_lazy as _
@@ -586,7 +585,7 @@ class Field(object):
         message_string = msg.format(**kwargs)
         raise ValidationError(message_string, code=key)
 
-    @cached_property
+    @property
     def root(self):
         """
         Returns the top-level serializer for this field.
@@ -596,7 +595,7 @@ class Field(object):
             root = root.parent
         return root
 
-    @cached_property
+    @property
     def context(self):
         """
         Returns the context as passed to the root serializer on initialization.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -502,6 +502,16 @@ class TestCreateOnlyDefault:
         assert serializer.validated_data['context_set'] == 'success'
 
 
+class Test5087Regression:
+    def test_parent_binding(self):
+        parent = serializers.Serializer()
+        field = serializers.CharField()
+
+        assert field.root is field
+        field.bind('name', parent)
+        assert field.root is parent
+
+
 # Tests for field input and output values.
 # ----------------------------------------
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -469,6 +469,22 @@ class TestSerializerValidationWithCompiledRegexField:
         assert serializer.errors == {}
 
 
+class Test2505Regression:
+    def test_serializer_context(self):
+        class NestedSerializer(serializers.Serializer):
+            def __init__(self, *args, **kwargs):
+                super(NestedSerializer, self).__init__(*args, **kwargs)
+                # .context should not cache
+                self.context
+
+        class ParentSerializer(serializers.Serializer):
+            nested = NestedSerializer()
+
+        serializer = ParentSerializer(data={}, context={'foo': 'bar'})
+        assert serializer.context == {'foo': 'bar'}
+        assert serializer.fields['nested'].context == {'foo': 'bar'}
+
+
 class Test4606Regression:
     def setup(self):
         class ExampleSerializer(serializers.Serializer):


### PR DESCRIPTION
Reverting #3288 solves issues demonstrated in #5087 and #2555. Accessing a field/serializer `root` *before* the parent is bound resulted in the incorrect object being cached. My thoughts on this are that the caching benefits have nominal performance improvements and isn't really worth the incorrect behavior. 