### PR TITLE
Make Travis CI include/exclude faster to read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,15 @@ env:
 matrix:
     fast_finish: true
     include:
-      - python: "3.6"
-        env: DJANGO=master
-      - python: "3.6"
-        env: DJANGO=1.11
-      - python: "3.6"
-        env: DJANGO=2.0
-      - python: "2.7"
-        env: TOXENV="lint"
-      - python: "2.7"
-        env: TOXENV="docs"
+      - { python: "3.6", env: DJANGO=master }
+      - { python: "3.6", env: DJANGO=1.11 }
+      - { python: "3.6", env: DJANGO=2.0 }
+      - { python: "2.7", env: TOXENV=lint }
+      - { python: "2.7", env: TOXENV=docs }
     exclude:
-      - python: "2.7"
-        env: DJANGO=master
-      - python: "2.7"
-        env: DJANGO=2.0
-      - python: "3.4"
-        env: DJANGO=master
+      - { python: "2.7", env: DJANGO=master }
+      - { python: "2.7", env: DJANGO=2.0 }
+      - { python: "3.4", env: DJANGO=master }
 
     allow_failures:
       - env: DJANGO=master


### PR DESCRIPTION
A simple syntax change to the Travis CI configuration file's include/exclude lists, which may seem awkward at first sight, but enhances readability:

1. Python versions are aligned vertically, line by line
1. Django versions are aligned vertically, line by line
1. `TOXENV`, which luckily has the same width as `DJANGO`, is aligned with environment values above

This allows for faster vertical scanning of the related configuration, and makes it easier to understand the reasoning behind those configurations.

**Credits:** Seen at the [django-analytical](https://github.com/jcassee/django-analytical) project.