### PR TITLE
Don't make the content mandatory in the generic content form

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -579,7 +579,8 @@ class BrowsableAPIRenderer(BaseRenderer):
                 _content = forms.CharField(
                     label='Content',
                     widget=forms.Textarea(attrs={'data-override': 'content'}),
-                    initial=content
+                    initial=content,
+                    required=False
                 )
 
             return GenericContentForm()


### PR DESCRIPTION
Sometimes, probably in the upgrade from Django 1.9 to 1.10, a post with
empty content is forbidden by javascript, with the message "Please fill
in this field". Filling the form with '{}' allows an application/json
request to be submitted.

The API call itself works perfectly well with a post with empty content:
the interface shouldn't make assumptions about it.
