### PR TITLE
Interactive documentation always uses false for boolean fields in requests

### DIFF
--- a/rest_framework/static/rest_framework/docs/js/api.js
+++ b/rest_framework/static/rest_framework/docs/js/api.js
@@ -129,7 +129,7 @@ $(function () {
           'false': false
         }[paramValue.toLowerCase()]
         if (value !== undefined) {
-          params[paramKey]
+          params[paramKey] = value
         }
       } else if (dataType === 'array' && paramValue) {
         try {


### PR DESCRIPTION
Closes #5477.

The value was being correctly determined, but was never assigned as the parameter value for the request.
