### PR TITLE
Copy declared validators to serialiser fields

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -987,8 +987,8 @@ class FloatField(Field):
 class DecimalField(Field):
     default_error_messages = {
         'invalid': _('A valid number is required.'),
-        'max_value': _('Ensure this value is less than or equal to {max_value}.'),
-        'min_value': _('Ensure this value is greater than or equal to {min_value}.'),
+        'max_value': _('Ensure this value is less than or equal to %(limit_value)s.'),
+        'min_value': _('Ensure this value is greater than or equal to %(limit_value)s.'),
         'max_digits': _('Ensure that there are no more than {max_digits} digits in total.'),
         'max_decimal_places': _('Ensure that there are no more than {max_decimal_places} decimal places.'),
         'max_whole_digits': _('Ensure that there are no more than {max_whole_digits} digits before the decimal point.'),

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -156,6 +156,9 @@ def get_field_kwargs(field_name, model_field):
         # URLField does not need to include the URLValidator argument,
         # as it is explicitly added in.
         if isinstance(model_field, models.URLField):
+            custom_message = model_field.error_messages.get("invalid", None)
+            if custom_message is not None:
+                kwargs.setdefault('error_messages', {}).update(invalid=custom_message)
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if not isinstance(validator, validators.URLValidator)

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -202,6 +202,9 @@ def get_field_kwargs(field_name, model_field):
                                    isinstance(model_field, models.TextField) or
                                    isinstance(model_field, models.FileField)):
         kwargs['max_length'] = max_length
