### PR TITLE
Move django.contrib.auth import out of compat. (fixes #5564)

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -11,7 +11,6 @@ import inspect
 import django
 from django.apps import apps
 from django.conf import settings
-from django.contrib.auth import views
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import \
     MaxLengthValidator as DjangoMaxLengthValidator
@@ -334,11 +333,3 @@ def authenticate(request=None, **credentials):
     else:
         return authenticate(request=request, **credentials)
 
-if django.VERSION < (1, 11):
-    login = views.login
-    login_kwargs = {'template_name': 'rest_framework/login.html'}
-    logout = views.logout
-else:
-    login = views.LoginView.as_view(template_name='rest_framework/login.html')
-    login_kwargs = {}
-    logout = views.LogoutView.as_view()

--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -14,9 +14,19 @@ and you should make sure your authentication settings include `SessionAuthentica
 """
 from __future__ import unicode_literals
 
+import django
 from django.conf.urls import url
+from django.contrib.auth import views
 
-from rest_framework.compat import login, login_kwargs, logout
+if django.VERSION < (1, 11):
+    login = views.login
+    login_kwargs = {'template_name': 'rest_framework/login.html'}
+    logout = views.logout
+else:
+    login = views.LoginView.as_view(template_name='rest_framework/login.html')
+    login_kwargs = {}
+    logout = views.LogoutView.as_view()
+
 
 app_name = 'rest_framework'
 urlpatterns = [


### PR DESCRIPTION
Fixed some regressions where compat was imported during app loading and
led to importing django.contrib.auth.models which ended in a
`AppRegistryNotReady` exception.
