### PR TITLE
Fixed issues with schema name collisions

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -106,7 +106,7 @@ def distribute_links(obj):
         distribute_links(value)
 
     for link in obj.links:
-        key = obj.get_next_key(str(link.action))
+        key = obj.get_next_key(link.action)
         obj[key] = link
 
 

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -4,7 +4,7 @@ generators.py   # Top-down schema generation
 See schemas.__init__.py for package overview.
 """
 import warnings
-from collections import OrderedDict, Counter
+from collections import Counter, OrderedDict
 from importlib import import_module
 
 from django.conf import settings

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -71,9 +71,13 @@ class LinkNode(OrderedDict):
         super(LinkNode, self).__init__()
 
     def get_next_key(self, method):
-        current_val = self.methods_counter[method]
-        self.methods_counter[method] += 1
-        return '{}_{}'.format(method, current_val)
+        while True:
+            current_val = self.methods_counter[method]
+            self.methods_counter[method] += 1
+
+            key = '{}_{}'.format(method, current_val)
+            if key not in self:
+                return key
 
 
 def insert_into(target, keys, value):

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -112,8 +112,8 @@ def distribute_links(obj, parent=None, parent_key='root'):
         key = get_unique_key(parent, parent_key)
         parent[key] = link
 
-    for key, value in obj.items():
-        distribute_links(value, obj, key)
+    for key in list(obj.keys()):
+        distribute_links(obj[key], obj, key)
 
 
 def is_custom_action(action):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -120,8 +120,7 @@ class TestRouterGeneratedSchema(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'list': {},
-                    'list_0': coreapi.Link(
+                    'get_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[
@@ -130,20 +129,17 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'custom_list_action': {},
-                    'custom_list_action_0': coreapi.Link(
+                    'get_1': coreapi.Link(
                         url='/example/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'read': {},
-                        'read_0': coreapi.Link(
+                        'get_0': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='get'
                         )
                     },
-                    'read': {},
-                    'read_0': coreapi.Link(
+                    'get_2': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -167,8 +163,7 @@ class TestRouterGeneratedSchema(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'list': {},
-                    'list_0': coreapi.Link(
+                    'get_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[
@@ -177,8 +172,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'create': {},
-                    'create_0': coreapi.Link(
+                    'post_0': coreapi.Link(
                         url='/example/',
                         action='post',
                         encoding='application/json',
@@ -187,8 +181,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
                         ]
                     ),
-                    'read': {},
-                    'read_0': coreapi.Link(
+                    'get_2': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -196,8 +189,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'custom_action': {},
-                    'custom_action_0': coreapi.Link(
+                    'post_1': coreapi.Link(
                         url='/example/{id}/custom_action/',
                         action='post',
                         encoding='application/json',
@@ -208,8 +200,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('d', required=False, location='form', schema=coreschema.String(title='D')),
                         ]
                     ),
-                    'custom_action_with_list_fields': {},
-                    'custom_action_with_list_fields_0': coreapi.Link(
+                    'post_2': coreapi.Link(
                         url='/example/{id}/custom_action_with_list_fields/',
                         action='post',
                         encoding='application/json',
@@ -220,25 +211,21 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('b', required=True, location='form', schema=coreschema.Array(title='B', items=coreschema.String())),
                         ]
                     ),
-                    'custom_list_action': {},
-                    'custom_list_action_0': coreapi.Link(
+                    'get_1': coreapi.Link(
                         url='/example/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'read': {},
-                        'read_0': coreapi.Link(
+                        'get_0': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='get'
                         ),
-                        'create': {},
-                        'create_0': coreapi.Link(
+                        'post_0': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='post'
                         )
                     },
-                    'update': {},
-                    'update_0': coreapi.Link(
+                    'put_0': coreapi.Link(
                         url='/example/{id}/',
                         action='put',
                         encoding='application/json',
@@ -249,8 +236,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'partial_update': {},
-                    'partial_update_0': coreapi.Link(
+                    'patch_0': coreapi.Link(
                         url='/example/{id}/',
                         action='patch',
                         encoding='application/json',
@@ -261,7 +247,6 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'delete': {},
                     'delete_0': coreapi.Link(
                         url='/example/{id}/',
                         action='delete',
@@ -344,20 +329,17 @@ class TestSchemaGenerator(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'create': {},
-                    'create_0': coreapi.Link(
+                    'post_0': coreapi.Link(
                         url='/example/',
                         action='post',
                         fields=[]
                     ),
-                    'list': {},
-                    'list_0': coreapi.Link(
+                    'get_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[]
                     ),
-                    'read': {},
-                    'read_0': coreapi.Link(
+                    'get_1': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -365,8 +347,7 @@ class TestSchemaGenerator(TestCase):
                         ]
                     ),
                     'sub': {
-                        'list': {},
-                        'list_0': coreapi.Link(
+                        'get_0': coreapi.Link(
                             url='/example/{id}/sub/',
                             action='get',
                             fields=[
@@ -401,20 +382,17 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'create': {},
-                    'create_0': coreapi.Link(
+                    'post_0': coreapi.Link(
                         url='/api/v1/example/',
                         action='post',
                         fields=[]
                     ),
-                    'list': {},
-                    'list_0': coreapi.Link(
+                    'get_0': coreapi.Link(
                         url='/api/v1/example/',
                         action='get',
                         fields=[]
                     ),
-                    'read': {},
-                    'read_0': coreapi.Link(
+                    'get_1': coreapi.Link(
                         url='/api/v1/example/{id}/',
                         action='get',
                         fields=[
@@ -422,8 +400,7 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
                         ]
                     ),
                     'sub': {
-                        'list': {},
-                        'list_0': coreapi.Link(
+                        'get_0': coreapi.Link(
                             url='/api/v1/example/{id}/sub/',
                             action='get',
                             fields=[
@@ -460,8 +437,7 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
             title='Example API',
             content={
                 'example1': {
-                    'list': {},
-                    'list_0': coreapi.Link(
+                    'get_0': coreapi.Link(
                         url='/example1/',
                         action='get',
                         fields=[
@@ -470,20 +446,17 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'custom_list_action': {},
-                    'custom_list_action_0': coreapi.Link(
+                    'get_1': coreapi.Link(
                         url='/example1/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'read': {},
-                        'read_0': coreapi.Link(
+                        'get_0': coreapi.Link(
                             url='/example1/custom_list_action_multiple_methods/',
                             action='get'
                         )
                     },
-                    'read': {},
-                    'read_0': coreapi.Link(
+                    'get_2': coreapi.Link(
                         url='/example1/{id}/',
                         action='get',
                         fields=[
@@ -521,8 +494,7 @@ class TestSchemaGeneratorWithRestrictedViewSets(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'list': {},
-                    'list_0': coreapi.Link(
+                    'get_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[]
@@ -694,8 +666,7 @@ class SchemaGenerationExclusionTests(TestCase):
             title='Exclusions',
             content={
                 'included-fbv': {
-                    'list': {},
-                    'list_0': coreapi.Link(url='/included-fbv/', action='get')
+                    'get_0': coreapi.Link(url='/included-fbv/', action='get')
                 }
             }
         )
@@ -820,10 +791,9 @@ class TestURLNamingCollisions(TestCase):
             content={
                 'test': {
                     'list': {
-                        'list': {},
-                        'list_0': coreapi.Link(url='/test/list/', action='get')
+                        'get_0': coreapi.Link(url='/test/list/', action='get')
                     },
-                    'list_0': coreapi.Link(url='/test', action='get')
+                    'get_0': coreapi.Link(url='/test', action='get')
                 }
             }
         )
@@ -832,7 +802,7 @@ class TestURLNamingCollisions(TestCase):
 
     def _verify_cbv_links(self, loc, url, methods=None, number=0):
         if methods is None:
-            methods = ('read', 'update', 'partial_update', 'delete')
+            methods = ('get', 'put', 'patch', 'delete')
 
         for method in methods:
             key = '{}_{}'.format(method, number)
@@ -868,20 +838,19 @@ class TestURLNamingCollisions(TestCase):
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
         schema = generator.get_schema()
-        desc = schema['detail_0'].description  # not important here
+        desc = schema['get_0'].description  # not important here
 
         expected = coreapi.Document(
             url='',
             title='Naming Colisions',
             content={
                 'detail': {
-                    'detail_export': {},
-                    'detail_export_0': coreapi.Link(
+                    'get_0': coreapi.Link(
                         url='/from-routercollision/detail/export/',
                         action='get',
                         description=desc)
                 },
-                'detail_0': coreapi.Link(
+                'get_0': coreapi.Link(
                     url='/from-routercollision/detail/',
                     action='get',
                     description=desc
@@ -900,9 +869,8 @@ class TestURLNamingCollisions(TestCase):
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
         schema = generator.get_schema()
 
-        assert schema['example']['read'] == {}
-        assert schema['example']['read_0'].url == '/example/{id}/'
-        assert schema['example']['read_1'].url == '/example/{slug}/'
+        assert schema['example']['get_0'].url == '/example/{id}/'
+        assert schema['example']['get_1'].url == '/example/{slug}/'
 
     def test_url_under_same_key_not_replaced_another(self):
 
@@ -914,5 +882,5 @@ class TestURLNamingCollisions(TestCase):
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
         schema = generator.get_schema()
 
-        assert schema['test']['list']['list_0'].url == '/test/list/'
-        assert schema['test']['list']['list_1'].url == '/test/{id}/list/'
+        assert schema['test']['list']['get_0'].url == '/test/list/'
+        assert schema['test']['list']['get_1'].url == '/test/{id}/list/'

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -120,7 +120,7 @@ class TestRouterGeneratedSchema(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'get_0': coreapi.Link(
+                    'list': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[
@@ -129,17 +129,17 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'get_1': coreapi.Link(
+                    'custom_list_action': coreapi.Link(
                         url='/example/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'get_0': coreapi.Link(
+                        'read': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='get'
                         )
                     },
-                    'get_2': coreapi.Link(
+                    'read': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -150,7 +150,6 @@ class TestRouterGeneratedSchema(TestCase):
                 }
             }
         )
-
         assert response.data == expected
 
     def test_authenticated_request(self):
@@ -163,7 +162,7 @@ class TestRouterGeneratedSchema(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'get_0': coreapi.Link(
+                    'list': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[
@@ -172,7 +171,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'post_0': coreapi.Link(
+                    'create': coreapi.Link(
                         url='/example/',
                         action='post',
                         encoding='application/json',
@@ -181,7 +180,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
                         ]
                     ),
-                    'get_2': coreapi.Link(
+                    'read': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -189,7 +188,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'post_1': coreapi.Link(
+                    'custom_action': coreapi.Link(
                         url='/example/{id}/custom_action/',
                         action='post',
                         encoding='application/json',
@@ -200,7 +199,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('d', required=False, location='form', schema=coreschema.String(title='D')),
                         ]
                     ),
-                    'post_2': coreapi.Link(
+                    'custom_action_with_list_fields': coreapi.Link(
                         url='/example/{id}/custom_action_with_list_fields/',
                         action='post',
                         encoding='application/json',
@@ -211,21 +210,21 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('b', required=True, location='form', schema=coreschema.Array(title='B', items=coreschema.String())),
                         ]
                     ),
-                    'get_1': coreapi.Link(
+                    'custom_list_action': coreapi.Link(
                         url='/example/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'get_0': coreapi.Link(
+                        'read': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='get'
                         ),
-                        'post_0': coreapi.Link(
+                        'create': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='post'
                         )
                     },
-                    'put_0': coreapi.Link(
+                    'update': coreapi.Link(
                         url='/example/{id}/',
                         action='put',
                         encoding='application/json',
@@ -236,7 +235,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'patch_0': coreapi.Link(
+                    'partial_update': coreapi.Link(
                         url='/example/{id}/',
                         action='patch',
                         encoding='application/json',
@@ -247,7 +246,7 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'delete_0': coreapi.Link(
+                    'delete': coreapi.Link(
                         url='/example/{id}/',
                         action='delete',
                         fields=[
@@ -329,17 +328,17 @@ class TestSchemaGenerator(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'post_0': coreapi.Link(
+                    'create': coreapi.Link(
                         url='/example/',
                         action='post',
                         fields=[]
                     ),
-                    'get_0': coreapi.Link(
+                    'list': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[]
                     ),
-                    'get_1': coreapi.Link(
+                    'read': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -347,7 +346,7 @@ class TestSchemaGenerator(TestCase):
                         ]
                     ),
                     'sub': {
-                        'get_0': coreapi.Link(
+                        'list': coreapi.Link(
                             url='/example/{id}/sub/',
                             action='get',
                             fields=[
@@ -382,17 +381,17 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'post_0': coreapi.Link(
+                    'create': coreapi.Link(
                         url='/api/v1/example/',
                         action='post',
                         fields=[]
                     ),
-                    'get_0': coreapi.Link(
+                    'list': coreapi.Link(
                         url='/api/v1/example/',
                         action='get',
                         fields=[]
                     ),
-                    'get_1': coreapi.Link(
+                    'read': coreapi.Link(
                         url='/api/v1/example/{id}/',
                         action='get',
                         fields=[
@@ -400,7 +399,7 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
                         ]
                     ),
                     'sub': {
-                        'get_0': coreapi.Link(
+                        'list': coreapi.Link(
                             url='/api/v1/example/{id}/sub/',
                             action='get',
                             fields=[
@@ -437,7 +436,7 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
             title='Example API',
             content={
                 'example1': {
-                    'get_0': coreapi.Link(
+                    'list': coreapi.Link(
                         url='/example1/',
                         action='get',
                         fields=[
@@ -446,17 +445,17 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'get_1': coreapi.Link(
+                    'custom_list_action': coreapi.Link(
                         url='/example1/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'get_0': coreapi.Link(
+                        'read': coreapi.Link(
                             url='/example1/custom_list_action_multiple_methods/',
                             action='get'
                         )
                     },
-                    'get_2': coreapi.Link(
+                    'read': coreapi.Link(
                         url='/example1/{id}/',
                         action='get',
                         fields=[
@@ -494,7 +493,7 @@ class TestSchemaGeneratorWithRestrictedViewSets(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'get_0': coreapi.Link(
+                    'list': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[]
@@ -666,7 +665,7 @@ class SchemaGenerationExclusionTests(TestCase):
             title='Exclusions',
             content={
                 'included-fbv': {
-                    'get_0': coreapi.Link(url='/included-fbv/', action='get')
+                    'list': coreapi.Link(url='/included-fbv/', action='get')
                 }
             }
         )
@@ -791,21 +790,26 @@ class TestURLNamingCollisions(TestCase):
             content={
                 'test': {
                     'list': {
-                        'get_0': coreapi.Link(url='/test/list/', action='get')
+                        'list': coreapi.Link(url='/test/list/', action='get')
                     },
-                    'get_0': coreapi.Link(url='/test', action='get')
+                    'list_0': coreapi.Link(url='/test', action='get')
                 }
             }
         )
 
         assert expected == schema
 
-    def _verify_cbv_links(self, loc, url, methods=None, number=0):
+    def _verify_cbv_links(self, loc, url, methods=None, suffixes=None):
         if methods is None:
-            methods = ('get', 'put', 'patch', 'delete')
+            methods = ('read', 'update', 'partial_update', 'delete')
+        if suffixes is None:
+            suffixes = (None for m in methods)
 
-        for method in methods:
-            key = '{}_{}'.format(method, number)
+        for method, suffix in zip(methods, suffixes):
+            if suffix is not None:
+                key = '{}_{}'.format(method, suffix)
+            else:
+                key = method
             assert loc[key].url == url
 
     def test_manually_routing_generic_view(self):
@@ -829,7 +833,7 @@ class TestURLNamingCollisions(TestCase):
         self._verify_cbv_links(schema['test']['get'], '/test/get/')
         self._verify_cbv_links(schema['test']['update'], '/test/update/')
         self._verify_cbv_links(schema['test']['retrieve'], '/test/retrieve/')
-        self._verify_cbv_links(schema['test'], '/test')
+        self._verify_cbv_links(schema['test'], '/test', suffixes=(None, '0', None, '0'))
 
     def test_from_router(self):
         patterns = [
@@ -838,19 +842,19 @@ class TestURLNamingCollisions(TestCase):
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
         schema = generator.get_schema()
-        desc = schema['get_0'].description  # not important here
+        desc = schema['detail_0'].description  # not important here
 
         expected = coreapi.Document(
             url='',
             title='Naming Colisions',
             content={
                 'detail': {
-                    'get_0': coreapi.Link(
+                    'detail_export': coreapi.Link(
                         url='/from-routercollision/detail/export/',
                         action='get',
                         description=desc)
                 },
-                'get_0': coreapi.Link(
+                'detail_0': coreapi.Link(
                     url='/from-routercollision/detail/',
                     action='get',
                     description=desc
@@ -869,8 +873,8 @@ class TestURLNamingCollisions(TestCase):
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
         schema = generator.get_schema()
 
-        assert schema['example']['get_0'].url == '/example/{id}/'
-        assert schema['example']['get_1'].url == '/example/{slug}/'
+        assert schema['example']['read'].url == '/example/{id}/'
+        assert schema['example']['read_0'].url == '/example/{slug}/'
 
     def test_url_under_same_key_not_replaced_another(self):
 
@@ -882,5 +886,5 @@ class TestURLNamingCollisions(TestCase):
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
         schema = generator.get_schema()
 
-        assert schema['test']['list']['get_0'].url == '/test/list/'
-        assert schema['test']['list']['get_1'].url == '/test/{id}/list/'
+        assert schema['test']['list']['list'].url == '/test/list/'
+        assert schema['test']['list']['list_0'].url == '/test/{id}/list/'

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,7 +19,6 @@ from rest_framework.schemas import (
     AutoSchema, ManualSchema, SchemaGenerator, get_schema_view
 )
 from rest_framework.schemas.generators import EndpointEnumerator
-from rest_framework.schemas.utils import is_list_view
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.utils import formatting
 from rest_framework.views import APIView
@@ -121,7 +120,8 @@ class TestRouterGeneratedSchema(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'list': coreapi.Link(
+                    'list': {},
+                    'list_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[
@@ -130,17 +130,20 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'custom_list_action': coreapi.Link(
+                    'custom_list_action': {},
+                    'custom_list_action_0': coreapi.Link(
                         url='/example/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'read': coreapi.Link(
+                        'read': {},
+                        'read_0': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='get'
                         )
                     },
-                    'read': coreapi.Link(
+                    'read': {},
+                    'read_0': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -151,6 +154,7 @@ class TestRouterGeneratedSchema(TestCase):
                 }
             }
         )
+
         assert response.data == expected
 
     def test_authenticated_request(self):
@@ -163,7 +167,8 @@ class TestRouterGeneratedSchema(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'list': coreapi.Link(
+                    'list': {},
+                    'list_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[
@@ -172,7 +177,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'create': coreapi.Link(
+                    'create': {},
+                    'create_0': coreapi.Link(
                         url='/example/',
                         action='post',
                         encoding='application/json',
@@ -181,7 +187,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
                         ]
                     ),
-                    'read': coreapi.Link(
+                    'read': {},
+                    'read_0': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -189,7 +196,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'custom_action': coreapi.Link(
+                    'custom_action': {},
+                    'custom_action_0': coreapi.Link(
                         url='/example/{id}/custom_action/',
                         action='post',
                         encoding='application/json',
@@ -200,7 +208,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('d', required=False, location='form', schema=coreschema.String(title='D')),
                         ]
                     ),
-                    'custom_action_with_list_fields': coreapi.Link(
+                    'custom_action_with_list_fields': {},
+                    'custom_action_with_list_fields_0': coreapi.Link(
                         url='/example/{id}/custom_action_with_list_fields/',
                         action='post',
                         encoding='application/json',
@@ -211,21 +220,25 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('b', required=True, location='form', schema=coreschema.Array(title='B', items=coreschema.String())),
                         ]
                     ),
-                    'custom_list_action': coreapi.Link(
+                    'custom_list_action': {},
+                    'custom_list_action_0': coreapi.Link(
                         url='/example/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'read': coreapi.Link(
+                        'read': {},
+                        'read_0': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='get'
                         ),
-                        'create': coreapi.Link(
+                        'create': {},
+                        'create_0': coreapi.Link(
                             url='/example/custom_list_action_multiple_methods/',
                             action='post'
                         )
                     },
-                    'update': coreapi.Link(
+                    'update': {},
+                    'update_0': coreapi.Link(
                         url='/example/{id}/',
                         action='put',
                         encoding='application/json',
@@ -236,7 +249,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'partial_update': coreapi.Link(
+                    'partial_update': {},
+                    'partial_update_0': coreapi.Link(
                         url='/example/{id}/',
                         action='patch',
                         encoding='application/json',
@@ -247,7 +261,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'delete': coreapi.Link(
+                    'delete': {},
+                    'delete_0': coreapi.Link(
                         url='/example/{id}/',
                         action='delete',
                         fields=[
@@ -329,17 +344,20 @@ class TestSchemaGenerator(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'create': coreapi.Link(
+                    'create': {},
+                    'create_0': coreapi.Link(
                         url='/example/',
                         action='post',
                         fields=[]
                     ),
-                    'list': coreapi.Link(
+                    'list': {},
+                    'list_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[]
                     ),
-                    'read': coreapi.Link(
+                    'read': {},
+                    'read_0': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
@@ -347,7 +365,8 @@ class TestSchemaGenerator(TestCase):
                         ]
                     ),
                     'sub': {
-                        'list': coreapi.Link(
+                        'list': {},
+                        'list_0': coreapi.Link(
                             url='/example/{id}/sub/',
                             action='get',
                             fields=[
@@ -382,17 +401,20 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'create': coreapi.Link(
+                    'create': {},
+                    'create_0': coreapi.Link(
                         url='/api/v1/example/',
                         action='post',
                         fields=[]
                     ),
-                    'list': coreapi.Link(
+                    'list': {},
+                    'list_0': coreapi.Link(
                         url='/api/v1/example/',
                         action='get',
                         fields=[]
                     ),
-                    'read': coreapi.Link(
+                    'read': {},
+                    'read_0': coreapi.Link(
                         url='/api/v1/example/{id}/',
                         action='get',
                         fields=[
@@ -400,7 +422,8 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
                         ]
                     ),
                     'sub': {
-                        'list': coreapi.Link(
+                        'list': {},
+                        'list_0': coreapi.Link(
                             url='/api/v1/example/{id}/sub/',
                             action='get',
                             fields=[
@@ -437,7 +460,8 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
             title='Example API',
             content={
                 'example1': {
-                    'list': coreapi.Link(
+                    'list': {},
+                    'list_0': coreapi.Link(
                         url='/example1/',
                         action='get',
                         fields=[
@@ -446,17 +470,20 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
                             coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
-                    'custom_list_action': coreapi.Link(
+                    'custom_list_action': {},
+                    'custom_list_action_0': coreapi.Link(
                         url='/example1/custom_list_action/',
                         action='get'
                     ),
                     'custom_list_action_multiple_methods': {
-                        'read': coreapi.Link(
+                        'read': {},
+                        'read_0': coreapi.Link(
                             url='/example1/custom_list_action_multiple_methods/',
                             action='get'
                         )
                     },
-                    'read': coreapi.Link(
+                    'read': {},
+                    'read_0': coreapi.Link(
                         url='/example1/{id}/',
                         action='get',
                         fields=[
@@ -494,7 +521,8 @@ class TestSchemaGeneratorWithRestrictedViewSets(TestCase):
             title='Example API',
             content={
                 'example': {
-                    'list': coreapi.Link(
+                    'list': {},
+                    'list_0': coreapi.Link(
                         url='/example/',
                         action='get',
                         fields=[]
@@ -666,7 +694,8 @@ class SchemaGenerationExclusionTests(TestCase):
             title='Exclusions',
             content={
                 'included-fbv': {
-                    'list': coreapi.Link(url='/included-fbv/', action='get')
+                    'list': {},
+                    'list_0': coreapi.Link(url='/included-fbv/', action='get')
                 }
             }
         )
@@ -749,6 +778,10 @@ class NamingCollisionView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = BasicModelSerializer
 
 
+class BasicNamingCollisionView(generics.RetrieveAPIView):
+    queryset = BasicModel.objects.all()
+
+
 class NamingCollisionViewSet(GenericViewSet):
     """
     Example via: https://stackoverflow.com/questions/43778668/django-rest-framwork-occured-typeerror-link-object-does-not-support-item-ass/
