### PR TITLE
Schema generation overriding

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -309,7 +309,7 @@ class Field(object):
 
     def __init__(self, read_only=False, write_only=False,
                  required=None, default=empty, initial=empty, source=None,
-                 label=None, help_text=None, style=None,
+                 label=None, help_text=None, schema=None, style=None,
                  error_messages=None, validators=None, allow_null=False):
         self._creation_counter = Field._creation_counter
         Field._creation_counter += 1
@@ -341,6 +341,9 @@ class Field(object):
 
         if validators is not None:
             self.validators = validators[:]
+
+        if schema is not None:
+            self.schema = schema
 
         # These are set up by `.bind()` when the field is added to a serializer.
         self.field_name = None

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -75,7 +75,7 @@ class PKOnlyObject(object):
 # rather than the parent serializer.
 MANY_RELATION_KWARGS = (
     'read_only', 'write_only', 'required', 'default', 'initial', 'source',
-    'label', 'help_text', 'style', 'error_messages', 'allow_empty',
+    'label', 'help_text', 'schema', 'style', 'error_messages', 'allow_empty',
     'html_cutoff', 'html_cutoff_text'
 )
 

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -27,6 +27,9 @@ header_regex = re.compile('^[a-zA-Z][0-9A-Za-z_]*:')
 
 
 def field_to_schema(field):
+    if hasattr(field, 'schema'):
+        return field.schema
+
     title = force_text(field.label) if field.label else ''
     description = force_text(field.help_text) if field.help_text else ''
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -74,7 +74,7 @@ from rest_framework.relations import Hyperlink, PKOnlyObject  # NOQA # isort:ski
 # rather than the parent serializer.
 LIST_SERIALIZER_KWARGS = (
     'read_only', 'write_only', 'required', 'default', 'initial', 'source',
-    'label', 'help_text', 'style', 'error_messages', 'allow_empty',
+    'label', 'help_text', 'schema', 'style', 'error_messages', 'allow_empty',
     'instance', 'data', 'partial', 'context', 'allow_null'
 )
 
@@ -1174,7 +1174,7 @@ class ModelSerializer(Serializer):
             valid_kwargs = set((
                 'read_only', 'write_only',
                 'required', 'default', 'initial', 'source',
-                'label', 'help_text', 'style',
+                'label', 'help_text', 'schema', 'style',
                 'error_messages', 'validators', 'allow_null', 'allow_blank',
                 'choices'
             ))


### PR DESCRIPTION
I'm happy overall with the auto generated schema and have no desire to write it by hand. Sometimes there are issues though and it would be nice if there was a way to override it partially.

This is a proof-of-concept solution for Fields, that adds `schema` argument. Here we tell it that PrimaryKeyRelatedField should have integer values and not String:

```python
class CatSanctuarySerializer(ModelSerializer):

    favorite_cat = PrimaryKeyRelatedField(
        required=False,
        queryset=Cat.objects.all(),
        schema=coreschema.Integer(title='Cat.'),
    )

    cats = PrimaryKeyRelatedField(
        many=True,
        required=False,
        queryset=Cat.objects.all(),
        schema=coreschema.Array(
            items=coreschema.Integer(),
            title='Cats',
            description='My cats'
        ),
    )

    class Meta:
        model = MyCatSanctuary
        fields = 'id', 'favorite_cat', 'cats'
```

Should be useful in many other cases when SchemaGenerator doesn't quite cut it. What do you think? 
Also, if something similar is implemented for Serializers, Views and ViewSets it should solve #4685 