### PR TITLE
Add rounding parameter to DecimalField

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -269,6 +269,7 @@ Corresponds to `django.db.models.fields.DecimalField`.
 - `max_value` Validate that the number provided is no greater than this value.
 - `min_value` Validate that the number provided is no less than this value.
 - `localize` Set to `True` to enable localization of input and output based on the current locale. This will also force `coerce_to_string` to `True`. Defaults to `False`. Note that data formatting is enabled if you have set `USE_L10N=True` in your settings file.
+- `rounding` Sets the rounding mode used when quantising to the configured precision. Valid values are [`decimal` module rounding modes][python-decimal-rounding-modes]. Defaults to `None`.
 
 #### Example usage
 
@@ -680,3 +681,4 @@ The [django-rest-framework-hstore][django-rest-framework-hstore] package provide
 [django-rest-framework-gis]: https://github.com/djangonauts/django-rest-framework-gis
 [django-rest-framework-hstore]: https://github.com/djangonauts/django-rest-framework-hstore
 [django-hstore]: https://github.com/djangonauts/django-hstore
+[python-decimal-rounding-modes]: https://docs.python.org/3/library/decimal.html#rounding-modes

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -992,8 +992,7 @@ class DecimalField(Field):
         'max_digits': _('Ensure that there are no more than {max_digits} digits in total.'),
         'max_decimal_places': _('Ensure that there are no more than {max_decimal_places} decimal places.'),
         'max_whole_digits': _('Ensure that there are no more than {max_whole_digits} digits before the decimal point.'),
-        'max_string_length': _('String value too large.'),
-        'invalid_rounding': _('Invalid rounding option {rounding}. Valid values for rounding are: {valid_roundings}')
+        'max_string_length': _('String value too large.')
     }
     MAX_STRING_LENGTH = 1000  # Guard against malicious string inputs.
 
@@ -1030,9 +1029,10 @@ class DecimalField(Field):
             self.validators.append(
                 MinValueValidator(self.min_value, message=message))
 
-        valid_roundings = [v for k, v in vars(decimal).items() if k.startswith('ROUND_')]
-        if rounding is not None and rounding not in valid_roundings:
-            self.fail('invalid_rounding', rounding=rounding, valid_roundings=valid_roundings)
+        if rounding is not None:
+            valid_roundings = [v for k, v in vars(decimal).items() if k.startswith('ROUND_')]
+            assert rounding in valid_roundings, \
+                'Invalid rounding option %s. Valid values for rounding are: %s' % (rounding, valid_roundings)
         self.rounding = rounding
 
     def to_internal_value(self, data):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -992,12 +992,13 @@ class DecimalField(Field):
         'max_digits': _('Ensure that there are no more than {max_digits} digits in total.'),
         'max_decimal_places': _('Ensure that there are no more than {max_decimal_places} decimal places.'),
         'max_whole_digits': _('Ensure that there are no more than {max_whole_digits} digits before the decimal point.'),
-        'max_string_length': _('String value too large.')
+        'max_string_length': _('String value too large.'),
+        'invalid_rounding': _('Invalid rounding option {rounding}. Valid values for rounding are: {valid_roundings}')
     }
     MAX_STRING_LENGTH = 1000  # Guard against malicious string inputs.
 
     def __init__(self, max_digits, decimal_places, coerce_to_string=None, max_value=None, min_value=None,
-                 localize=False, **kwargs):
+                 localize=False, rounding=None, **kwargs):
         self.max_digits = max_digits
         self.decimal_places = decimal_places
         self.localize = localize
@@ -1028,6 +1029,11 @@ class DecimalField(Field):
                 six.text_type)(min_value=self.min_value)
             self.validators.append(
                 MinValueValidator(self.min_value, message=message))
+
+        valid_roundings = [v for k, v in vars(decimal).items() if k.startswith('ROUND_')]
+        if rounding is not None and rounding not in valid_roundings:
+            self.fail('invalid_rounding', rounding=rounding, valid_roundings=valid_roundings)
+        self.rounding = rounding
 
     def to_internal_value(self, data):
         """
@@ -1121,6 +1127,7 @@ class DecimalField(Field):
             context.prec = self.max_digits
         return value.quantize(
             decimal.Decimal('.1') ** self.decimal_places,
+            rounding=self.rounding,
             context=context
         )
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1031,8 +1031,8 @@ class DecimalField(Field):
 
         if rounding is not None:
             valid_roundings = [v for k, v in vars(decimal).items() if k.startswith('ROUND_')]
-            assert rounding in valid_roundings, \
-                'Invalid rounding option %s. Valid values for rounding are: %s' % (rounding, valid_roundings)
+            assert rounding in valid_roundings, (
+                'Invalid rounding option %s. Valid values for rounding are: %s' % (rounding, valid_roundings))
         self.rounding = rounding
 
     def to_internal_value(self, data):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,7 +3,7 @@ import os
 import re
 import unittest
 import uuid
-from decimal import Decimal
+from decimal import ROUND_DOWN, ROUND_UP, Decimal
 
 import django
 import pytest
@@ -1094,10 +1094,10 @@ class TestNoDecimalPlaces(FieldValues):
 
 class TestRoundingDecimalField(TestCase):
     def test_valid_rounding(self):
-        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding='ROUND_UP')
+        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding=ROUND_UP)
         assert field.to_representation(Decimal('1.234')) == '1.24'
 
-        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding='ROUND_DOWN')
+        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding=ROUND_DOWN)
         assert field.to_representation(Decimal('1.234')) == '1.23'
 
     def test_invalid_rounding(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1092,6 +1092,22 @@ class TestNoDecimalPlaces(FieldValues):
     field = serializers.DecimalField(max_digits=6, decimal_places=None)
 
 
+class TestRoundingDecimalField(TestCase):
+    def test_valid_rounding(self):
+        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding='ROUND_UP')
+        assert field.to_representation(Decimal('1.234')) == '1.24'
+
+        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding='ROUND_DOWN')
+        assert field.to_representation(Decimal('1.234')) == '1.23'
+
+    def test_invalid_rounding(self):
+        with pytest.raises(AssertionError) as excinfo:
+            serializers.DecimalField(max_digits=1, decimal_places=1, rounding='ROUND_UNKNOWN')
+        assert 'Invalid rounding option' in str(excinfo.value)
+
+
+
+
 # Date & time serializers...
 
 class TestDateField(FieldValues):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1106,10 +1106,7 @@ class TestRoundingDecimalField(TestCase):
         assert 'Invalid rounding option' in str(excinfo.value)
 
 
-
-
 # Date & time serializers...
-
 class TestDateField(FieldValues):
     """
     Valid and invalid values for `DateField`.


### PR DESCRIPTION
Closes #5535. Closes #5531

Updates #5535 

* [x] Fixes `flake8` errors
* [x] Uses `decimal` module constants, instead of magic strings. 
* [x] Adds docs note. 