@@ -779,9 +812,31 @@ class TestURLNamingCollisions(TestCase):
         ]
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
+        schema = generator.get_schema()
 
-        with pytest.raises(ValueError):
-            generator.get_schema()
+        expected = coreapi.Document(
+            url='',
+            title='Naming Colisions',
+            content={
+                'test': {
+                    'list': {
+                        'list': {},
+                        'list_0': coreapi.Link(url='/test/list/', action='get')
+                    },
+                    'list_0': coreapi.Link(url='/test', action='get')
+                }
+            }
+        )
+
+        assert expected == schema
+
+    def _verify_cbv_links(self, loc, url, methods=None, number=0):
+        if methods is None:
+            methods = ('read', 'update', 'partial_update', 'delete')
+
+        for method in methods:
+            key = '{}_{}'.format(method, number)
+            assert loc[key].url == url
 
     def test_manually_routing_generic_view(self):
         patterns = [
@@ -797,8 +852,14 @@ class TestURLNamingCollisions(TestCase):
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
 
-        with pytest.raises(ValueError):
-            generator.get_schema()
+        schema = generator.get_schema()
+
+        self._verify_cbv_links(schema['test']['delete'], '/test/delete/')
+        self._verify_cbv_links(schema['test']['put'], '/test/put/')
+        self._verify_cbv_links(schema['test']['get'], '/test/get/')
+        self._verify_cbv_links(schema['test']['update'], '/test/update/')
+        self._verify_cbv_links(schema['test']['retrieve'], '/test/retrieve/')
+        self._verify_cbv_links(schema['test'], '/test')
 
     def test_from_router(self):
         patterns = [
@@ -806,18 +867,52 @@ class TestURLNamingCollisions(TestCase):
         ]
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
+        schema = generator.get_schema()
+        desc = schema['detail_0'].description  # not important here
 
-        with pytest.raises(ValueError):
-            generator.get_schema()
+        expected = coreapi.Document(
+            url='',
+            title='Naming Colisions',
+            content={
+                'detail': {
+                    'detail_export': {},
+                    'detail_export_0': coreapi.Link(
+                        url='/from-routercollision/detail/export/',
+                        action='get',
+                        description=desc)
+                },
+                'detail_0': coreapi.Link(
+                    url='/from-routercollision/detail/',
+                    action='get',
+                    description=desc
+                )
+            }
+        )
 
+        assert schema == expected
 
-def test_is_list_view_recognises_retrieve_view_subclasses():
-    class TestView(generics.RetrieveAPIView):
-        pass
+    def test_url_under_same_key_not_replaced(self):
+        patterns = [
+            url(r'example/(?P<pk>\d+)/$', BasicNamingCollisionView.as_view()),
+            url(r'example/(?P<slug>\w+)/$', BasicNamingCollisionView.as_view()),
+        ]
 
-    path = '/looks/like/a/list/view/'
-    method = 'get'
-    view = TestView()
+        generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
+        schema = generator.get_schema()
 
-    is_list = is_list_view(path, method, view)
-    assert not is_list, "RetrieveAPIView subclasses should not be classified as list views."
+        assert schema['example']['read'] == {}
+        assert schema['example']['read_0'].url == '/example/{id}/'
+        assert schema['example']['read_1'].url == '/example/{slug}/'
+
+    def test_url_under_same_key_not_replaced_another(self):
+
+        patterns = [
+            url(r'^test/list/', simple_fbv),
+            url(r'^test/(?P<pk>\d+)/list/', simple_fbv),
+        ]
+
+        generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
+        schema = generator.get_schema()
+
+        assert schema['test']['list']['list_0'].url == '/test/list/'
+        assert schema['test']['list']['list_1'].url == '/test/{id}/list/'

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,6 +19,7 @@ from rest_framework.schemas import (
     AutoSchema, ManualSchema, SchemaGenerator, get_schema_view
 )
 from rest_framework.schemas.generators import EndpointEnumerator
+from rest_framework.schemas.utils import is_list_view
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.utils import formatting
 from rest_framework.views import APIView
@@ -888,3 +889,15 @@ class TestURLNamingCollisions(TestCase):
 
         assert schema['test']['list']['list'].url == '/test/list/'
         assert schema['test']['list']['list_0'].url == '/test/{id}/list/'
+
+
+def test_is_list_view_recognises_retrieve_view_subclasses():
+    class TestView(generics.RetrieveAPIView):
+        pass
+
+    path = '/looks/like/a/list/view/'
+    method = 'get'
+    view = TestView()
+
+    is_list = is_list_view(path, method, view)
+    assert not is_list, "RetrieveAPIView subclasses should not be classified as list views."


### PR DESCRIPTION
If urls include elements in `['retrieve', 'list', 'create', 'update', 'partial_update', 'destroy']` schema generation can fail (if a **nested** item clashes with a previously definedLink) or replace other link.

PR fixes https://github.com/encode/django-rest-framework/issues/5484 and https://github.com/encode/django-rest-framework/issues/4704.

Also took unit tests from another PR targeting this issue: https://github.com/encode/django-rest-framework/pull/5464

