### PR TITLE
Allow `schema = None`. Deprecate `exclude_from_schema`

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -225,6 +225,12 @@ To customise the `Link` generation you may:
     This allows manually specifying the schema for some views whilst maintaining
     automatic generation elsewhere.
 
+You may disable schema generation for a view by setting `schema` to `None`:
+
+        class CustomView(APIView):
+            ...
+            schema = None  # Will not appear in schema
+
 ---
 
 **Note**: For full details on `SchemaGenerator` plus the `AutoSchema` and

--- a/docs/api-guide/views.md
+++ b/docs/api-guide/views.md
@@ -130,7 +130,7 @@ REST framework also allows you to work with regular function based views.  It pr
 
 ## @api_view()
 
-**Signature:** `@api_view(http_method_names=['GET'], exclude_from_schema=False)`
+**Signature:** `@api_view(http_method_names=['GET'])`
 
 The core of this functionality is the `api_view` decorator, which takes a list of HTTP methods that your view should respond to. For example, this is how you would write a very simple view that just manually returns some data:
 
@@ -150,12 +150,6 @@ By default only `GET` methods will be accepted. Other methods will respond with 
             return Response({"message": "Got some data!", "data": request.data})
         return Response({"message": "Hello, world!"})
 
-You can also mark an API view as being omitted from any [auto-generated schema][schemas],
-using the `exclude_from_schema` argument.:
-
-    @api_view(['GET'], exclude_from_schema=True)
-    def api_docs(request):
-        ...
 
 ## API policy decorators
 
@@ -204,7 +198,14 @@ decorator. For example:
         return Response({"message": "Hello for today! See you tomorrow!"})
 
 This decorator takes a single `AutoSchema` instance, an `AutoSchema` subclass
-instance or `ManualSchema` instance as described in the [Schemas documentation][schemas],
+instance or `ManualSchema` instance as described in the [Schemas documentation][schemas].
+You may pass `None` in order to exclude the view from schema generation.
+
+    @api_view(['GET'])
+    @schema(None)
+    def view(request):
+        return Response({"message": "Will not appear in schema!"})
+
 
 [cite]: http://reinout.vanrees.org/weblog/2011/08/24/class-based-views-usage.html
 [cite2]: http://www.boredomandlaziness.org/2012/05/djangos-cbvs-are-not-mistake-but.html

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -43,6 +43,7 @@ You can determine your currently installed version using `pip freeze`:
 ### 3.6.5
 
 * Fix `DjangoModelPermissions` to ensure user authentication before calling the view's `get_queryset()` method. As a side effect, this changes the order of the HTTP method permissions and authentication checks, and 405 responses will only be returned when authenticated. If you want to replicate the old behavior, see the PR for details. [#5376][gh5376]
+* Deprecated `exclude_from_schema` on `APIView` and `api_view` decorator. Set `schema = None` or `@schema(None)` as appropriate.
 
 ### 3.6.4
 

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -43,7 +43,8 @@ You can determine your currently installed version using `pip freeze`:
 ### 3.6.5
 
 * Fix `DjangoModelPermissions` to ensure user authentication before calling the view's `get_queryset()` method. As a side effect, this changes the order of the HTTP method permissions and authentication checks, and 405 responses will only be returned when authenticated. If you want to replicate the old behavior, see the PR for details. [#5376][gh5376]
