### PR TITLE
Fix excludes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,5 @@ include README.md
 include LICENSE.md
 recursive-include rest_framework/static *.js *.css *.png *.eot *.svg *.ttf *.woff
 recursive-include rest_framework/templates *.html
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
## Description

I definitely see files from `__pycache__` as well as `.pyc` files in the 3.6.4 package. Fixed according to [reddit](https://www.reddit.com/r/Python/comments/40s8qw/simplify_your_manifestin_commands) and https://github.com/django/django/pull/5817.
