### PR TITLE
JSONEncoder: Don’t strip microseconds from `time`

### DIFF
--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -37,8 +37,6 @@ class JSONEncoder(json.JSONEncoder):
             if timezone and timezone.is_aware(obj):
                 raise ValueError("JSON can't represent timezone-aware times.")
             representation = obj.isoformat()
-            if obj.microsecond:
-                representation = representation[:12]
             return representation
         elif isinstance(obj, datetime.timedelta):
             return six.text_type(total_seconds(obj))

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -44,7 +44,7 @@ class JSONEncoderTests(TestCase):
         Tests encoding a timezone
         """
         current_time = datetime.now().time()
-        assert self.encoder.default(current_time) == current_time.isoformat()[:12]
+        assert self.encoder.default(current_time) == current_time.isoformat()
 
     def test_encode_time_tz(self):
         """


### PR DESCRIPTION
Closes #4749.

This is the matching commit to the fix for `datetime` in #4256