-* Deprecated `exclude_from_schema` on `APIView` and `api_view` decorator. Set `schema = None` or `@schema(None)` as appropriate.
+* Deprecated `exclude_from_schema` on `APIView` and `api_view` decorator. Set `schema = None` or `@schema(None)` as appropriate. [#5422][gh5422]
+
 
 ### 3.6.4
 
@@ -1424,3 +1425,4 @@ For older release notes, [please see the version 2.x documentation][old-release-
 
 <!-- 3.6.5 -->
 [gh5376]: https://github.com/encode/django-rest-framework/issues/5376
+[gh5422]: https://github.com/encode/django-rest-framework/issues/5422

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -78,7 +78,7 @@ def api_view(http_method_names=None, exclude_from_schema=False):
 
         if exclude_from_schema:
             warnings.warn(
-                "The `exclude_from_schema` argument to `api_view` is deprecated. "
+                "The `exclude_from_schema` argument to `api_view` is pending deprecation. "
                 "Use the `schema` decorator instead, passing `None`.",
                 PendingDeprecationWarning
             )

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -9,6 +9,7 @@ used to annotate methods on viewsets that should be included by routers.
 from __future__ import unicode_literals
 
 import types
+import warnings
 
 from django.utils import six
 
@@ -76,9 +77,11 @@ def api_view(http_method_names=None, exclude_from_schema=False):
                                         APIView.schema)
 
         if exclude_from_schema:
-            # This won't catch an explicit `exclude_from_schema=False`
-            #   but it should be good enough.
-            # TODO: DeprecationWarning
+            warnings.warn(
+                "The `exclude_from_schema` argument to `api_view` is deprecated. "
+                "Use the `schema` decorator instead, passing `None`.",
+                PendingDeprecationWarning
+            )
             WrappedAPIView.exclude_from_schema = exclude_from_schema
 
         return WrappedAPIView.as_view()

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -75,7 +75,12 @@ def api_view(http_method_names=None, exclude_from_schema=False):
         WrappedAPIView.schema = getattr(func, 'schema',
                                         APIView.schema)
 
-        WrappedAPIView.exclude_from_schema = exclude_from_schema
+        if exclude_from_schema:
+            # This won't catch an explicit `exclude_from_schema=False`
+            #   but it should be good enough.
+            # TODO: DeprecationWarning
+            WrappedAPIView.exclude_from_schema = exclude_from_schema
+
         return WrappedAPIView.as_view()
     return decorator
 

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -291,7 +291,7 @@ class APIRootView(views.APIView):
     The default basic root view for DefaultRouter
     """
     _ignore_model_permissions = True
-    exclude_from_schema = True
+    schema = None  # exclude from schema
     api_root_dict = None
 
     def get(self, request, *args, **kwargs):

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -150,8 +150,8 @@ class EndpointEnumerator(object):
             return False  # Ignore anything except REST framework views.
 
         if hasattr(callback.cls, 'exclude_from_schema'):
-            fmt = ("{}. The `APIView.exclude_from_schema` is pending deprecation. "
-                   "Set `schema = None` instead")
+            fmt = ("The `{}.exclude_from_schema` is pending deprecation. "
+                   "Set `schema = None` instead.")
             msg = fmt.format(callback.cls.__name__)
             warnings.warn(msg, PendingDeprecationWarning)
             if getattr(callback.cls, 'exclude_from_schema', False):

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -148,7 +148,12 @@ class EndpointEnumerator(object):
         if not is_api_view(callback):
             return False  # Ignore anything except REST framework views.
 
-        if getattr(callback.cls, 'exclude_from_schema', False):
+        if hasattr(callback.cls, 'exclude_from_schema'):
+            # TODO: deprecation warning
+            if getattr(callback.cls, 'exclude_from_schema', False):
+                return False
+
+        if callback.cls.schema is None:
             return False
 
         if path.endswith('.{format}') or path.endswith('.{format}/'):

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -3,6 +3,7 @@ generators.py   # Top-down schema generation
 
 See schemas.__init__.py for package overview.
 """
+import warnings
 from collections import OrderedDict
 from importlib import import_module
 
@@ -149,7 +150,10 @@ class EndpointEnumerator(object):
             return False  # Ignore anything except REST framework views.
 
         if hasattr(callback.cls, 'exclude_from_schema'):
-            # TODO: deprecation warning
+            fmt = ("{}. The `APIView.exclude_from_schema` is deprecated. "
+                   "Set `schema = None` instead")
+            msg = fmt.format(callback.cls.__name__)
+            warnings.warn(msg, PendingDeprecationWarning)
             if getattr(callback.cls, 'exclude_from_schema', False):
                 return False
 

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -150,7 +150,7 @@ class EndpointEnumerator(object):
             return False  # Ignore anything except REST framework views.
 
         if hasattr(callback.cls, 'exclude_from_schema'):
-            fmt = ("{}. The `APIView.exclude_from_schema` is deprecated. "
+            fmt = ("{}. The `APIView.exclude_from_schema` is pending deprecation. "
                    "Set `schema = None` instead")
             msg = fmt.format(callback.cls.__name__)
             warnings.warn(msg, PendingDeprecationWarning)

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -150,7 +150,7 @@ class EndpointEnumerator(object):
             return False  # Ignore anything except REST framework views.
 
         if hasattr(callback.cls, 'exclude_from_schema'):
-            fmt = ("The `{}.exclude_from_schema` is pending deprecation. "
+            fmt = ("The `{}.exclude_from_schema` attribute is pending deprecation. "
                    "Set `schema = None` instead.")
             msg = fmt.format(callback.cls.__name__)
             warnings.warn(msg, PendingDeprecationWarning)

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -148,6 +148,9 @@ class EndpointEnumerator(object):
         if not is_api_view(callback):
             return False  # Ignore anything except REST framework views.
 
+        if getattr(callback.cls, 'exclude_from_schema', False):
+            return False
+
         if path.endswith('.{format}') or path.endswith('.{format}/'):
             return False  # Ignore .json style URLs.
 
@@ -239,8 +242,6 @@ class SchemaGenerator(object):
         view_endpoints = []
         for path, method, callback in self.endpoints:
             view = self.create_view(callback, method, request)
-            if getattr(view, 'exclude_from_schema', False):
-                continue
             path = self.coerce_path(path, method, view)
             paths.append(path)
             view_endpoints.append((path, method, view))

--- a/rest_framework/schemas/views.py
+++ b/rest_framework/schemas/views.py
@@ -11,7 +11,7 @@ from rest_framework.views import APIView
 
 class SchemaView(APIView):
     _ignore_model_permissions = True
-    exclude_from_schema = True
+    schema = None  # exclude from schema
     renderer_classes = None
     schema_generator = None
     public = False

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -112,8 +112,6 @@ class APIView(View):
     # Allow dependency injection of other settings to make testing easier.
     settings = api_settings
 
-    # Mark the view as being included or excluded from schema generation.
-    exclude_from_schema = False
     schema = AutoSchema()
 
     @classmethod

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -690,10 +690,16 @@ class SchemaGenerationExclusionTests(TestCase):
         assert should_include == expected
 
     def test_deprecations(self):
-        with pytest.warns(PendingDeprecationWarning):
+        with pytest.warns(PendingDeprecationWarning) as record:
             @api_view(["GET"], exclude_from_schema=True)
             def view(request):
                 pass
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "The `exclude_from_schema` argument to `api_view` is pending "
+            "deprecation. Use the `schema` decorator instead, passing `None`."
+        )
 
         class OldFashionedExcludedView(APIView):
             exclude_from_schema = True
@@ -706,5 +712,11 @@ class SchemaGenerationExclusionTests(TestCase):
         ]
 
         inspector = EndpointEnumerator(patterns)
-        with pytest.warns(PendingDeprecationWarning):
+        with pytest.warns(PendingDeprecationWarning) as record:
             inspector.get_api_endpoints()
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "The `OldFashionedExcludedView.exclude_from_schema` is "
+            "pending deprecation. Set `schema = None` instead."
+        )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -8,12 +8,13 @@ from django.test import TestCase, override_settings
 
 from rest_framework import filters, pagination, permissions, serializers
 from rest_framework.compat import coreapi, coreschema
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import detail_route, list_route, api_view, schema
 from rest_framework.request import Request
 from rest_framework.routers import DefaultRouter
 from rest_framework.schemas import (
     AutoSchema, ManualSchema, SchemaGenerator, get_schema_view
 )
