### PR TITLE
Have `is_list_view` recognise RetrieveModel… views

### DIFF
--- a/rest_framework/schemas/utils.py
+++ b/rest_framework/schemas/utils.py
@@ -3,6 +3,7 @@ utils.py        # Shared helper functions
 
 See schemas.__init__.py for package overview.
 """
+from rest_framework.mixins import RetrieveModelMixin
 
 
 def is_list_view(path, method, view):
@@ -14,6 +15,8 @@ def is_list_view(path, method, view):
         return view.action == 'list'
 
     if method.lower() != 'get':
+        return False
+    if isinstance(view, RetrieveModelMixin):
         return False
     path_components = path.strip('/').split('/')
     if path_components and '{' in path_components[-1]:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,6 +19,7 @@ from rest_framework.schemas import (
     AutoSchema, ManualSchema, SchemaGenerator, get_schema_view
 )
 from rest_framework.schemas.generators import EndpointEnumerator
+from rest_framework.schemas.utils import is_list_view
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.utils import formatting
 from rest_framework.views import APIView
@@ -808,3 +809,15 @@ class TestURLNamingCollisions(TestCase):
 
         with pytest.raises(ValueError):
             generator.get_schema()
+
+
+def test_is_list_view_recognises_retrieve_view_subclasses():
+    class TestView(generics.RetrieveAPIView):
+        pass
+
+    path = '/looks/like/a/list/view/'
+    method = 'get'
+    view = TestView()
+
+    is_list = is_list_view(path, method, view)
+    assert not is_list, "RetrieveAPIView subclasses should not be classified as list views."


### PR DESCRIPTION
Fixes #5165

Adds `isinstance` check for `RetrieveModelMixin`. Useful when you've routed a view to a URL without a lookup parameter. e.g. `/accounts/profile/` which pulls its object (the current user) from the `request`.