### PR TITLE
Add value repr to the assertion output in FieldValues tests

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -533,7 +533,8 @@ class FieldValues:
         Ensure that valid values return the expected validated data.
         """
         for input_value, expected_output in get_items(self.valid_inputs):
-            assert self.field.run_validation(input_value) == expected_output
+            assert self.field.run_validation(input_value) == expected_output, \
+                'input value: {}'.format(repr(input_value))
 
     def test_invalid_inputs(self):
         """
@@ -542,11 +543,13 @@ class FieldValues:
         for input_value, expected_failure in get_items(self.invalid_inputs):
             with pytest.raises(serializers.ValidationError) as exc_info:
                 self.field.run_validation(input_value)
-            assert exc_info.value.detail == expected_failure
+            assert exc_info.value.detail == expected_failure, \
+                'input value: {}'.format(repr(input_value))
 
     def test_outputs(self):
         for output_value, expected_output in get_items(self.outputs):
-            assert self.field.to_representation(output_value) == expected_output
+            assert self.field.to_representation(output_value) == expected_output, \
+                'output value: {}'.format(repr(output_value))
 
 
 # Boolean types...


### PR DESCRIPTION
For the `FieldValues` tests, multiple input/output values can result in the same validated/rendered value. Since the assertion is testing the validated/rendered value, it's not possible to discern which raw input is actually causing the test to fail. Fixed by adding the raw value representation to the assertion message.