+from rest_framework.schemas.generators import EndpointEnumerator
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.utils import formatting
 from rest_framework.views import APIView
@@ -613,3 +614,79 @@ def test_docstring_is_not_stripped_by_get_description():
     descr = schema.get_description('example', 'get')
     # the first and last character are '\n' correctly removed by get_description
     assert descr == formatting.dedent(ExampleDocstringAPIView.__doc__[1:][:-1])
+
+
+# Views for SchemaGenerationExclusionTests
+class ExcludedAPIView(APIView):
+    exclude_from_schema = True
+
+    def get(self, request, *args, **kwargs):
+        pass
+
+
+@api_view(['GET'], exclude_from_schema=True)
+def excluded_fbv(request):
+    pass
+
+
+@api_view(['GET'])
+def included_fbv(request):
+    pass
+
+
+@unittest.skipUnless(coreapi, 'coreapi is not installed')
+class SchemaGenerationExclusionTests(TestCase):
+    def setUp(self):
+        self.patterns = [
+            url('^excluded-cbv/?$', ExcludedAPIView.as_view()),
+            url('^excluded-fbv/?$', excluded_fbv),
+            url('^included-fbv/?$', included_fbv),
+        ]
+
+    def test_schema_generator_excludes_correctly(self):
+        """Schema should not include excluded views"""
+        generator = SchemaGenerator(title='Exclusions', patterns=self.patterns)
+        schema = generator.get_schema()
+        expected = coreapi.Document(
+            url='',
+            title='Exclusions',
+            content={
+                'included-fbv': {
+                    'list': coreapi.Link(url='/included-fbv/', action='get')
+                }
+            }
+        )
+
+        assert len(schema.data) == 1
+        assert 'included-fbv' in schema.data
+        assert schema == expected
+
+    def test_endpoint_enumerator_excludes_correctly(self):
+        """It is responsibility of EndpointEnumerator to exclude views"""
+        inspector = EndpointEnumerator(self.patterns)
+        endpoints = inspector.get_api_endpoints()
+
+        assert len(endpoints) == 1
+        path, method, callback = endpoints[0]
+        assert path == '/included-fbv/'
+
+
+    def test_should_include_endpoint_excludes_correctly(self):
+        """This is the specific method that should handle the exclusion"""
+        inspector = EndpointEnumerator(self.patterns)
+
+        pairs = [
+            (inspector.get_path_from_regex(pattern.regex.pattern), pattern.callback)
+                for pattern in self.patterns
+        ]
+
+        should_include = [
+            inspector.should_include_endpoint(*pair) for pair in pairs
+        ]
+
+        expected = [False, False, True]
+
+        assert should_include == expected
+
+    def test_deprecations(self):
+        pass

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -695,14 +695,14 @@ class SchemaGenerationExclusionTests(TestCase):
             def view(request):
                 pass
 
