### PR TITLE
Add trove classifier for Python 3.6 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )


### PR DESCRIPTION
Helps users know, at a glance, if the library is compatible with a project.
