### PR TITLE
Add import for TextLexer.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -213,7 +213,7 @@ except ImportError:
 
 try:
     import pygments
-    from pygments.lexers import get_lexer_by_name
+    from pygments.lexers import get_lexer_by_name, TextLexer
     from pygments.formatters import HtmlFormatter
 
     def pygments_highlight(text, lang, style):


### PR DESCRIPTION
If pygments did not recognize the language name it was being passed,
this would raise a `NameError` because `TextLexer` import was missing.