### PR TITLE
unnecessary strip() breaks markdown formatting

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -476,7 +476,7 @@ class SchemaGenerator(object):
             return formatting.dedent(smart_text(method_docstring))
 
         description = view.get_view_description()
-        lines = [line.strip() for line in description.splitlines()]
+        lines = [line for line in description.splitlines()]
         current_section = ''
         sections = {'': ''}
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -496,3 +496,45 @@ class Test4605Regression(TestCase):
             '/auth/convert-token/'
         ])
         assert prefix == '/'
+
+
+class ExampleDocstringAPIView(APIView):
+    """
+=== title
+
+ * item a
+   * item a-a
+   * item a-b
+ * item b
+
+ - item 1
+ - item 2
+
+    code block begin
+    code
+    code
+    code
+    code block end
+
+the end
+"""
+
+    def get(self, *args, **kwargs):
+        pass
+
+    def post(self, request, *args, **kwargs):
+        pass
+
+
+class TestDocstringIsNotStrippedByGetDescription(TestCase):
+    def setUp(self):
+        self.patterns = [
+            url('^example/?$', ExampleDocstringAPIView.as_view()),
+        ]
+
+    def test_docstring(self):
+        view = ExampleDocstringAPIView()
+        generator = SchemaGenerator(title='Example API', patterns=self.patterns)
+        descr = generator.get_description('example', 'get', view)
+        # the first and last character are '\n' correctly removed by get_description
+        assert descr == ExampleDocstringAPIView.__doc__[1:][:-1]


### PR DESCRIPTION
1. Is unnecessary
2. Is breaking markdown formatting.