### PR TITLE
5378 fix schema generation markdown

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -207,7 +207,7 @@ class AutoSchema(ViewInspector):
             return formatting.dedent(smart_text(method_docstring))
 
         description = view.get_view_description()
-        lines = [line.strip() for line in description.splitlines()]
+        lines = [line for line in description.splitlines()]
         current_section = ''
         sections = {'': ''}
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -577,3 +577,46 @@ class TestDescriptor(TestCase):
         view = CustomView()
         link = view.schema.get_link(path, method, base_url)
         assert link == expected
+
+
+
+class ExampleDocstringAPIView(APIView):
+    """
+=== title
+
+ * item a
+   * item a-a
+   * item a-b
+ * item b
+
+ - item 1
+ - item 2
+
+    code block begin
+    code
+    code
+    code
+    code block end
+
+the end
+"""
+
+    def get(self, *args, **kwargs):
+        pass
+
+    def post(self, request, *args, **kwargs):
+        pass
+
+
+class TestDocstringIsNotStrippedByGetDescription(TestCase):
+    def setUp(self):
+        self.patterns = [
+            url('^example/?$', ExampleDocstringAPIView.as_view()),
+        ]
+
+    def test_docstring(self):
+        view = ExampleDocstringAPIView()
+        schema = view.schema
+        descr = schema.get_description('example', 'get')
+        # the first and last character are '\n' correctly removed by get_description
+        assert descr == ExampleDocstringAPIView.__doc__[1:][:-1]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -15,6 +15,7 @@ from rest_framework.schemas import (
     AutoSchema, ManualSchema, SchemaGenerator, get_schema_view
 )
 from rest_framework.test import APIClient, APIRequestFactory
+from rest_framework.utils import formatting
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
@@ -579,44 +580,36 @@ class TestDescriptor(TestCase):
         assert link == expected
 
 
+def test_docstring_is_not_stripped_by_get_description():
+    class ExampleDocstringAPIView(APIView):
+        """
+        === title
 
-class ExampleDocstringAPIView(APIView):
-    """
-=== title
+         * item a
+           * item a-a
+           * item a-b
+         * item b
 
- * item a
-   * item a-a
-   * item a-b
- * item b
+         - item 1
+         - item 2
 
- - item 1
- - item 2
+            code block begin
+            code
+            code
+            code
+            code block end
 
-    code block begin
-    code
-    code
-    code
-    code block end
+        the end
+        """
 
-the end
-"""
+        def get(self, *args, **kwargs):
+            pass
 
-    def get(self, *args, **kwargs):
-        pass
+        def post(self, request, *args, **kwargs):
+            pass
 
-    def post(self, request, *args, **kwargs):
-        pass
-
-
-class TestDocstringIsNotStrippedByGetDescription(TestCase):
-    def setUp(self):
-        self.patterns = [
-            url('^example/?$', ExampleDocstringAPIView.as_view()),
-        ]
-
-    def test_docstring(self):
-        view = ExampleDocstringAPIView()
-        schema = view.schema
-        descr = schema.get_description('example', 'get')
-        # the first and last character are '\n' correctly removed by get_description
-        assert descr == ExampleDocstringAPIView.__doc__[1:][:-1]
+    view = ExampleDocstringAPIView()
+    schema = view.schema
+    descr = schema.get_description('example', 'get')
+    # the first and last character are '\n' correctly removed by get_description
+    assert descr == formatting.dedent(ExampleDocstringAPIView.__doc__[1:][:-1])


### PR DESCRIPTION
Removes incorrect `strip` call from `AutoSchema.get_descrition()` that was breaking markdown formatting. 

Update of #5378, following #5354. Closes #5240. 