### PR TITLE
Add interactive docs error template

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -812,6 +812,7 @@ class DocumentationRenderer(BaseRenderer):
     format = 'html'
     charset = 'utf-8'
     template = 'rest_framework/docs/index.html'
+    error_template = 'rest_framework/docs/error.html'
     code_style = 'emacs'
     languages = ['shell', 'javascript', 'python']
 
@@ -824,9 +825,19 @@ class DocumentationRenderer(BaseRenderer):
         }
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        template = loader.get_template(self.template)
-        context = self.get_context(data, renderer_context['request'])
-        return template.render(context, request=renderer_context['request'])
+        if isinstance(data, coreapi.Document):
+            template = loader.get_template(self.template)
+            context = self.get_context(data, renderer_context['request'])
+            return template.render(context, request=renderer_context['request'])
+        else:
+            template = loader.get_template(self.error_template)
+            context = {
+                "data": data,
+                "request": renderer_context['request'],
+                "response": renderer_context['response'],
+                "debug": settings.DEBUG,
+            }
+            return template.render(context, request=renderer_context['request'])
 
 
 class SchemaJSRenderer(BaseRenderer):

--- a/rest_framework/templates/rest_framework/docs/error.html
+++ b/rest_framework/templates/rest_framework/docs/error.html
@@ -1,0 +1,75 @@
+{% load staticfiles %}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	    <title>Error Rendering Schema</title>
+	</head>
+    <body>
+
+
+
+<h1>Error</h1>
+
+<pre>
+{{ data }}
+</pre>
+
+
+{% if debug is True %}
+<hr />
+<h2>Additional Information</h2>
+<p>Note: You are seeing this message because <code>DEBUG==True</code>.</p>
+
+<p>Seeing this page is <em>usually</em> a configuration error: are your
+<code>DEFAULT_AUTHENTICATION_CLASSES</code> or <code>DEFAULT_PERMISSION_CLASSES</code>
+being applied unexpectedly?</p>
+
+<p>Your response status code is: <code>{{ response.status_code }}</code></p>
+
+<h3>401 Unauthorised.</h3>
+<ul>
+    <li>Do you have SessionAuthentication enabled?</li>
+    <li>Are you logged in?</li>
+</ul>
+
+
+<h3>403 Forbidden.</h3>
+<ul>
+    <li>Do you have sufficient permissions to access this view?</li>
+    <li>Is you schema non-empty? (An empty schema will lead to a permission denied error being raised.)</li>
+</ul>
+
+
+<p>Most commonly the intended solution is to disable authentication and permissions
+when including the docs urls:</p>
+
+<pre>
+   url(r'^docs/', include_docs_urls(title='Your API',
+                                    authentication_classes=[],
+                                    permission_classes=[])),
+</pre>
+
+
+<h2>Overriding this template</h2>
+
+<p>If you wish access to your docs to be authenticated you may override this template
+at <code>rest_framework/docs/error.html</code>.</p>
+
+<p>The available context is: <code>data</code> the error dict above, <code>request</code>,
+<code>response</code> and the <code>debug</code> flag.</p>
+
+{% endif %}
+
+
+
+        <script src="{% static 'rest_framework/docs/js/jquery-1.10.2.min.js' %}"></script>
+    </body>
+</html>
+
+
+
+


### PR DESCRIPTION
Closes #5496 

Adds a **plain** error template for `DocumentationRenderer`. 

Previously we've not had to switch template for the error case, since both cases are presented the same. With the interactive docs we need to switch to a different template. (We do this by checking whether we have a `coreapi.Document`, as expected, or not.) 

I've not added any styling here. For the 90% case seeing this template is a configuration error, so I've added DEBUG-only notes for explaining that. 

Those that need a better template can easily override in their own projects. 

We can **happily** take PRs improving this template, but I'd rather leave that for community input at this point. 

