### PR TITLE
Fixed the MultipleFieldLookupMixin example to properly check for object level permission

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -330,7 +330,9 @@ For example, if you need to lookup objects based on multiple fields in the URL c
             for field in self.lookup_fields:
                 if self.kwargs[field]: # Ignore empty fields.
                     filter[field] = self.kwargs[field]
-            return get_object_or_404(queryset, **filter)  # Lookup the object
+            obj = get_object_or_404(queryset, **filter)  # Lookup the object
+            self.check_object_permissions(self.request, obj)
+            return obj
 
 You can then simply apply this mixin to a view or viewset anytime you need to apply the custom behavior.
 


### PR DESCRIPTION
The MultipleFieldLookupMixin example on the documentation does not check for object level permission. Thus, when it is used in conjunction with a custom permission (e.g., the IsOwner permission), it behaves unexpectedly.