### PR TITLE
include date and date-time format in coreapi schema generation

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -68,6 +68,18 @@ def field_to_schema(field):
         return coreschema.Number(title=title, description=description)
     elif isinstance(field, serializers.IntegerField):
         return coreschema.Integer(title=title, description=description)
+    elif isinstance(field, serializers.DateField):
+        return coreschema.String(
+            title=title,
+            description=description,
+            format='date'
+        )
+    elif isinstance(field, serializers.DateTimeField):
+        return coreschema.String(
+            title=title,
+            description=description,
+            format='date-time'
+        )
 
     if field.style.get('base_template') == 'textarea.html':
         return coreschema.String(


### PR DESCRIPTION
This adds the proper format when translating serializers.DateField & DateTimeField to coreapi/coreschema

Helps down the line with swagger:
https://github.com/marcgibbons/django-rest-swagger/issues/703