### PR TITLE
DjangoModelPermissions should perform auth check before accessing the view's queryset

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -40,6 +40,10 @@ You can determine your currently installed version using `pip freeze`:
 
 ## 3.6.x series
 
+### 3.6.5
+
+* Fix `DjangoModelPermissions` to ensure user authentication before calling the view's `get_queryset()` method. As a side effect, this changes the order of the HTTP method permissions and authentication checks, and 405 responses will only be returned when authenticated. If you want to replicate the old behavior, see the PR for details. [#5376][gh5376]
+
 ### 3.6.4
 
 **Date**: [21st August 2017][3.6.4-milestone]
@@ -1417,5 +1421,5 @@ For older release notes, [please see the version 2.x documentation][old-release-
 [gh5147]: https://github.com/encode/django-rest-framework/issues/5147
 [gh5131]: https://github.com/encode/django-rest-framework/issues/5131
 
-
-
+<!-- 3.6.5 -->
+[gh5376]: https://github.com/encode/django-rest-framework/issues/5376

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -120,6 +120,10 @@ class DjangoModelPermissions(BasePermission):
         if getattr(view, '_ignore_model_permissions', False):
             return True
 
+        if not request.user or (
+           not is_authenticated(request.user) and self.authenticated_users_only):
+            return False
+
         if hasattr(view, 'get_queryset'):
             queryset = view.get_queryset()
             assert queryset is not None, (
@@ -135,11 +139,7 @@ class DjangoModelPermissions(BasePermission):
 
         perms = self.get_required_permissions(request.method, queryset.model)
 
-        return (
-            request.user and
-            (is_authenticated(request.user) or not self.authenticated_users_only) and
-            request.user.has_perms(perms)
-        )
+        return request.user.has_perms(perms)
 
 
 class DjangoModelPermissionsOrAnonReadOnly(DjangoModelPermissions):

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -114,6 +114,21 @@ class DjangoModelPermissions(BasePermission):
 
         return [perm % kwargs for perm in self.perms_map[method]]
 
+    def _queryset(self, view):
+        assert hasattr(view, 'get_queryset') \
+            or getattr(view, 'queryset', None) is not None, (
+            'Cannot apply {} on a view that does not set '
+            '`.queryset` or have a `.get_queryset()` method.'
+        ).format(self.__class__.__name__)
+
+        if hasattr(view, 'get_queryset'):
+            queryset = view.get_queryset()
+            assert queryset is not None, (
+                '{}.get_queryset() returned None'.format(view.__class__.__name__)
+            )
+            return queryset
+        return view.queryset
+
     def has_permission(self, request, view):
         # Workaround to ensure DjangoModelPermissions are not applied
         # to the root view when using DefaultRouter.
@@ -124,19 +139,7 @@ class DjangoModelPermissions(BasePermission):
            not is_authenticated(request.user) and self.authenticated_users_only):
             return False
 
-        if hasattr(view, 'get_queryset'):
-            queryset = view.get_queryset()
-            assert queryset is not None, (
-                '{}.get_queryset() returned None'.format(view.__class__.__name__)
-            )
-        else:
-            queryset = getattr(view, 'queryset', None)
-
-        assert queryset is not None, (
-            'Cannot apply DjangoModelPermissions on a view that '
-            'does not set `.queryset` or have a `.get_queryset()` method.'
-        )
-
+        queryset = self._queryset(view)
         perms = self.get_required_permissions(request.method, queryset.model)
 
         return request.user.has_perms(perms)
@@ -183,16 +186,8 @@ class DjangoObjectPermissions(DjangoModelPermissions):
         return [perm % kwargs for perm in self.perms_map[method]]
 
     def has_object_permission(self, request, view, obj):
-        if hasattr(view, 'get_queryset'):
-            queryset = view.get_queryset()
-        else:
-            queryset = getattr(view, 'queryset', None)
-
-        assert queryset is not None, (
-            'Cannot apply DjangoObjectPermissions on a view that '
-            'does not set `.queryset` or have a `.get_queryset()` method.'
-        )
-
+        # authentication checks have already executed via has_permission
+        queryset = self._queryset(view)
         model_cls = queryset.model
         user = request.user
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -209,6 +209,16 @@ class ModelPermissionsIntegrationTests(TestCase):
         response = instance_view(request, pk='1')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
+    def test_check_auth_before_queryset_call(self):
+        class View(RootView):
+            def get_queryset(_):
+                self.fail('should not reach due to auth check')
+        view = View.as_view()
+
+        request = factory.get('/', HTTP_AUTHORIZATION='')
+        response = view(request)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
 
 class BasicPermModel(models.Model):
     text = models.CharField(max_length=100)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -201,11 +201,11 @@ class ModelPermissionsIntegrationTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_calling_method_not_allowed(self):
-        request = factory.generic('METHOD_NOT_ALLOWED', '/')
+        request = factory.generic('METHOD_NOT_ALLOWED', '/', HTTP_AUTHORIZATION=self.permitted_credentials)
         response = root_view(request)
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-        request = factory.generic('METHOD_NOT_ALLOWED', '/1')
+        request = factory.generic('METHOD_NOT_ALLOWED', '/1', HTTP_AUTHORIZATION=self.permitted_credentials)
         response = instance_view(request, pk='1')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
@@ -396,7 +396,7 @@ class ObjectPermissionsIntegrationTests(TestCase):
         self.assertListEqual(response.data, [])
 
     def test_cannot_method_not_allowed(self):
-        request = factory.generic('METHOD_NOT_ALLOWED', '/')
+        request = factory.generic('METHOD_NOT_ALLOWED', '/', HTTP_AUTHORIZATION=self.credentials['readonly'])
         response = object_permissions_list_view(request)
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 


### PR DESCRIPTION
The below will replicate the old behavior where `MethodNotAllowed` preceded the authentication check:

```python
class DjangoModelPermissions(permissions.DjangoModelPermissions):

    def has_permission(self, request, view):
        if request.method not in self.perms_map:
            raise exceptions.MethodNotAllowed(request.method)
        return super().has_permission(request, view)

````

----

This is an updated version of #5367 that includes a regression test. 

Note:
This does *slightly* change the behavior for when the request has no authentication. Previously, if a user made an unauthenticated request, they would receive a 405. With the PR, users would receive the 401 first, then 405 once authenticated. 

I'd argue that the change is more correct, given the general ordering of [authentication, authorization](https://github.com/encode/django-rest-framework/blob/3.6.4/rest_framework/views.py#L394-L396), then [method allowed checks](https://github.com/encode/django-rest-framework/blob/3.6.4/rest_framework/views.py#L477-L484). Either way, the old behavior can be replicated by moving the 405 check out of `get_required_permissions()` and into `has_permission()` before the `request.user `check.