### PR TITLE
substitute '@@' code block delimiter with triple backtick,  more con…

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -244,7 +244,7 @@ if markdown is not None and pygments is not None:
 
     class CodeBlockPreprocessor(Preprocessor):
         pattern = re.compile(
-            r'^\s*@@ (.+?) @@\s*(.+?)^\s*@@', re.M|re.S)
+            r'^\s*``` ([^\n]+)\n(.+?)^\s*```', re.M|re.S)
 
         formatter = HtmlFormatter()
 

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -244,7 +244,7 @@ if markdown is not None and pygments is not None:
 
     class CodeBlockPreprocessor(Preprocessor):
         pattern = re.compile(
-            r'^\s*``` ([^\n]+)\n(.+?)^\s*```', re.M|re.S)
+            r'^\s*``` *([^\n]+)\n(.+?)^\s*```', re.M|re.S)
 
         formatter = HtmlFormatter()
 

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -26,12 +26,12 @@ indented
 
 # hash style header #
 
-@@ json @@
+``` json
 [{
     "alpha": 1,
     "beta: "this is a string"
 }]
-@@"""
+```"""
 
 # If markdown is installed we also test it's working
 # (and that our wrapped forces '=' to h2 and '-' to h3)
@@ -47,12 +47,12 @@ string&quot;</span><br /><span class="p">}]</span><br /></pre></div>
 <p><br /></p>"""
 
 MARKED_DOWN_NOT_HILITE = """
-<p>@@ json @@
+<p>``` json
 [{
     "alpha": 1,
     "beta: "this is a string"
 }]
-@@</p>"""
+```</p>"""
 
 # We support markdown < 2.1 and markdown >= 2.1
 MARKED_DOWN_lt_21 = """<h2>an example docstring</h2>
@@ -105,13 +105,14 @@ class TestViewNamesAndDescriptions(TestCase):
 
             # hash style header #
 
-            @@ json @@
+            ``` json
             [{
                 "alpha": 1,
                 "beta: "this is a string"
             }]
-            @@"""
+            ```"""
 
+        print("MOCK:\n[%s]" % MockView().get_view_description())
         assert MockView().get_view_description() == DESCRIPTION
 
     def test_view_description_can_be_empty(self):

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -47,12 +47,11 @@ string&quot;</span><br /><span class="p">}]</span><br /></pre></div>
 <p><br /></p>"""
 
 MARKED_DOWN_NOT_HILITE = """
-<p>``` json
+<p><code>json
 [{
     "alpha": 1,
     "beta: "this is a string"
-}]
-```</p>"""
+}]</code></p>"""
 
 # We support markdown < 2.1 and markdown >= 2.1
 MARKED_DOWN_lt_21 = """<h2>an example docstring</h2>
@@ -150,15 +149,16 @@ class TestViewNamesAndDescriptions(TestCase):
         Ensure markdown to HTML works as expected.
         """
         if apply_markdown:
+            md_applied = apply_markdown(DESCRIPTION)
             gte_21_match = (
-                apply_markdown(DESCRIPTION) == (
+                md_applied == (
                     MARKED_DOWN_gte_21 % MARKED_DOWN_HILITE) or
-                apply_markdown(DESCRIPTION) == (
+                md_applied == (
                     MARKED_DOWN_gte_21 % MARKED_DOWN_NOT_HILITE))
             lt_21_match = (
-                apply_markdown(DESCRIPTION) == (
+                md_applied == (
                     MARKED_DOWN_lt_21 % MARKED_DOWN_HILITE) or
-                apply_markdown(DESCRIPTION) == (
+                md_applied == (
                     MARKED_DOWN_lt_21 % MARKED_DOWN_NOT_HILITE))
             assert gte_21_match or lt_21_match
 

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -112,7 +112,6 @@ class TestViewNamesAndDescriptions(TestCase):
             }]
             ```"""
 
-        print("MOCK:\n[%s]" % MockView().get_view_description())
         assert MockView().get_view_description() == DESCRIPTION
 
     def test_view_description_can_be_empty(self):


### PR DESCRIPTION
…sistent with other markdown extensions

following the discussion on the previous pull request (https://github.com/encode/django-rest-framework/pull/5462) I moved from:
```
@@ <lang> @@
...
block of code
...
@@
```

to:
```
``` <lang>
...
block of code
...
\```
```
(that extra backslash is just so I can fool githubs markdown parsing to let me put triple backticks inside a code block marked out by triple backticks)