### PR TITLE
Fields with 'allow_null=True' should imply a default serialization value

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -311,10 +311,6 @@ class Field(object):
         self._creation_counter = Field._creation_counter
         Field._creation_counter += 1
 
-        # If `default` is unset, then use `None` when allow_null is `True`.
-        if default is empty and allow_null:
-            default = None
-
         # If `required` is unset, then use `True` unless a default is provided.
         if required is None:
             required = default is empty and not read_only
@@ -446,6 +442,8 @@ class Field(object):
         except (KeyError, AttributeError) as exc:
             if self.default is not empty:
                 return self.get_default()
+            if self.allow_null:
+                return None
             if not self.required:
                 raise SkipField()
             msg = (

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -311,6 +311,10 @@ class Field(object):
         self._creation_counter = Field._creation_counter
         Field._creation_counter += 1
 
+        # If `default` is unset, then use `None` when allow_null is `True`.
+        if default is empty and allow_null:
+            default = None
+
         # If `required` is unset, then use `True` unless a default is provided.
         if required is None:
             required = default is empty and not read_only

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -449,6 +449,14 @@ class TestDefaultOutput:
         assert Serializer({'nested': {'a': '3', 'b': {}}}).data == {'nested': {'a': '3', 'c': '2'}}
         assert Serializer({'nested': {'a': '3', 'b': {'c': '4'}}}).data == {'nested': {'a': '3', 'c': '4'}}
 
+    def test_default_for_allow_null(self):
+        # allow_null=True should imply default=None
+        class Serializer(serializers.Serializer):
+            foo = serializers.CharField()
+            bar = serializers.CharField(source='foo.bar', allow_null=True)
+
+        assert Serializer({'foo': None}).data == {'foo': None, 'bar': None}
+
 
 class TestCacheSerializerData:
     def test_cache_serializer_data(self):


### PR DESCRIPTION
The following currently fails as it's missing a `default` value for serialization. 

```python
class Serializer(serializers.Serializer):
    bar = serializers.CharField(source='foo.bar', allow_null=True)
```

The question is whether or not `allow_null=True` should imply `default=None`. 

Thanks to @eschercode for pointing this out [here](https://github.com/encode/django-rest-framework/commit/07258ca032e062334310c112469d6432f6eeb818#commitcomment-25097134).

cc @xordoquy