### PR TITLE
Remove old django-filter templates

### DIFF
--- a/rest_framework/templates/rest_framework/filters/django_filter.html
+++ b/rest_framework/templates/rest_framework/filters/django_filter.html
@@ -1,6 +1,0 @@
-{% load i18n %}
-<h2>{% trans "Field filters" %}</h2>
-<form class="form" action="" method="get">
-    {{ filter.form.as_p }}
-    <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
-</form>

--- a/rest_framework/templates/rest_framework/filters/django_filter_crispyforms.html
+++ b/rest_framework/templates/rest_framework/filters/django_filter_crispyforms.html
@@ -1,5 +1,0 @@
-{% load crispy_forms_tags %}
-{% load i18n %}
-
-<h2>{% trans "Field filters" %}</h2>
-{% crispy filter.form %}


### PR DESCRIPTION
Removes the old django-filter templates. This was a forgotten part of ~~#5273~~ #4507.