+        custom_message = model_field.error_messages.get("max_length", None)
+        if custom_message is not None:
+            kwargs.setdefault('error_messages', {}).update(max_length=custom_message)
         validator_kwarg = [
             validator for validator in validator_kwarg
             if not isinstance(validator, validators.MaxLengthValidator)

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -3,6 +3,7 @@ Helper functions for mapping model fields to a dictionary of default
 keyword arguments that should be used for their equivalent serializer fields.
 """
 import inspect
+from collections import OrderedDict
 
 from django.core import validators
 from django.db import models
@@ -130,10 +131,11 @@ def get_field_kwargs(field_name, model_field):
         max_value, message = next((
             (validator.limit_value, validator.message) for validator in validator_kwarg
             if isinstance(validator, validators.MaxValueValidator)
-        ), (None, None))
+        ), (None, ''))
         if max_value is not None and isinstance(model_field, NUMERIC_FIELD_TYPES):
             kwargs['max_value'] = max_value
-            kwargs['error_messages'] = {'max_value': message}
+            if message != '':
+                kwargs.setdefault('error_messages', OrderedDict()).update(max_value=message)
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if not isinstance(validator, validators.MaxValueValidator)
@@ -144,10 +146,11 @@ def get_field_kwargs(field_name, model_field):
         min_value, message = next((
             (validator.limit_value, validator.message) for validator in validator_kwarg
             if isinstance(validator, validators.MinValueValidator)
-        ), (None, None))
+        ), (None, ''))
         if min_value is not None and isinstance(model_field, NUMERIC_FIELD_TYPES):
             kwargs['min_value'] = min_value
-            kwargs.setdefault('error_messages', {}).update(min_value=message)
+            if message != '':
+                kwargs.setdefault('error_messages', OrderedDict()).update(min_value=message)
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if not isinstance(validator, validators.MinValueValidator)
@@ -202,9 +205,9 @@ def get_field_kwargs(field_name, model_field):
                                    isinstance(model_field, models.TextField) or
                                    isinstance(model_field, models.FileField)):
         kwargs['max_length'] = max_length
-        custom_message = model_field.error_messages.get("max_length", None)
-        if custom_message is not None:
-            kwargs.setdefault('error_messages', {}).update(max_length=custom_message)
+        custom_message = model_field.error_messages.get("max_length", '')
+        if custom_message != '':
+            kwargs.setdefault('error_messages', OrderedDict()).update(max_length=custom_message)
         validator_kwarg = [
             validator for validator in validator_kwarg
             if not isinstance(validator, validators.MaxLengthValidator)
@@ -215,10 +218,11 @@ def get_field_kwargs(field_name, model_field):
     min_length, message = next((
         (validator.limit_value, validator.message) for validator in validator_kwarg
         if isinstance(validator, validators.MinLengthValidator)
-    ), (None, None))
+    ), (None, ''))
     if min_length is not None and isinstance(model_field, models.CharField):
         kwargs['min_length'] = min_length
-        kwargs.setdefault('error_messages', {}).update(min_length=message)
+        if message != '':
+            kwargs.setdefault('error_messages', OrderedDict()).update(min_length=message)
         validator_kwarg = [
             validator for validator in validator_kwarg
             if not isinstance(validator, validators.MinLengthValidator)

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -127,12 +127,13 @@ def get_field_kwargs(field_name, model_field):
     else:
         # Ensure that max_value is passed explicitly as a keyword arg,
         # rather than as a validator.
-        max_value = next((
-            validator.limit_value for validator in validator_kwarg
+        max_value, messsage = next((
+            (validator.limit_value, validator.message) for validator in validator_kwarg
             if isinstance(validator, validators.MaxValueValidator)
-        ), None)
+        ), (None, None))
         if max_value is not None and isinstance(model_field, NUMERIC_FIELD_TYPES):
             kwargs['max_value'] = max_value
+            kwargs['error_messages'] = {'max_value': messsage}
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if not isinstance(validator, validators.MaxValueValidator)
@@ -140,12 +141,13 @@ def get_field_kwargs(field_name, model_field):
 
         # Ensure that min_value is passed explicitly as a keyword arg,
         # rather than as a validator.
-        min_value = next((
-            validator.limit_value for validator in validator_kwarg
+        min_value, messsage = next((
+            (validator.limit_value, validator.message) for validator in validator_kwarg
             if isinstance(validator, validators.MinValueValidator)
-        ), None)
+        ), (None, None))
         if min_value is not None and isinstance(model_field, NUMERIC_FIELD_TYPES):
             kwargs['min_value'] = min_value
+            kwargs['error_messages'] = {**kwargs['error_messages'], **{'min_value': messsage}}
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if not isinstance(validator, validators.MinValueValidator)

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -164,6 +164,9 @@ def get_field_kwargs(field_name, model_field):
         # EmailField does not need to include the validate_email argument,
         # as it is explicitly added in.
         if isinstance(model_field, models.EmailField):
+            custom_message = model_field.error_messages.get("invalid", None)
+            if custom_message is not None:
+                kwargs.setdefault('error_messages', {}).update(invalid=custom_message)
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if validator is not validators.validate_email

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -127,13 +127,13 @@ def get_field_kwargs(field_name, model_field):
     else:
         # Ensure that max_value is passed explicitly as a keyword arg,
         # rather than as a validator.
-        max_value, messsage = next((
+        max_value, message = next((
             (validator.limit_value, validator.message) for validator in validator_kwarg
             if isinstance(validator, validators.MaxValueValidator)
         ), (None, None))
         if max_value is not None and isinstance(model_field, NUMERIC_FIELD_TYPES):
             kwargs['max_value'] = max_value
-            kwargs['error_messages'] = {'max_value': messsage}
+            kwargs['error_messages'] = {'max_value': message}
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if not isinstance(validator, validators.MaxValueValidator)
@@ -141,13 +141,13 @@ def get_field_kwargs(field_name, model_field):
 
         # Ensure that min_value is passed explicitly as a keyword arg,
         # rather than as a validator.
-        min_value, messsage = next((
+        min_value, message = next((
             (validator.limit_value, validator.message) for validator in validator_kwarg
             if isinstance(validator, validators.MinValueValidator)
         ), (None, None))
         if min_value is not None and isinstance(model_field, NUMERIC_FIELD_TYPES):
             kwargs['min_value'] = min_value
-            kwargs['error_messages'] = {**kwargs['error_messages'], **{'min_value': messsage}}
+            kwargs.setdefault('error_messages', {}).update(min_value=message)
             validator_kwarg = [
                 validator for validator in validator_kwarg
                 if not isinstance(validator, validators.MinValueValidator)

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -209,12 +209,13 @@ def get_field_kwargs(field_name, model_field):
 
     # Ensure that min_length is passed explicitly as a keyword arg,
     # rather than as a validator.
-    min_length = next((
-        validator.limit_value for validator in validator_kwarg
+    min_length, message = next((
+        (validator.limit_value, validator.message) for validator in validator_kwarg
         if isinstance(validator, validators.MinLengthValidator)
-    ), None)
+    ), (None, None))
     if min_length is not None and isinstance(model_field, models.CharField):
         kwargs['min_length'] = min_length
+        kwargs.setdefault('error_messages', {}).update(min_length=message)
         validator_kwarg = [
             validator for validator in validator_kwarg
             if not isinstance(validator, validators.MinLengthValidator)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -200,7 +200,7 @@ class TestRegularFieldMappings(TestCase):
         expected = dedent("""
             TestSerializer():
                 id = IntegerField(label='ID', read_only=True)
-                value_limit_field = IntegerField(error_messages={'max_value': 'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': 'Ensure this value is greater than or equal to %(limit_value)s.'}, max_value=10, min_value=1)
+                value_limit_field = IntegerField(error_messages=OrderedDict([('max_value', 'Ensure this value is less than or equal to %(limit_value)s.'), ('min_value', 'Ensure this value is greater than or equal to %(limit_value)s.')]), max_value=10, min_value=1)
                 length_limit_field = CharField(max_length=12, min_length=3)
                 blank_field = CharField(allow_blank=True, max_length=10, required=False)
                 null_field = IntegerField(allow_null=True, required=False)
@@ -218,6 +218,7 @@ class TestRegularFieldMappings(TestCase):
                 "{'max_value': 'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': 'Ensure this value is greater than or equal to %(limit_value)s.'}",
                 "{'max_value': u'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': u'Ensure this value is greater than or equal to %(limit_value)s.'}"
             )
