### PR TITLE
Fix authtoken managment command

### DIFF
--- a/rest_framework/authtoken/management/commands/drf_create_token.py
+++ b/rest_framework/authtoken/management/commands/drf_create_token.py
@@ -31,15 +31,16 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        username = options['username']
+        usernames = options['username']
         reset_token = options['reset_token']
 
-        try:
-            token = self.create_user_token(username, reset_token)
-        except UserModel.DoesNotExist:
-            raise CommandError(
-                'Cannot create the Token: user {0} does not exist'.format(
-                    username)
-            )
-        self.stdout.write(
-            'Generated token {0} for user {1}'.format(token.key, username))
+        for username in usernames:
+            try:
+                token = self.create_user_token(username, reset_token)
+            except UserModel.DoesNotExist:
+                raise CommandError(
+                    'Cannot create the Token: user {0} does not exist'.format(
+                        username)
+                )
+            self.stdout.write(
+                'Generated token {0} for user {1}'.format(token.key, username))

--- a/rest_framework/authtoken/management/commands/drf_create_token.py
+++ b/rest_framework/authtoken/management/commands/drf_create_token.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         return token[0]
 
     def add_arguments(self, parser):
-        parser.add_argument('username', type=str, nargs='+')
+        parser.add_argument('username', type=str)
 
         parser.add_argument(
             '-r',
@@ -31,16 +31,15 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        usernames = options['username']
+        username = options['username']
         reset_token = options['reset_token']
 
-        for username in usernames:
-            try:
-                token = self.create_user_token(username, reset_token)
-            except UserModel.DoesNotExist:
-                raise CommandError(
-                    'Cannot create the Token: user {0} does not exist'.format(
-                        username)
-                )
-            self.stdout.write(
-                'Generated token {0} for user {1}'.format(token.key, username))
+        try:
+            token = self.create_user_token(username, reset_token)
+        except UserModel.DoesNotExist:
+            raise CommandError(
+                'Cannot create the Token: user {0} does not exist'.format(
+                    username)
+            )
+        self.stdout.write(
+            'Generated token {0} for user {1}'.format(token.key, username))

--- a/tests/test_authtoken.py
+++ b/tests/test_authtoken.py
@@ -1,7 +1,9 @@
 import pytest
 from django.contrib.admin import site
 from django.contrib.auth.models import User
+from django.core.management import call_command
 from django.test import TestCase
+from django.utils.six import StringIO
 
 from rest_framework.authtoken.admin import TokenAdmin
 from rest_framework.authtoken.management.commands.drf_create_token import \
@@ -68,3 +70,11 @@ class AuthTokenCommandTests(TestCase):
         second_token_key = Token.objects.first().key
 
         assert first_token_key == second_token_key
+
+    def test_command_output(self):
+        out = StringIO()
+        call_command('drf_create_token', self.user.username, stdout=out)
+        token_saved = Token.objects.first()
+        self.assertIn('Generated token', out.getvalue())
+        self.assertIn(self.user.username, out.getvalue())
+        self.assertIn(token_saved.key, out.getvalue())


### PR DESCRIPTION
## Problem
Command raised an error when creating token because username param is a list.

## Solution
Two options
- Make username param single argument
- Iterate trough username params

I choose to go with second. 