### PR TITLE
Allowed writable HyperlinkedIdentityField

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -408,7 +408,8 @@ class HyperlinkedIdentityField(HyperlinkedRelatedField):
 
     def __init__(self, view_name=None, **kwargs):
         assert view_name is not None, 'The `view_name` argument is required.'
-        kwargs['read_only'] = True
+        if 'read_only' not in kwargs:
+            kwargs['read_only'] = True
         kwargs['source'] = '*'
         super(HyperlinkedIdentityField, self).__init__(view_name, **kwargs)
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -469,7 +469,10 @@ class Serializer(BaseSerializer):
             except SkipField:
                 pass
             else:
-                set_value(ret, field.source_attrs, validated_value)
+                if field.source_attrs != [] or field.source == "*":
+                    set_value(ret, field.source_attrs, validated_value)
+                else:
+                    set_value(ret, [field.field_name, ], primitive_value)
 
         if errors:
             raise ValidationError(errors)


### PR DESCRIPTION
## Description

When calling POST, PUT, PATCH on objects with nested objects we need to know if the nested object is new or an update. To achieve this the nested object has a URL field which must be writable so as to appear in the validated data of myserializer.create and myserializer.update.

Example serializer:

    class TenderSerializer(serializers.HyperlinkedModelSerializer):
        type = TypeField()
        url = serializers.HyperlinkedIdentityField(view_name='tender-detail', 
                                                 read_only=False, 
                                                 queryset=Tender.objects.all())

        class Meta:
            model = Tender
            fields = ('type', 'url', 'sale', 'tender_type', 'amount',
                      'reference', )

    class SaleSerializer(serializers.HyperlinkedModelSerializer):
        tenders = TenderSerializer( many=True, read_only=False )
    
        class Meta:
            model = Sale
            fields = ('type', 'store', 'seller', 'datetime', 'docket_number', ...
                   'tenders',)
        
        def create(self, validated_data):
            tenders_data = validated_data.pop('tenders')
            sale = Sale.objects.create(**validated_data)

            for tender_data in tenders_data:
                # Are we updating or creating the nested object?
                if 'url' in tender_data.keys():
                    resolved_func, unused_args, resolved_kwargs = resolve(
                        urlparse(tender_data['url']).path)
                    object = resolved_func.cls.queryset.get(pk=resolved_kwargs['pk'])
                    for key, value in tender_data.items():
                        setattr( object, key, value )  
                else:
                    Tender.objects.create(sale=sale, **tender_data)
            return sale