### PR TITLE
Add pip cache support to the Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 python:
     - "2.7"


### PR DESCRIPTION
For documentation on the feature, see:

https://docs.travis-ci.com/user/caching/#pip-cache

With packages cached, builds will be slightly faster and help reduce load on PyPI.