### PR TITLE
Allow setting custom authentication and permissions on docs view. 

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -334,6 +334,15 @@ to be exposed in the schema:
 May be used to specify a `SchemaGenerator` subclass to be passed to the
 `SchemaView`.
 
+#### `authentication_classes`
+
+May be used to specify the list of authentication classes that will apply to the schema endpoint.
+Defaults to `settings.DEFAULT_AUTHENTICATION_CLASSES`
+
+#### `permission_classes`
+
+May be used to specify the list of permission classes that will apply to the schema endpoint.
+Defaults to `settings.DEFAULT_PERMISSION_CLASSES`
 
 
 ## Using an explicit schema view

--- a/rest_framework/documentation.py
+++ b/rest_framework/documentation.py
@@ -4,11 +4,14 @@ from rest_framework.renderers import (
     CoreJSONRenderer, DocumentationRenderer, SchemaJSRenderer
 )
 from rest_framework.schemas import SchemaGenerator, get_schema_view
+from rest_framework.settings import api_settings
 
 
 def get_docs_view(
         title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator):
+        patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     renderer_classes = [DocumentationRenderer, CoreJSONRenderer]
 
     return get_schema_view(
@@ -19,12 +22,16 @@ def get_docs_view(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
 
 
 def get_schemajs_view(
         title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator):
+        patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     renderer_classes = [SchemaJSRenderer]
 
     return get_schema_view(
@@ -35,12 +42,16 @@ def get_schemajs_view(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
 
 
 def include_docs_urls(
         title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator):
+        patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     docs_view = get_docs_view(
         title=title,
         description=description,
@@ -48,6 +59,8 @@ def include_docs_urls(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
     schema_js_view = get_schemajs_view(
         title=title,
@@ -56,6 +69,8 @@ def include_docs_urls(
         public=public,
         patterns=patterns,
         generator_class=generator_class,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )
     urls = [
         url(r'^$', docs_view, name='docs-index'),

--- a/rest_framework/schemas/__init__.py
+++ b/rest_framework/schemas/__init__.py
@@ -20,13 +20,17 @@ basic use-cases:
 
 Other access should target the submodules directly
 """
+from rest_framework.settings import api_settings
+
 from .generators import SchemaGenerator
 from .inspectors import AutoSchema, ManualSchema  # noqa
 
 
 def get_schema_view(
         title=None, url=None, description=None, urlconf=None, renderer_classes=None,
-        public=False, patterns=None, generator_class=SchemaGenerator):
+        public=False, patterns=None, generator_class=SchemaGenerator,
+        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     """
     Return a schema view.
     """
@@ -40,4 +44,6 @@ def get_schema_view(
         renderer_classes=renderer_classes,
         schema_generator=generator,
         public=public,
+        authentication_classes=authentication_classes,
+        permission_classes=permission_classes,
     )


### PR DESCRIPTION
Incorporates and closes #5309. Fixes #5399 

* Adapts work by @Omnipotence456 after #5354. 
* Adds note to `get_schema_view` docs. 

**Aside**: I note, in passing, that `include_docs_urls` and the helper functions from `documentation.py` are essentially undocumented. I'll add an issue for that but want to address it separately. 