### PR TITLE
Fix missing six.text_type() call on APIException.__str__

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -92,7 +92,7 @@ class APIException(Exception):
         self.detail = _get_error_details(detail, code)
 
     def __str__(self):
-        return self.detail
+        return six.text_type(self.detail)
 
     def get_codes(self):
         """
@@ -135,9 +135,6 @@ class ValidationError(APIException):
             detail = [detail]
 
         self.detail = _get_error_details(detail, code)
-
-    def __str__(self):
-        return six.text_type(self.detail)
 
 
 class ParseError(APIException):


### PR DESCRIPTION
The call was added in 426547c61c725ca7dc47671c084d1a2805c92305
to allow for dict-style arguments to ValidationError but does not
apply to other APIException descendants.

It is possible to hit edge cases when printing an APIException in a
custom exception handler, that was passed a non-string as its first
argument (eg. AuthenticationError({"code": "foo", "detail": "bar"}))
