### PR TITLE
Adding a more explicit error message when a view does have a get_queryset method but it returned nothing

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -122,6 +122,9 @@ class DjangoModelPermissions(BasePermission):
 
         if hasattr(view, 'get_queryset'):
             queryset = view.get_queryset()
+            assert queryset is not None, (
+                'The `.get_queryset()` method from the view did not return anything.'
+            )
         else:
             queryset = getattr(view, 'queryset', None)
 

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -123,7 +123,7 @@ class DjangoModelPermissions(BasePermission):
         if hasattr(view, 'get_queryset'):
             queryset = view.get_queryset()
             assert queryset is not None, (
-                'Return of {}.get_queryset() was None'.format(view.__class__.__name__)
+                '{}.get_queryset() returned None'.format(view.__class__.__name__)
             )
         else:
             queryset = getattr(view, 'queryset', None)

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -123,7 +123,7 @@ class DjangoModelPermissions(BasePermission):
         if hasattr(view, 'get_queryset'):
             queryset = view.get_queryset()
             assert queryset is not None, (
-                'The `.get_queryset()` method from the view did not return anything.'
+                'Return of {}.get_queryset() was None'.format(view.__class__.__name__)
             )
         else:
             queryset = getattr(view, 'queryset', None)


### PR DESCRIPTION
## Description

Hello! I have been using DRF for a while and was looking at some issues to start contributing.

I found issue  #4585 and tried to solve the confusing error message when a `.get_queryset()` method exists but does not return anything.

----
Closes #4585 