### PR TITLE
Interactive docs - make bottom sidebar items fixed to bottom (refs #5370)

### DIFF
--- a/rest_framework/static/rest_framework/docs/css/base.css
+++ b/rest_framework/static/rest_framework/docs/css/base.css
@@ -64,6 +64,10 @@ pre.highlight code {
   display: none;
 }
 
+.sidebar .menu-list {
+  width: inherit;
+}
+
 .sidebar .menu-list ul,
 .sidebar .menu-list li {
   background: #2e353d;
@@ -194,7 +198,8 @@ body {
 
 .sidebar .menu-list.menu-list-bottom {
     margin-bottom: 0;
-    position: absolute;
+    position: fixed;
+    width: inherit;
     bottom: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
## Description

Closes https://github.com/encode/django-rest-framework/issues/5370

## **UPDATE:**

Current solution is to make .menu-list-bottom: {position: fixed; width: inherit;}, and .menu-list: {width: inherit;}

This appears to have the desired effect of keeping the Auth/Code buttons always at the bottom of the sidebar, and always above the rest of the menu items.

### The below info is no longer accurate, the solution in this branch is no longer using "position: sticky". I'm leaving the below info for historical purposes.

Simply changing the CSS position of menu-list-bottom to 'sticky' instead of 'absolute' causes the Authentication/Source Code buttons to operate as expected.

**NOTE:** The 'position: sticky' is a more recent CSS feature, and so browser support is not universal. See here for a list of supported browsers: [http://caniuse.com/#feat=css-sticky](http://caniuse.com/#feat=css-sticky). Notably, it appears that this change would not work in any version of IE.

## Old Behavior

The Authentication and Source Code language selection buttons on the bottom left of the interactive API docs overlap with endpoints in the navigation bar on the left when there are enough endpoints. When you uncollapse an endpoint close to these buttons it opens under these buttons. (see linked issue above)

## New Behavior

The Authentication and Source Code selection buttons consistently appear visible below all endpoints, while the endpoint list remains scrollable. Interaction with the buttons (collapsing and un-collapsing) also works as expected - the full "bottom menu" is always visible and interactable at the bottom of the sidebar.