### PR TITLE
Fix documentation `data` rendering

### DIFF
--- a/rest_framework/templates/rest_framework/docs/document.html
+++ b/rest_framework/templates/rest_framework/docs/document.html
@@ -13,8 +13,8 @@
     {% if 'javascript' in langs %}{% include "rest_framework/docs/langs/javascript-intro.html" %}{% endif %}
 </div>
 </div>
-{% if document.data %}
-{% for section_key, section in document.data|items %}
+{% if document|data %}
+{% for section_key, section in document|data|items %}
 {% if section_key %}
     <h2 id="{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h2>

--- a/rest_framework/templates/rest_framework/docs/sidebar.html
+++ b/rest_framework/templates/rest_framework/docs/sidebar.html
@@ -5,8 +5,8 @@
     <i class="fa fa-bars fa-2x toggle-btn" data-toggle="collapse" data-target="#menu-content"></i>
     <div class="menu-list">
         <ul id="menu-content" class="menu-content collapse out">
-            {% if document.data %}
-            {% for section_key, section in document.data|items %}
+            {% if document|data %}
+            {% for section_key, section in document|data|items %}
             <li data-toggle="collapse" data-target="#{{ section_key }}-dropdown" class="collapsed">
                 <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
                 <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{ section_key }}-dropdown">

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -246,6 +246,20 @@ def items(value):
 
 
 @register.filter
+def data(value):
+    """
+    Simple filter to access `data` attribute of object,
+    specifically coreapi.Document.
+
+    As per `items` filter above, allows accessing `document.data` when
+    Document contains Link keyed-at "data".
+
+    See issue #5395
+    """
+    return value.data
+
+
+@register.filter
 def schema_links(section, sec_key=None):
     """
     Recursively find every link in a schema, even nested.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,9 @@ def pytest_configure():
             {
                 'BACKEND': 'django.template.backends.django.DjangoTemplates',
                 'APP_DIRS': True,
+                'OPTIONS': {
+                    "debug": True,  # We want template errors to raise
+                }
             },
         ],
         MIDDLEWARE=MIDDLEWARE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def pytest_configure():
                 'BACKEND': 'django.template.backends.django.DjangoTemplates',
                 'APP_DIRS': True,
                 'OPTIONS': {
-                    "debug": True,  # We want template errors to raise
+                    "debug": True,  # We want template errors to raise
                 }
             },
         ],

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import re
 from collections import MutableMapping, OrderedDict
 
-import coreapi
 import pytest
 from django.conf.urls import include, url
 from django.core.cache import cache
@@ -15,6 +14,7 @@ from django.utils import six
 from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
+import coreapi
 from rest_framework import permissions, serializers, status
 from rest_framework.renderers import (
     AdminRenderer, BaseRenderer, BrowsableAPIRenderer, DocumentationRenderer,

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import re
 from collections import MutableMapping, OrderedDict
 
+import coreapi
 import pytest
 from django.conf.urls import include, url
 from django.core.cache import cache
@@ -16,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import permissions, serializers, status
 from rest_framework.renderers import (
-    AdminRenderer, BaseRenderer, BrowsableAPIRenderer,
+    AdminRenderer, BaseRenderer, BrowsableAPIRenderer, DocumentationRenderer,
     HTMLFormRenderer, JSONRenderer, StaticHTMLRenderer
 )
 from rest_framework.request import Request
@@ -706,3 +707,32 @@ class AdminRendererTests(TestCase):
         response = view(request)
         response.render()
         self.assertInHTML('<tr><th>Iteritems</th><td>a string</td></tr>', str(response.content))
+
+
+class TestDocumentationRenderer(TestCase):
+
+    def test_document_with_link_named_data(self):
+        """
+        Ref #5395: Doc's `document.data` would fail with a Link named "data".
+            As per #4972, use templatetag instead.
+        """
+        document = coreapi.Document(
+            title='Data Endpoint API',
+            url='https://api.example.org/',
+            content={
+                'data': coreapi.Link(
+                    url='/data/',
+                    action='get',
+                    fields=[],
+                    description='Return data.'
+                )
+            }
+        )
+
+        factory = APIRequestFactory()
+        request = factory.get('/')
+
+        renderer = DocumentationRenderer()
+
+        html = renderer.render(document, accepted_media_type="text/html", renderer_context={"request": request})
+        assert '<h1>Data Endpoint API</h1>' in html

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,11 @@
 """
-Blank URLConf just to keep the test suite happy
+URLConf for test suite.
+
+We need only the docs urls for DocumentationRenderer tests.
 """
-urlpatterns = []
+from django.conf.urls import url
+from rest_framework.documentation import include_docs_urls
+
+urlpatterns = [
+    url(r'^docs/', include_docs_urls(title='Test Suite API')),
+]


### PR DESCRIPTION
Closes #5395. 

If your `coreapi.Document` contains a `Link` called `data` then calls to `document.data` in the templates would fail. 

This PR adds a test case for that and a template tag to resolve the issue. (Note, it's the same fix as #4972)