### PR TITLE
Support URLPattern and URLResolver from Django 2.0

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -25,12 +25,33 @@ from django.views.generic import View
 
 try:
     from django.urls import (
-        NoReverseMatch, RegexURLPattern, RegexURLResolver, ResolverMatch, Resolver404, get_script_prefix, reverse, reverse_lazy, resolve
+        NoReverseMatch, URLPattern as RegexURLPattern, URLResolver as RegexURLResolver, ResolverMatch, Resolver404, get_script_prefix, reverse, reverse_lazy, resolve
     )
+
 except ImportError:
     from django.core.urlresolvers import (  # Will be removed in Django 2.0
         NoReverseMatch, RegexURLPattern, RegexURLResolver, ResolverMatch, Resolver404, get_script_prefix, reverse, reverse_lazy, resolve
     )
+
+
+def get_regex_pattern(urlpattern):
+    if hasattr(urlpattern, 'pattern'):
+        # Django 2.0
+        return urlpattern.pattern.regex.pattern
+    else:
+        # Django < 2.0
+        return urlpattern.regex.pattern
+
+
+def make_url_resolver(regex, urlpatterns):
+    try:
+        # Django 2.0
+        from django.urls.resolvers import RegexPattern
+        return RegexURLResolver(RegexPattern(regex), urlpatterns)
+
+    except ImportError:
+        # Django < 2.0
+        return RegexURLResolver(regex, urlpatterns)
 
 
 try:

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -15,7 +15,7 @@ from django.utils import six
 
 from rest_framework import exceptions
 from rest_framework.compat import (
-    RegexURLPattern, RegexURLResolver, coreapi, coreschema
+    RegexURLPattern, RegexURLResolver, coreapi, coreschema, get_regex_pattern
 )
 from rest_framework.request import clone_request
 from rest_framework.settings import api_settings
@@ -135,7 +135,7 @@ class EndpointEnumerator(object):
         api_endpoints = []
 
         for pattern in patterns:
-            path_regex = prefix + pattern.regex.pattern
+            path_regex = prefix + get_regex_pattern(pattern)
             if isinstance(pattern, RegexURLPattern):
                 path = self.get_path_from_regex(path_regex)
                 callback = pattern.callback

--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.conf.urls import include, url
 
-from rest_framework.compat import RegexURLResolver
+from rest_framework.compat import RegexURLResolver, get_regex_pattern
 from rest_framework.settings import api_settings
 
 
@@ -11,7 +11,7 @@ def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required):
     for urlpattern in urlpatterns:
         if isinstance(urlpattern, RegexURLResolver):
             # Set of included URL patterns
-            regex = urlpattern.regex.pattern
+            regex = get_regex_pattern(urlpattern)
             namespace = urlpattern.namespace
             app_name = urlpattern.app_name
             kwargs = urlpattern.default_kwargs
@@ -22,7 +22,7 @@ def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required):
             ret.append(url(regex, include((patterns, app_name), namespace), kwargs))
         else:
             # Regular URL pattern
-            regex = urlpattern.regex.pattern.rstrip('$').rstrip('/') + suffix_pattern
+            regex = get_regex_pattern(urlpattern).rstrip('$').rstrip('/') + suffix_pattern
             view = urlpattern.callback
             kwargs = urlpattern.default_args
             name = urlpattern.name

--- a/tests/test_urlpatterns.py
+++ b/tests/test_urlpatterns.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from django.conf.urls import include, url
 from django.test import TestCase
 
-from rest_framework.compat import RegexURLResolver, Resolver404
+from rest_framework.compat import make_url_resolver, Resolver404
 from rest_framework.test import APIRequestFactory
 from rest_framework.urlpatterns import format_suffix_patterns
 
@@ -28,7 +28,7 @@ class FormatSuffixTests(TestCase):
             urlpatterns = format_suffix_patterns(urlpatterns)
         except Exception:
             self.fail("Failed to apply `format_suffix_patterns` on  the supplied urlpatterns")
-        resolver = RegexURLResolver(r'^/', urlpatterns)
+        resolver = make_url_resolver(r'^/', urlpatterns)
         for test_path in test_paths:
             request = factory.get(test_path.path)
             try:
@@ -43,7 +43,7 @@ class FormatSuffixTests(TestCase):
         urlpatterns = format_suffix_patterns([
             url(r'^test/$', dummy_view),
         ])
-        resolver = RegexURLResolver(r'^/', urlpatterns)
+        resolver = make_url_resolver(r'^/', urlpatterns)
 
         test_paths = [
             (URLTestPath('/test.api', (), {'format': 'api'}), True),

--- a/tests/test_urlpatterns.py
+++ b/tests/test_urlpatterns.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from django.conf.urls import include, url
 from django.test import TestCase
 
-from rest_framework.compat import make_url_resolver, Resolver404
+from rest_framework.compat import Resolver404, make_url_resolver
 from rest_framework.test import APIRequestFactory
 from rest_framework.urlpatterns import format_suffix_patterns
 


### PR DESCRIPTION
## Description

Fixes #5456

My attempt to make sense of the new [URL routing API](https://github.com/django/django/commit/df41b5a05d4e00e80e73afe629072e37873e767a#diff-b2f90a810a553411112f412de2a26617) from Django 2.0:

* `RegexURLPattern` and `RegexURLResolver` are renamed to `URLPattern` and `URLResolver` respectively.
* Their regexes are now encapsulated inside `RegexPattern`/`RoutePattern` instances and are located at `self.pattern.regex` (was `self.regex`).
* Both `url()` and the new `path()` return `URLPattern`. So, no changes needed to support the new routing syntax.