### PR TITLE
Fix invalid escape sequence deprecation warnings

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -313,9 +313,9 @@ class ExampleDetailView(APIView):
 class TestSchemaGenerator(TestCase):
     def setUp(self):
         self.patterns = [
-            url('^example/?$', ExampleListView.as_view()),
-            url('^example/(?P<pk>\d+)/?$', ExampleDetailView.as_view()),
-            url('^example/(?P<pk>\d+)/sub/?$', ExampleDetailView.as_view()),
+            url(r'^example/?$', ExampleListView.as_view()),
+            url(r'^example/(?P<pk>\d+)/?$', ExampleDetailView.as_view()),
+            url(r'^example/(?P<pk>\d+)/sub/?$', ExampleDetailView.as_view()),
         ]
 
     def test_schema_for_regular_views(self):
@@ -365,9 +365,9 @@ class TestSchemaGenerator(TestCase):
 class TestSchemaGeneratorNotAtRoot(TestCase):
     def setUp(self):
         self.patterns = [
-            url('^api/v1/example/?$', ExampleListView.as_view()),
-            url('^api/v1/example/(?P<pk>\d+)/?$', ExampleDetailView.as_view()),
-            url('^api/v1/example/(?P<pk>\d+)/sub/?$', ExampleDetailView.as_view()),
+            url(r'^api/v1/example/?$', ExampleListView.as_view()),
+            url(r'^api/v1/example/(?P<pk>\d+)/?$', ExampleDetailView.as_view()),
+            url(r'^api/v1/example/(?P<pk>\d+)/sub/?$', ExampleDetailView.as_view()),
         ]
 
     def test_schema_for_regular_views(self):


### PR DESCRIPTION
When running tests with warnings enabled, appear as:

```
DeprecationWarning: invalid escape sequence \d
```

Starting with Python 3.6, invalid escape sequences are deprecated. In a future Python versions they will be a syntax error. For more details, see:

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

> A backslash-character pair that is not a valid escape sequence now generates a DeprecationWarning. Although this will eventually become a SyntaxError, that will not be for several Python releases.
