### PR TITLE
Unexpected result when passing empty body to RequestFactory

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -303,7 +303,7 @@ class Request(object):
             stream = None
 
         if stream is None or media_type is None:
-            if media_type and not is_form_media_type(media_type):
+            if media_type and is_form_media_type(media_type):
                 empty_data = QueryDict('', encoding=self._request._encoding)
             else:
                 empty_data = {}

--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -227,6 +227,15 @@ class APIRequestFactory(DjangoRequestFactory):
         data, content_type = self._encode_data(data, format, content_type)
         return self.generic('OPTIONS', path, data, content_type, **extra)
 
+    def generic(self, method, path, data='',
+                content_type='application/octet-stream', secure=False, **extra):
+        # Include the CONTENT_TYPE, regardless of whether or not data is empty.
+        if content_type is not None:
+            extra['CONTENT_TYPE'] = str(content_type)
+
+        return super(APIRequestFactory, self).generic(
+            method, path, data, content_type, secure, **extra)
+
     def request(self, **kwargs):
         request = super(APIRequestFactory, self).request(**kwargs)
         request._dont_enforce_csrf_checks = not self.enforce_csrf_checks

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -282,4 +282,4 @@ class TestAPIRequestFactory(TestCase):
             data=None,
             content_type='application/json',
         )
-        assert request.content_type == 'application/json'
+        assert request.META['CONTENT_TYPE'] == 'application/json'

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -274,3 +274,12 @@ class TestAPIRequestFactory(TestCase):
         assert dict(request.GET) == {'demo': ['testé']}
         request = factory.get('/view/', {'demo': 'testé'})
         assert dict(request.GET) == {'demo': ['testé']}
+
+    def test_empty_request_content_type(self):
+        factory = APIRequestFactory()
+        request = factory.post(
+            '/post-view/',
+            data=None,
+            content_type='application/json',
+        )
+        assert request.content_type == 'application/json'


### PR DESCRIPTION
This resulted from and fixes #5349. In short, because of how DRF overrides `RequestFactory`, passing `data=None` to the request methods will result in the request object *not* having it's `CONTENT_TYPE` set. 

The solution is to just simply set the header if present.

----

In more detail:
- Django's `RequestFactory` methods will generally [override](https://github.com/django/django/blob/1.11/django/test/client.py#L346) `data=None` to an empty dict.
    - DRF's `RequestFactory` overrides this behavior, and does *not* set `data` to an empty dict. 
- Django's `RequestFactory` has special handling when [encoding](https://github.com/django/django/blob/1.11/django/test/client.py#L309-L311) `data` for *multipart/form-data* requests, otherwise it simply [`force_bytes`](https://github.com/django/django/blob/1.11/django/test/client.py#L319). 
- In general use w/ Django, these methods will provide a truthy data value
    - `multipart/form-data` encoding will include boundary lines.
    - `force_bytes({})` => `b'{}'`
- Because general usage has truthy data, [this block](https://github.com/django/django/blob/1.11/django/test/client.py#L403-L407) is executed and sets the request's `CONTENT_TYPE`.
- Since DRF's `RequestFactory` methods don't override `data`, [`_encode_data`](https://github.com/encode/django-rest-framework/blob/3.6.4/rest_framework/test.py#L158-L159) returns an empty string, thus not setting the request's `CONTENT_TYPE`.