### PR TITLE
Schema: Exclude OPTIONS/HEAD for ViewSet actions

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -222,12 +222,11 @@ class EndpointEnumerator(object):
         if hasattr(callback, 'actions'):
             actions = set(callback.actions.keys())
             http_method_names = set(callback.cls.http_method_names)
-            return [method.upper() for method in actions & http_method_names]
+            methods = [method.upper() for method in actions & http_method_names]
+        else:
+            methods = callback.cls().allowed_methods
 
-        return [
-            method for method in
-            callback.cls().allowed_methods if method not in ('OPTIONS', 'HEAD')
-        ]
+        return [method for method in methods if method not in ('OPTIONS', 'HEAD')]
 
 
 class SchemaGenerator(object):


### PR DESCRIPTION
Closes #5528.

Viewset custom actions (@detail_route etc) OPTIONS (and HEAD) methods were not being excluded from Schema Generations.

This PR adds a test reproducing the reported error and adjusts `EndpointEnumerator.get_allowed_methods()` to filter ViewSet actions in the same way as other `APIView`s