-        class OldFashjonedExcludedView(APIView):
+        class OldFashionedExcludedView(APIView):
             exclude_from_schema = True
 
             def get(self, request, *args, **kwargs):
                 pass
 
         patterns = [
-            url('^excluded-old-fashioned/$', OldFashjonedExcludedView.as_view()),
+            url('^excluded-old-fashioned/$', OldFashionedExcludedView.as_view()),
         ]
 
         inspector = EndpointEnumerator(patterns)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -641,9 +641,9 @@ def included_fbv(request):
 class SchemaGenerationExclusionTests(TestCase):
     def setUp(self):
         self.patterns = [
-            url('^excluded-cbv/?$', ExcludedAPIView.as_view()),
-            url('^excluded-fbv/?$', excluded_fbv),
-            url('^included-fbv/?$', included_fbv),
+            url('^excluded-cbv/$', ExcludedAPIView.as_view()),
+            url('^excluded-fbv/$', excluded_fbv),
+            url('^included-fbv/$', included_fbv),
         ]
 
     def test_schema_generator_excludes_correctly(self):
@@ -690,4 +690,21 @@ class SchemaGenerationExclusionTests(TestCase):
         assert should_include == expected
 
     def test_deprecations(self):
-        pass
+        with pytest.warns(PendingDeprecationWarning):
+            @api_view(["GET"], exclude_from_schema=True)
+            def view(request):
+                pass
+
+        class OldFashjonedExcludedView(APIView):
+            exclude_from_schema = True
+
+            def get(self, request, *args, **kwargs):
+                pass
+
+        patterns = [
+            url('^excluded-old-fashioned/$', OldFashjonedExcludedView.as_view()),
+        ]
+
+        inspector = EndpointEnumerator(patterns)
+        with pytest.warns(PendingDeprecationWarning):
+            inspector.get_api_endpoints()

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -717,6 +717,6 @@ class SchemaGenerationExclusionTests(TestCase):
 
         assert len(record) == 1
         assert str(record[0].message) == (
-            "The `OldFashionedExcludedView.exclude_from_schema` is "
+            "The `OldFashionedExcludedView.exclude_from_schema` attribute is "
             "pending deprecation. Set `schema = None` instead."
         )


### PR DESCRIPTION
The PR allows setting `schema = None` to exclude APIView subclasses from schema generation. 

For function based views use `@schema(None)`. 

It deprecates `exclude_from_schema` on APIView and the `exclude_from_schema` argument to `api_view`. 