### PR TITLE
Fix default value handling for dotted sources

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -93,9 +93,6 @@ def get_attribute(instance, attrs):
     Also accepts either attribute lookup on objects or dictionary lookups.
     """
     for attr in attrs:
-        if instance is None:
-            # Break out early if we get `None` at any point in a nested lookup.
-            return None
         try:
             if isinstance(instance, collections.Mapping):
                 instance = instance[attr]

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -411,6 +411,19 @@ class TestDefaultOutput:
         serializer = self.Serializer(instance)
         assert serializer.data == {'has_default': 'def', 'has_default_callable': 'ghi', 'no_default': 'abc'}
 
+    def test_default_for_source_source(self):
+        """
+        'default="something"' should be used when a traversed attribute is missing from input.
+        """
+        class Serializer(serializers.Serializer):
+            traversed = serializers.CharField(default='x', source='traversed.attr')
+
+        assert Serializer({}).data == {'traversed': 'x'}
+        assert Serializer({'traversed': {}}).data == {'traversed': 'x'}
+        assert Serializer({'traversed': None}).data == {'traversed': 'x'}
+
+        assert Serializer({'traversed': {'attr': 'abc'}}).data == {'traversed': 'abc'}
+
 
 class TestCacheSerializerData:
     def test_cache_serializer_data(self):


### PR DESCRIPTION
This fixes #5371. In short, default handling works as expected when traversed attributes return an `object`/`dict`, but not when one part of the traversal returns `None`.

```python
class Serializer(serializers.Serializer):
    bar = serializers.CharField(default='x', source='foo.bar')
    
>>> Serializer({}).data
ReturnDict([('bar', 'x')])

>>> Serializer({'foo': {}}).data
ReturnDict([('bar', 'x')])

>>> Serializer({'foo': None}).data
ReturnDict([('bar', None)])
```