### PR TITLE
Catch OverflowError for "out of range" datetimes

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1131,7 +1131,8 @@ class DateTimeField(Field):
     default_error_messages = {
         'invalid': _('Datetime has wrong format. Use one of these formats instead: {format}.'),
         'date': _('Expected a datetime but got a date.'),
-        'make_aware': _('Invalid datetime for the timezone "{timezone}".')
+        'make_aware': _('Invalid datetime for the timezone "{timezone}".'),
+        'overflow': _('Datetime value out of range.')
     }
     datetime_parser = datetime.datetime.strptime
 
@@ -1153,7 +1154,10 @@ class DateTimeField(Field):
 
         if field_timezone is not None:
             if timezone.is_aware(value):
-                return value.astimezone(field_timezone)
+                try:
+                    return value.astimezone(field_timezone)
+                except OverflowError:
+                    self.fail('overflow')
             try:
                 return timezone.make_aware(value, field_timezone)
             except InvalidTimeError:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1171,6 +1171,7 @@ class TestDateTimeField(FieldValues):
         '2001-99-99T99:00': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].'],
         '2018-08-16 22:00-24:00': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].'],
         datetime.date(2001, 1, 1): ['Expected a datetime but got a date.'],
+        '9999-12-31T21:59:59.99990-03:00': [''],
     }
     outputs = {
         datetime.datetime(2001, 1, 1, 13, 00): '2001-01-01T13:00:00Z',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1171,7 +1171,7 @@ class TestDateTimeField(FieldValues):
         '2001-99-99T99:00': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].'],
         '2018-08-16 22:00-24:00': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].'],
         datetime.date(2001, 1, 1): ['Expected a datetime but got a date.'],
-        '9999-12-31T21:59:59.99990-03:00': [''],
+        '9999-12-31T21:59:59.99990-03:00': ['Datetime value out of range.'],
     }
     outputs = {
         datetime.datetime(2001, 1, 1, 13, 00): '2001-01-01T13:00:00Z',


### PR DESCRIPTION
Closes: #5545

I would expect that this invalid value would raise a ValidationError but instead it raises an OverflowError.
