### PR TITLE
replaced '.' for '__' in dotted ordering sources

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -199,7 +199,7 @@ class OrderingFilter(BaseFilterBackend):
             raise ImproperlyConfigured(msg % self.__class__.__name__)
 
         return [
-            (field.source or field_name, field.label)
+            (field.source.replace('.', '__') or field_name, field.label)
             for field_name, field in serializer_class(context=context).fields.items()
             if not getattr(field, 'write_only', False) and not field.source == '*'
         ]


### PR DESCRIPTION
## Description

I ran into an issue the other day where a serializer referring to a field in a related object didn't provide the correct field name for the ordering filter backend. 

Updating the `get_default_valid_fields` method so that for dotted sources the `.` for `__` fixes my use case.