### PR TITLE
Added default value for 'detail' param into 'ValidationError' exception

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -123,7 +123,7 @@ class ValidationError(APIException):
     default_detail = _('Invalid input.')
     default_code = 'invalid'
 
-    def __init__(self, detail, code=None):
+    def __init__(self, detail=None, code=None):
         if detail is None:
             detail = self.default_detail
         if code is None:


### PR DESCRIPTION
## Description

In the current implementation, _detail_ is a positional argument. But the code in line [127](https://github.com/encode/django-rest-framework/pull/5342/files#diff-7215000329f5ee2146a1d6bdcdf270b3L127) expects an keyword. If I do not pass the argument _detail_ when creating an instance of _ValidationError_, then we get: 

    TypeError: __init__() missing 1 required positional argument: 'detail'

but not __('Invalid input.')_
