### PR TITLE
Add force_authenticate in APITestCase example

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -317,6 +317,11 @@ You can use any of REST framework's test case classes as you would for the regul
             """
             url = reverse('account-list')
             data = {'name': 'DabApps'}
+            
+            # Make an authenticated request
+            user = User.objects.get(username='arlene')
+            self.client.force_authenticate(user=user)
+            
             response = self.client.post(url, data, format='json')
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             self.assertEqual(Account.objects.count(), 1)


### PR DESCRIPTION
I believe it is better to document explicitly for people who skims the docs. Honestly, based on my experience I didn't know this will work before I read the code for `APITestCase`.
