### PR TITLE
Fix naming collisions in Schema Generation 

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -778,7 +778,9 @@ class TestURLNamingCollisions(TestCase):
         ]
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
-        schema = generator.get_schema()
+
+        with pytest.raises(ValueError):
+            generator.get_schema()
 
     def test_manually_routing_generic_view(self):
         patterns = [
@@ -793,7 +795,9 @@ class TestURLNamingCollisions(TestCase):
         ]
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
-        schema = generator.get_schema()
+
+        with pytest.raises(ValueError):
+            generator.get_schema()
 
     def test_from_router(self):
         patterns = [
@@ -801,4 +805,6 @@ class TestURLNamingCollisions(TestCase):
         ]
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
-        schema = generator.get_schema()
+
+        with pytest.raises(ValueError):
+            generator.get_schema()

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -12,7 +12,7 @@ from rest_framework.decorators import (
     api_view, detail_route, list_route, schema
 )
 from rest_framework.request import Request
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import DefaultRouter, SimpleRouter
 from rest_framework.schemas import (
     AutoSchema, ManualSchema, SchemaGenerator, get_schema_view
 )
@@ -20,7 +20,7 @@ from rest_framework.schemas.generators import EndpointEnumerator
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.utils import formatting
 from rest_framework.views import APIView
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 factory = APIRequestFactory()
 
@@ -726,3 +726,50 @@ class SchemaGenerationExclusionTests(TestCase):
             "The `OldFashionedExcludedView.exclude_from_schema` attribute is "
             "pending deprecation. Set `schema = None` instead."
         )
+
+
+
+@api_view(["GET"])
+def simple_fbv(request):
+    pass
+
+
+class NamingCollisionViewSet(GenericViewSet):
+    """
+    Example via: https://stackoverflow.com/questions/43778668/django-rest-framwork-occured-typeerror-link-object-does-not-support-item-ass/
+    """
+    permision_class = ()
+
+    @list_route()
+    def detail(self, request):
+        return {}
+
+    @list_route(url_path='detail/export')
+    def detail_export(self, request):
+        return {}
+
+
+naming_collisions_router = SimpleRouter()
+naming_collisions_router.register(r'collision', NamingCollisionViewSet, base_name="collision")
+
+
+class TestURLNamingCollisions(TestCase):
+    """
+    Ref: https://github.com/encode/django-rest-framework/issues/4704
+    """
+    def test_manually_routing_nested_routes(self):
+        patterns = [
+            url(r'^test', simple_fbv),
+            url(r'^test/list/', simple_fbv),
+        ]
+
+        generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
+        schema = generator.get_schema()
+
+    def test_from_router(self):
+        patterns = [
+            url(r'from-router', include(naming_collisions_router.urls)),
+        ]
+
+        generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
+        schema = generator.get_schema()


### PR DESCRIPTION
Closes #4704

**WIP DO NOT MERGE**

If urls include elements in `['retrieve', 'list', 'create', 'update', 'partial_update', 'destroy'] — I **think** just those — schema generation can fail is a **nested** item clashes with a previously defined `Link`. 

(We want a dictionary to insert a `Link` to, but a `Link` is already there.) 


Thus far, just added a couple of failing test case for the reported cases. 
