### PR TITLE
Add note on force_authenticate + refresh_from_db

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -86,6 +86,10 @@ For example, when forcibly authenticating using a token, you might do something 
 
 ---
 
+**Note**: `force_authenticate` directly sets `request.user` to the in-memory `user` instance. If you are re-using the same `user` instance across multiple tests that update the saved `user` state, you may need to call [`refresh_from_db()`][refresh_from_db_docs] between tests.
+
+---
+
 **Note**: When using `APIRequestFactory`, the object that is returned is Django's standard `HttpRequest`, and not REST framework's `Request` object, which is only generated once the view is called.
 
 This means that setting attributes directly on the request object may not always have the effect you expect.  For example, setting `.token` directly will have no effect, and setting `.user` directly will only work if session authentication is being used.
@@ -378,3 +382,4 @@ For example, to add support for using `format='html'` in test requests, you migh
 [client]: https://docs.djangoproject.com/en/stable/topics/testing/tools/#the-test-client
 [requestfactory]: https://docs.djangoproject.com/en/stable/topics/testing/advanced/#django.test.client.RequestFactory
 [configuration]: #configuration
+[refresh_from_db_docs]: https://docs.djangoproject.com/en/1.11/ref/models/instances/#django.db.models.Model.refresh_from_db


### PR DESCRIPTION
…in case you’re reusing the same in-memory user whilst updating it in the DB.

Closes #5016, closes #5066, closes #4102
