### PR TITLE
Update test matrix: Add Django 2.0, drop 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
 sudo: false
 
 env:
-    - DJANGO=1.8
-    - DJANGO=1.9
     - DJANGO=1.10
     - DJANGO=1.11
     - DJANGO=2.0
@@ -24,8 +22,6 @@ matrix:
         env: DJANGO=1.11
       - python: "3.6"
         env: DJANGO=2.0
-      - python: "3.3"
-        env: DJANGO=1.8
       - python: "2.7"
         env: TOXENV="lint"
       - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - DJANGO=1.9
     - DJANGO=1.10
     - DJANGO=1.11
+    - DJANGO=2.0
     - DJANGO=master
 
 matrix:
@@ -21,6 +22,8 @@ matrix:
         env: DJANGO=master
       - python: "3.6"
         env: DJANGO=1.11
+      - python: "3.6"
+        env: DJANGO=2.0
       - python: "3.3"
         env: DJANGO=1.8
       - python: "2.7"
@@ -30,11 +33,14 @@ matrix:
     exclude:
       - python: "2.7"
         env: DJANGO=master
+      - python: "2.7"
+        env: DJANGO=2.0
       - python: "3.4"
         env: DJANGO=master
 
     allow_failures:
       - env: DJANGO=master
+      - env: DJANGO=2.0
 
 install:
     - pip install tox tox-travis

--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,7 +1,7 @@
 # PEP8 code linting, which we run on all commits.
-flake8==2.4.0
+flake8==3.4.1
 flake8-tidy-imports==1.1.0
-pep8==1.5.7
+pep8==1.7.0
 
 # Sort and lint imports
 isort==4.2.5

--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -1,2 +1,2 @@
 # MkDocs to build our documentation.
-mkdocs==0.16.2
+mkdocs==0.16.3

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,7 +1,7 @@
 # Optional packages which may be used with REST framework.
 pytz==2017.2
 markdown==2.6.4
-django-guardian==1.4.8
+django-guardian==1.4.9
 django-filter==1.0.4
-coreapi==2.2.4
+coreapi==2.3.1
 coreschema==0.0.4

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -1,8 +1,8 @@
 # Wheel for PyPI installs.
-wheel==0.29.0
+wheel==0.30.0
 
 # Twine for secured PyPI uploads.
-twine==1.6.5
+twine==1.9.1
 
 # Transifex client for managing translation resources.
 transifex-client==0.11

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,4 +1,4 @@
 # PyTest for running the tests.
-pytest==3.0.5
+pytest==3.2.2
 pytest-django==3.1.2
-pytest-cov==2.4.0
+pytest-cov==2.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ addopts=--tb=short
 
 [tox]
 envlist =
-       {py27,py33,py34,py35}-django18,
-       {py27,py34,py35}-django{19,110},
+       {py27,py34,py35}-django110,
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
        {py35,py36}-djangomaster
@@ -12,8 +11,6 @@ envlist =
 
 [travis:env]
 DJANGO =
-    1.8: django18
-    1.9: django19
     1.10: django110
     1.11: django111
     2.0: django20
@@ -25,8 +22,6 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django18: Django>=1.8,<1.9
-        django19: Django>=1.9,<1.10
         django110: Django>=1.10,<1.11
         django111: Django>=1.11,<2.0
         django20: Django>=2.0a1,<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
        {py27,py33,py34,py35}-django18,
        {py27,py34,py35}-django{19,110},
        {py27,py34,py35,py36}-django111,
+       {py34,py35,py36}-django20,
        {py35,py36}-djangomaster
        lint,docs
 
@@ -15,6 +16,7 @@ DJANGO =
     1.9: django19
     1.10: django110
     1.11: django111
+    2.0: django20
     master: djangomaster
 
 [testenv]
@@ -27,6 +29,7 @@ deps =
         django19: Django>=1.9,<1.10
         django110: Django>=1.10,<1.11
         django111: Django>=1.11,<2.0
+        django20: Django>=2.0a1,<2.1
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
Replaces #5442, focusing just on the text matrix. 

* Update test requirements. 
* Add Django 2.0
* Drop Django 1.8 in preparation for #5058 
* Drop 1.9: EOL. 
