### PR TITLE
QueryParameterHyperlinkedIdentityField added

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -12,7 +12,7 @@ from django.utils.encoding import (
 )
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
-
+from django.utils.http import urlencode
 from rest_framework.compat import (
     NoReverseMatch, Resolver404, get_script_prefix, resolve
 )
@@ -417,6 +417,16 @@ class HyperlinkedIdentityField(HyperlinkedRelatedField):
         # to run the 'only get the pk for this relationship' code.
         return False
 
+class QueryParameterHyperlinkedIdentityField(HyperlinkedIdentityField):
+    def __init__(self, query_params, **kwargs):
+        super(QueryParameterHyperlinkedIdentityField, self).__init__(**kwargs)
+        self.query_params = query_params
+
+    def get_url(self, obj, view_name, request, format):
+        url = super(QueryParameterHyperlinkedIdentityField, self).get_url(obj, view_name, request, format)
+        if len(self.query_params) > 0:
+            url += "?"+urlencode({k: getattr(obj, v) for k,v in self.query_params.items()})
+        return url
 
 class SlugRelatedField(RelatedField):
     """

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -60,7 +60,7 @@ from rest_framework.fields import (  # NOQA # isort:skip
     SerializerMethodField, SlugField, TimeField, URLField, UUIDField,
 )
 from rest_framework.relations import (  # NOQA # isort:skip
-    HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField,
+    HyperlinkedIdentityField, HyperlinkedRelatedField, QueryParameterHyperlinkedIdentityField, ManyRelatedField,
     PrimaryKeyRelatedField, RelatedField, SlugRelatedField, StringRelatedField,
 )
 


### PR DESCRIPTION
## Description

refs #5289 

I have included the solution I have found for the problem described in the issue above - small thing but it was useful to me and could be to others as well. With the added extension to the HyperlinkedIdentityField called QueryParameterHyperlinkedIdentityField in the relations.py, a user can now generate a hyperlink to containing the specified query parameter just as he/she would using the HyperlinkedIdentityField with an added parameter. 

Typical use case is below: 

`hyperlink_w/_query_param = serializers.QueryParameterHyperlinkedIdentityField(view_name='view-detail', lookup_field='entry_id', query_params={'param': 'parameter'})`

to obtain /view/<entry_id>?param=parameter as a hyperlink. 

As I said, it's a small thing but it works for me and maybe others would find it easier than to have to encode the url themselves.


