### PR TITLE
Fix warning in AutoSchema.get_serializer_fields()

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -292,8 +292,8 @@ class AutoSchema(ViewInspector):
             serializer = None
             warnings.warn('{}.get_serializer() raised an exception during '
                           'schema generation. Serializer fields will not be '
-                          'generated for {} {}.'.format(
-                              type(view), method, path))
+                          'generated for {} {}.'
+                          .format(view.__class__.__name__, method, path))
 
         if isinstance(serializer, serializers.ListSerializer):
             return [


### PR DESCRIPTION
This now prints `Foo.get_serializer()` instead of `<class 'Foo'>.get_serializer()`