### PR TITLE
Fix ModelSerializer custom named fields with source on model

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1010,7 +1010,9 @@ class ModelSerializer(Serializer):
                 continue
 
             extra_field_kwargs = extra_kwargs.get(field_name, {})
-            source = extra_field_kwargs.get('source', '*') != '*' or field_name
+            source = extra_field_kwargs.get('source', '*')
+            if source == '*':
+                source = field_name
 
             # Determine the serializer field class and keyword arguments.
             field_class, field_kwargs = self.build_field(

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -557,39 +557,6 @@ class TestRelationalFieldMappings(TestCase):
         self.maxDiff = None
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 
-    def test_nested_hyperlinked_relations_named_source(self):
-        class TestSerializer(serializers.HyperlinkedModelSerializer):
-            class Meta:
-                model = RelationalModel
-                depth = 1
-                fields = '__all__'
-
-                extra_kwargs = {
-                    'url': {
-                        'source': 'url'
-                    }}
-
-        expected = dedent("""
-            TestSerializer():
-                url = HyperlinkedIdentityField(source='url', view_name='relationalmodel-detail')
-                foreign_key = NestedSerializer(read_only=True):
-                    url = HyperlinkedIdentityField(view_name='foreignkeytargetmodel-detail')
-                    name = CharField(max_length=100)
-                one_to_one = NestedSerializer(read_only=True):
-                    url = HyperlinkedIdentityField(view_name='onetoonetargetmodel-detail')
-                    name = CharField(max_length=100)
-                many_to_many = NestedSerializer(many=True, read_only=True):
-                    url = HyperlinkedIdentityField(view_name='manytomanytargetmodel-detail')
-                    name = CharField(max_length=100)
-                through = NestedSerializer(many=True, read_only=True):
-                    url = HyperlinkedIdentityField(view_name='throughtargetmodel-detail')
-                    name = CharField(max_length=100)
-        """)
-        self.maxDiff = None
-        self.assertEqual(unicode_repr(TestSerializer()), expected)
-
-
-
     def test_nested_unique_together_relations(self):
         class TestSerializer(serializers.HyperlinkedModelSerializer):
             class Meta:
@@ -1168,3 +1135,25 @@ class Test5004UniqueChoiceField(TestCase):
         serializer = TestUniqueChoiceSerializer(data={'name': 'choice1'})
         assert not serializer.is_valid()
         assert serializer.errors == {'name': ['unique choice model with this name already exists.']}
+
+class TestFieldSource(TestCase):
+    
+    def test_named_field_source(self):
+        class TestSerializer(serializers.ModelSerializer):
+
+            class Meta:
+                model = RegularFieldsModel 
+                fields = ('number_field',)
+                extra_kwargs = {
+                    'number_field': {
+                        'source': 'integer_field'
+                    }
+                }
+
+        expected = dedent("""
+            TestSerializer():
+                number_field = IntegerField(source='integer_field')
+        """)
+        self.maxDiff = None
+        self.assertEqual(unicode_repr(TestSerializer()), expected)
+

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -1136,13 +1136,13 @@ class Test5004UniqueChoiceField(TestCase):
         assert not serializer.is_valid()
         assert serializer.errors == {'name': ['unique choice model with this name already exists.']}
 
+
 class TestFieldSource(TestCase):
-    
     def test_named_field_source(self):
         class TestSerializer(serializers.ModelSerializer):
 
             class Meta:
-                model = RegularFieldsModel 
+                model = RegularFieldsModel
                 fields = ('number_field',)
                 extra_kwargs = {
                     'number_field': {
@@ -1156,4 +1156,3 @@ class TestFieldSource(TestCase):
         """)
         self.maxDiff = None
         self.assertEqual(unicode_repr(TestSerializer()), expected)
-

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -557,6 +557,39 @@ class TestRelationalFieldMappings(TestCase):
         self.maxDiff = None
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 
+    def test_nested_hyperlinked_relations_named_source(self):
+        class TestSerializer(serializers.HyperlinkedModelSerializer):
+            class Meta:
+                model = RelationalModel
+                depth = 1
+                fields = '__all__'
+
+                extra_kwargs = {
+                    'url': {
+                        'source': 'url'
+                    }}
+
+        expected = dedent("""
+            TestSerializer():
+                url = HyperlinkedIdentityField(source='url', view_name='relationalmodel-detail')
+                foreign_key = NestedSerializer(read_only=True):
+                    url = HyperlinkedIdentityField(view_name='foreignkeytargetmodel-detail')
+                    name = CharField(max_length=100)
+                one_to_one = NestedSerializer(read_only=True):
+                    url = HyperlinkedIdentityField(view_name='onetoonetargetmodel-detail')
+                    name = CharField(max_length=100)
+                many_to_many = NestedSerializer(many=True, read_only=True):
+                    url = HyperlinkedIdentityField(view_name='manytomanytargetmodel-detail')
+                    name = CharField(max_length=100)
+                through = NestedSerializer(many=True, read_only=True):
+                    url = HyperlinkedIdentityField(view_name='throughtargetmodel-detail')
+                    name = CharField(max_length=100)
+        """)
+        self.maxDiff = None
+        self.assertEqual(unicode_repr(TestSerializer()), expected)
+
+
+
     def test_nested_unique_together_relations(self):
         class TestSerializer(serializers.HyperlinkedModelSerializer):
             class Meta:


### PR DESCRIPTION
## Description

Fixes #5389 

Includes a test that fails on master, passes before #5138, and now passes with included fix.