### PR TITLE
Update JS constructor syntax

### DIFF
--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -408,7 +408,7 @@ The `coreapi` library, and the `schema` object will now both be available on the
 
 In order to interact with the API you'll need a client instance.
 
-    var client = coreapi.Client()
+    var client = new coreapi.Client()
 
 Typically you'll also want to provide some authentication credentials when
 instantiating the client.
@@ -423,7 +423,7 @@ the user to login, and then instantiate a client using session authentication:
         csrfCookieName: 'csrftoken',
         csrfHeaderName: 'X-CSRFToken'
     })
-    let client = coreapi.Client({auth: auth})
+    let client = new coreapi.Client({auth: auth})
 
 The authentication scheme will handle including a CSRF header in any outgoing
 requests for unsafe HTTP methods.
@@ -437,7 +437,7 @@ The `TokenAuthentication` class can be used to support REST framework's built-in
         scheme: 'JWT'
         token: '<token>'
     })
-    let client = coreapi.Client({auth: auth})
+    let client = new coreapi.Client({auth: auth})
 
 When using TokenAuthentication you'll probably need to implement a login flow
 using the CoreAPI client.
@@ -448,7 +448,7 @@ request to an "obtain token" endpoint
 For example, using the "Django REST framework JWT" package
 
     // Setup some globally accessible state
-    window.client = coreapi.Client()
+    window.client = new coreapi.Client()
     window.loggedIn = false
 
     function loginUser(username, password) {
@@ -475,7 +475,7 @@ The `BasicAuthentication` class can be used to support HTTP Basic Authentication
         username: '<username>',
         password: '<password>'
     })
-    let client = coreapi.Client({auth: auth})
+    let client = new coreapi.Client({auth: auth})
 
 ## Using the client
 


### PR DESCRIPTION
Fixes #5247

Adds missing `new` to the instantiation examples for the JS client. 