### PR TITLE
Fix doc Response data attribute description

### DIFF
--- a/docs/api-guide/responses.md
+++ b/docs/api-guide/responses.md
@@ -42,7 +42,7 @@ Arguments:
 
 ## .data
 
-The unrendered content of a `Request` object.
+The unrendered, serialized data of the response.
 
 ## .status_code
 


### PR DESCRIPTION

## Description
Response data attribute was confusingly referencing the Request object. I added what I think is a better description from looking at the code.
refs #5360
