### PR TITLE
Fixed Django 2.1 compatibility due to removal of django.contrib.auth.login()/logout() views.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -11,6 +11,7 @@ import inspect
 import django
 from django.apps import apps
 from django.conf import settings
+from django.contrib.auth import views
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import \
     MaxLengthValidator as DjangoMaxLengthValidator
@@ -332,3 +333,12 @@ def authenticate(request=None, **credentials):
         return authenticate(**credentials)
     else:
         return authenticate(request=request, **credentials)
+
+if django.VERSION < (1, 11):
+    login = views.login
+    login_kwargs = {'template_name': 'rest_framework/login.html'}
+    logout = views.logout
+else:
+    login = views.LoginView.as_view(template_name='rest_framework/login.html')
+    login_kwargs = {}
+    logout = views.LogoutView.as_view()

--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -15,12 +15,11 @@ and you should make sure your authentication settings include `SessionAuthentica
 from __future__ import unicode_literals
 
 from django.conf.urls import url
-from django.contrib.auth import views
 
-template_name = {'template_name': 'rest_framework/login.html'}
+from rest_framework.compat import login, login_kwargs, logout
 
 app_name = 'rest_framework'
 urlpatterns = [
-    url(r'^login/$', views.login, template_name, name='login'),
-    url(r'^logout/$', views.logout, template_name, name='logout'),
+    url(r'^login/$', login, login_kwargs, name='login'),
+    url(r'^logout/$', logout, name='logout'),
 ]


### PR DESCRIPTION
Fixed Django 2.1 compatibility due to removal of `django.contrib.auth.login()/logout()` views (see Django documentation [1.11](https://docs.djangoproject.com/en/1.11/releases/1.11/#django-contrib-auth), [2.1](https://docs.djangoproject.com/en/dev/releases/2.1/#features-removed-in-2-1)).

```
________________ ERROR collecting tests/test_authentication.py _________________
tests/test_authentication.py:85: in <module>
    url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
.tox/py35-djangomaster/lib/python3.5/site-packages/django/urls/conf.py:34: in include
    urlconf_module = import_module(urlconf_module)
.tox/py35-djangomaster/lib/python3.5/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
rest_framework/urls.py:24: in <module>
    url(r'^login/$', views.login, template_name, name='login'),
E   AttributeError: module 'django.contrib.auth.views' has no attribute 'login'

___________________ ERROR collecting tests/test_renderers.py ___________________
tests/test_renderers.py:121: in <module>
    url(r'^api', include('rest_framework.urls', namespace='rest_framework'))
.tox/py35-djangomaster/lib/python3.5/site-packages/django/urls/conf.py:34: in include
    urlconf_module = import_module(urlconf_module)
.tox/py35-djangomaster/lib/python3.5/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
rest_framework/urls.py:24: in <module>
    url(r'^login/$', views.login, template_name, name='login'),
E   AttributeError: module 'django.contrib.auth.views' has no attribute 'login'

___________________ ERROR collecting tests/test_response.py ____________________
tests/test_response.py:131: in <module>
    url(r'^restframework', include('rest_framework.urls', namespace='rest_framework'))
.tox/py35-djangomaster/lib/python3.5/site-packages/django/urls/conf.py:34: in include
    urlconf_module = import_module(urlconf_module)
.tox/py35-djangomaster/lib/python3.5/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
rest_framework/urls.py:24: in <module>
    url(r'^login/$', views.login, template_name, name='login'),
E   AttributeError: module 'django.contrib.auth.views' has no attribute 'login'
```