+        self.maxDiff = None
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 
     def test_method_field(self):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -200,7 +200,7 @@ class TestRegularFieldMappings(TestCase):
         expected = dedent("""
             TestSerializer():
                 id = IntegerField(label='ID', read_only=True)
-                value_limit_field = IntegerField(max_value=10, min_value=1)
+                value_limit_field = IntegerField(error_messages={'max_value': 'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': 'Ensure this value is greater than or equal to %(limit_value)s.'}, max_value=10, min_value=1)
                 length_limit_field = CharField(max_length=12, min_length=3)
                 blank_field = CharField(allow_blank=True, max_length=10, required=False)
                 null_field = IntegerField(allow_null=True, required=False)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -214,6 +214,9 @@ class TestRegularFieldMappings(TestCase):
             expected = expected.replace(
                 "('red', 'Red'), ('blue', 'Blue'), ('green', 'Green')",
                 "(u'red', u'Red'), (u'blue', u'Blue'), (u'green', u'Green')"
+            ).replace(
+                "{'max_value': 'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': 'Ensure this value is greater than or equal to %(limit_value)s.'}",
+                {'max_value': u'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': u'Ensure this value is greater than or equal to %(limit_value)s.'}
             )
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -216,7 +216,7 @@ class TestRegularFieldMappings(TestCase):
                 "(u'red', u'Red'), (u'blue', u'Blue'), (u'green', u'Green')"
             ).replace(
                 "{'max_value': 'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': 'Ensure this value is greater than or equal to %(limit_value)s.'}",
-                {'max_value': u'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': u'Ensure this value is greater than or equal to %(limit_value)s.'}
+                "{'max_value': u'Ensure this value is less than or equal to %(limit_value)s.', 'min_value': u'Ensure this value is greater than or equal to %(limit_value)s.'}"
             )
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 from django.core.validators import (
-    EmailValidator, MaxLengthValidator, MaxValueValidator, MinLengthValidator,
+    MaxLengthValidator, MaxValueValidator, MinLengthValidator,
     MinValueValidator, URLValidator
 )
 from django.db import DataError, models
@@ -612,7 +612,9 @@ class ValidatorMessageTests(TestCase):
 
     def test_email_validator_message_is_copied_from_model(self):
         class UserModel(models.Model):
-            email = models.EmailField(validators=[EmailValidator(message='Please enter a valid email.')])
+            email = models.EmailField(
+                error_messages={"invalid": "Please enter a valid email."}
+            )
 
         class UserSerializer(serializers.ModelSerializer):
             class Meta:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,7 +1,10 @@
 import datetime
 
 import pytest
-from django.core.validators import MinValueValidator, MaxValueValidator, URLValidator, EmailValidator, MinLengthValidator, MaxLengthValidator
+from django.core.validators import (
+    EmailValidator, MaxLengthValidator, MaxValueValidator, MinLengthValidator,
+    MinValueValidator, URLValidator
+)
 from django.db import DataError, models
 from django.test import TestCase
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,8 +2,7 @@ import datetime
 
 import pytest
 from django.core.validators import (
-    MaxLengthValidator, MaxValueValidator, MinLengthValidator,
-    MinValueValidator
+    MaxValueValidator, MinLengthValidator, MinValueValidator
 )
 from django.db import DataError, models
 from django.test import TestCase
@@ -648,10 +647,11 @@ class ValidatorMessageTests(TestCase):
         assert s.errors['text'] == ['This is too short.']
 
     def test_max_length_validator_message_is_copied_from_model(self):
-        # Added this test because was expecting is_valid() to be false but it is not.
-        # Will investigate further
         class Post(models.Model):
-            text = models.CharField(max_length=100, validators=[MaxLengthValidator(limit_value=1, message='This is too long.')])
+            text = models.CharField(
+                max_length=1,
+                error_messages={"max_length": "This is too long"}
+            )
 
         class PostSerializer(serializers.ModelSerializer):
             class Meta:
@@ -661,3 +661,4 @@ class ValidatorMessageTests(TestCase):
         data = {'text': 'A very long text'}
         s = PostSerializer(data=data)
         assert not s.is_valid()
+        assert s.errors['text'] == ['This is too long']

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -37,7 +37,7 @@ class RelatedModel(models.Model):
 
 class RelatedModelSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username',
-                                     validators=[UniqueValidator(queryset=UniquenessModel.objects.all(), lookup='iexact')])  # NOQA
+        validators=[UniqueValidator(queryset=UniquenessModel.objects.all(), lookup='iexact')])  # NOQA
 
     class Meta:
         model = RelatedModel
@@ -246,12 +246,10 @@ class TestUniquenessTogetherValidation(TestCase):
         When model fields are not included in a serializer, then uniqueness
         validators should not be added for that field.
         """
-
         class ExcludedFieldSerializer(serializers.ModelSerializer):
             class Meta:
                 model = UniquenessTogetherModel
                 fields = ('id', 'race_name',)
-
         serializer = ExcludedFieldSerializer()
         expected = dedent("""
             ExcludedFieldSerializer():
@@ -265,7 +263,6 @@ class TestUniquenessTogetherValidation(TestCase):
         When serializer fields are read only, then uniqueness
         validators should not be added for that field.
         """
-
         class ReadOnlyFieldSerializer(serializers.ModelSerializer):
             class Meta:
                 model = UniquenessTogetherModel
@@ -285,7 +282,6 @@ class TestUniquenessTogetherValidation(TestCase):
         """
         Ensure validators can be explicitly removed..
         """
-
         class NoValidatorsSerializer(serializers.ModelSerializer):
             class Meta:
                 model = UniquenessTogetherModel
@@ -334,7 +330,6 @@ class TestUniquenessTogetherValidation(TestCase):
         filter_queryset should add value from existing instance attribute
         if it is not provided in attributes dict
         """
-
         class MockQueryset(object):
             def filter(self, **kwargs):
                 self.called_with = kwargs
@@ -417,7 +412,6 @@ class TestUniquenessForDateValidation(TestCase):
             'published': datetime.date(2000, 1, 1)
         }
 
-
 # Tests for `UniqueForMonthValidator`
 # ----------------------------------
 
@@ -434,6 +428,7 @@ class UniqueForMonthSerializer(serializers.ModelSerializer):
 
 
 class UniqueForMonthTests(TestCase):
+
     def setUp(self):
         self.instance = UniqueForMonthModel.objects.create(
             slug='existing', published='2017-01-01'
@@ -456,7 +451,6 @@ class UniqueForMonthTests(TestCase):
             'published': datetime.date(2017, 2, 1)
         }
 
-
 # Tests for `UniqueForYearValidator`
 # ----------------------------------
 
@@ -473,6 +467,7 @@ class UniqueForYearSerializer(serializers.ModelSerializer):
 
 
 class UniqueForYearTests(TestCase):
+
     def setUp(self):
         self.instance = UniqueForYearModel.objects.create(
             slug='existing', published='2017-01-01'
@@ -538,25 +533,23 @@ class TestHiddenFieldUniquenessForDateValidation(TestCase):
 
 
 class ValidatorsTests(TestCase):
+
     def test_qs_exists_handles_type_error(self):
         class TypeErrorQueryset(object):
             def exists(self):
                 raise TypeError
-
         assert qs_exists(TypeErrorQueryset()) is False
 
     def test_qs_exists_handles_value_error(self):
         class ValueErrorQueryset(object):
             def exists(self):
                 raise ValueError
-
         assert qs_exists(ValueErrorQueryset()) is False
 
     def test_qs_exists_handles_data_error(self):
         class DataErrorQueryset(object):
             def exists(self):
                 raise DataError
-
         assert qs_exists(DataErrorQueryset()) is False
 
     def test_validator_raises_error_if_not_all_fields_are_provided(self):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from django.core.validators import (
     MaxLengthValidator, MaxValueValidator, MinLengthValidator,
-    MinValueValidator, URLValidator
+    MinValueValidator
 )
 from django.db import DataError, models
 from django.test import TestCase
@@ -597,7 +597,9 @@ class ValidatorMessageTests(TestCase):
 
     def test_url_validator_message_is_copied_from_model(self):
         class BlogModel(models.Model):
-            url = models.URLField(validators=[URLValidator(message='This URL is not valid.')])
+            url = models.URLField(
+                error_messages={"invalid": "This URL is not valid."}
+            )
 
         class BlogSerializer(serializers.ModelSerializer):
             class Meta:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -631,7 +631,10 @@ class ValidatorMessageTests(TestCase):
 
     def test_min_length_validator_message_is_copied_from_model(self):
         class Review(models.Model):
-            text = models.CharField(max_length=100, validators=[MinLengthValidator(limit_value=5, message='This is too short.')])
+            text = models.CharField(
+                max_length=100,
+                validators=[MinLengthValidator(limit_value=5, message='This is too short.')]
+            )
 
         class ReviewSerializer(serializers.ModelSerializer):
             class Meta:


### PR DESCRIPTION
Replaces #5411. Closes #5410. 

* Rebases work by @rvignesh89. 
* Fixes lint errors. 
* [x] Add for "other" field types, (those with tests from https://github.com/encode/django-rest-framework/commit/31eba2030154abae5ddc4c228bac68413c146e37)