### PR TITLE
Rejecting anonymous in DjangoModelPermissions *before* the get_queryset call

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -201,11 +201,15 @@ class ModelPermissionsIntegrationTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_calling_method_not_allowed(self):
-        request = factory.generic('METHOD_NOT_ALLOWED', '/')
+        request = factory.generic(
+            'METHOD_NOT_ALLOWED', '/', HTTP_AUTHORIZATION=self.permitted_credentials
+        )
         response = root_view(request)
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-        request = factory.generic('METHOD_NOT_ALLOWED', '/1')
+        request = factory.generic(
+            'METHOD_NOT_ALLOWED', '/1', HTTP_AUTHORIZATION=self.permitted_credentials
+        )
         response = instance_view(request, pk='1')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
@@ -396,7 +400,9 @@ class ObjectPermissionsIntegrationTests(TestCase):
         self.assertListEqual(response.data, [])
 
     def test_cannot_method_not_allowed(self):
-        request = factory.generic('METHOD_NOT_ALLOWED', '/')
+        request = factory.generic(
+            'METHOD_NOT_ALLOWED', '/', HTTP_AUTHORIZATION=self.credentials['readonly']
+        )
         response = object_permissions_list_view(request)
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 


### PR DESCRIPTION
## Description

There can be a situation when `get_queryset` uses request.user to determine a queryset filtration to apply. If DjangoModelPermissions has `authenticated_users_only` equal to `True`, one could assume that there'll be no anonymous in the `get_queryset`. However, that was not the case before this PR.

## Before

There were workarounds which you had to apply if you wanted to avoid anonymous inside the `get_queryset` method:
1. Either do a manually check like
    ```python
    if request.user.is_anonymous():
        return Model.objects.None()
    ```
    **in every concerned viewset**
2. or add the `IsAuthenticated` permission **to every concerned viewset**.

Both seem to be reasonably redundant.

## After

No additional tuning is required. Having `authenticated_users_only` equal to `True` is enough.