### PR TITLE
Fix all BytesWarning caught during tests

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -567,6 +567,8 @@ class BrowsableAPIRenderer(BaseRenderer):
                     if isinstance(field, serializers.HiddenField):
                         data.pop(name, None)
                 content = renderer.render(data, accepted, context)
+                # Renders returns bytes, but CharField expects a str.
+                content = content.decode('utf-8')
             else:
                 content = None
 

--- a/rest_framework/utils/mediatypes.py
+++ b/rest_framework/utils/mediatypes.py
@@ -83,5 +83,5 @@ class _MediaType(object):
     def __str__(self):
         ret = "%s/%s" % (self.main_type, self.sub_type)
         for key, val in self.params.items():
-            ret += "; %s=%s" % (key, val)
+            ret += "; %s=%s" % (key, val.decode('ascii'))
         return ret

--- a/tests/test_negotiation.py
+++ b/tests/test_negotiation.py
@@ -77,11 +77,7 @@ class TestAcceptedMediaType(TestCase):
 
     def test_mediatype_string_representation(self):
         mediatype = _MediaType('test/*; foo=bar')
-        params_str = ''
-        for key, val in mediatype.params.items():
-            params_str += '; %s=%s' % (key, val)
-        expected = 'test/*' + params_str
-        assert str(mediatype) == expected
+        assert str(mediatype) == 'test/*; foo=bar'
 
     def test_raise_error_if_no_suitable_renderers_found(self):
         class MockRenderer(object):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -676,7 +676,7 @@ class AdminRendererTests(TestCase):
         request = factory.get('/')
         response = view(request)
         response.render()
-        self.assertInHTML('<tr><th>Foo</th><td>a string</td></tr>', str(response.content))
+        self.assertContains(response, '<tr><th>Foo</th><td>a string</td></tr>', html=True)
 
     def test_render_dict_with_items_key(self):
         factory = APIRequestFactory()
@@ -691,7 +691,7 @@ class AdminRendererTests(TestCase):
         request = factory.get('/')
         response = view(request)
         response.render()
-        self.assertInHTML('<tr><th>Items</th><td>a string</td></tr>', str(response.content))
+        self.assertContains(response, '<tr><th>Items</th><td>a string</td></tr>', html=True)
 
     def test_render_dict_with_iteritems_key(self):
         factory = APIRequestFactory()
@@ -706,7 +706,7 @@ class AdminRendererTests(TestCase):
         request = factory.get('/')
         response = view(request)
         response.render()
-        self.assertInHTML('<tr><th>Iteritems</th><td>a string</td></tr>', str(response.content))
+        self.assertContains(response, '<tr><th>Iteritems</th><td>a string</td></tr>', html=True)
 
 
 class TestDocumentationRenderer(TestCase):


### PR DESCRIPTION
Running the tests with bytes warning enabled shows some bytes/str mixups. Fix them all.

Some examples of mixing usage:

`str(b'foo')` -- calling str() on bytes
`b'foo' == 'foo'` -- compare str with bytes
`'foo' + b'bar`' -- concatenating str and bytes
