### PR TITLE
Fix model fields not being omitted on output/serialization

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -176,7 +176,7 @@ class RelatedField(Field):
                 pass
 
         # Standard case, return the object instance.
-        return get_attribute(instance, self.source_attrs)
+        return super(RelatedField, self).get_attribute(instance)
 
     def get_choices(self, cutoff=None):
         queryset = self.get_queryset()

--- a/tests/test_multitable_inheritance.py
+++ b/tests/test_multitable_inheritance.py
@@ -44,7 +44,7 @@ class InheritedModelSerializationTests(TestCase):
         """
         child = ChildModel(name1='parent name', name2='child name')
         serializer = DerivedModelSerializer(child)
-        assert set(serializer.data.keys()) == set(['name1', 'name2', 'id'])
+        assert set(serializer.data.keys()) == set(['name1', 'name2'])
 
     def test_onetoone_primary_key_model_fields_as_expected(self):
         """

--- a/tests/test_one_to_one_with_inheritance.py
+++ b/tests/test_one_to_one_with_inheritance.py
@@ -43,4 +43,4 @@ class InheritedModelSerializationTests(TestCase):
         child = ChildModel(name1='parent name', name2='child name')
         serializer = DerivedModelSerializer(child)
         self.assertEqual(set(serializer.data.keys()),
-                         set(['name1', 'name2', 'id', 'childassociatedmodel']))
+                         set(['name1', 'name2', 'childassociatedmodel']))

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -170,7 +170,7 @@ class PKManyToManyTests(TestCase):
 
         serializer = ManyToManySourceSerializer(source)
 
-        expected = {'id': None, 'name': 'source-unsaved', 'targets': []}
+        expected = {'name': 'source-unsaved', 'targets': []}
         # no query if source hasn't been created yet
         with self.assertNumQueries(0):
             assert serializer.data == expected
@@ -330,7 +330,7 @@ class PKForeignKeyTests(TestCase):
 
     def test_foreign_key_with_unsaved(self):
         source = ForeignKeySource(name='source-unsaved')
-        expected = {'id': None, 'name': 'source-unsaved', 'target': None}
+        expected = {'name': 'source-unsaved', 'target': None}
 
         serializer = ForeignKeySourceSerializer(source)
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -360,12 +360,17 @@ class TestNotRequiredOutput:
         """
         'required=False' should allow an object attribute to be missing in output.
         """
-        class ExampleSerializer(serializers.Serializer):
-            omitted = serializers.CharField(required=False)
-            included = serializers.CharField()
+        class MyModel(models.Model):
+            omitted = models.CharField(max_length=10, blank=True)
+            included = models.CharField(max_length=10)
+
+        class ExampleSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = MyModel
+                exclude = ('id', )
 
             def create(self, validated_data):
-                return MockObject(**validated_data)
+                return self.Meta.model(**validated_data)
 
         serializer = ExampleSerializer(data={'included': 'abc'})
         serializer.is_valid()


### PR DESCRIPTION
## Description

The documentation says about a [field's `required` argument](http://www.django-rest-framework.org/api-guide/fields/#required):

> Setting this to False also allows the object attribute or dictionary key to be omitted from output when serializing the instance.

But this isn't the case for Django ORM model instances because they always return at least the field default so there's never an `AttributeError`.  This means that DRF's logic for omitting fields is never triggered and all model fields are always present in the JSON representation regardless of the field's `required` argument.

This PR fixes that by conditionally checking against the model field's default when the instance is a Django ORM model instance only when DRF's omit logic would take effect and forcing an `AttributeError` in those cases.  There's full test coverage for all the code this PR touches and there are no tox errors that I didn't also see when runagainst `encode/master`.

http://www.django-rest-framework.org/api-guide/fields/#required