### PR TITLE
Implement HttpRequest proxying with __getattr__ for optimized access.

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -372,19 +372,23 @@ class Request(object):
         else:
             self.auth = None
 
-    def __getattribute__(self, attr):
+    def __getattr__(self, attr):
         """
         If an attribute does not exist on this instance, then we also attempt
         to proxy it to the underlying HttpRequest object.
         """
         try:
-            return super(Request, self).__getattribute__(attr)
+            return getattr(self._request, attr)
         except AttributeError:
-            info = sys.exc_info()
+            outer_info = sys.exc_info()
+
+            # raise the 'original' AttributeError for the proxying Request object instead of the underlying
+            # HttpRequest object.
             try:
-                return getattr(self._request, attr)
+                self.__getattribute__(attr)
             except AttributeError:
-                six.reraise(info[0], info[1], info[2].tb_next)
+                inner_info = sys.exc_info()
+                six.reraise(inner_info[0], inner_info[1], outer_info[2].tb_next)
 
     @property
     def DATA(self):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -249,3 +249,28 @@ class TestSecure(TestCase):
     def test_default_secure_true(self):
         request = Request(factory.get('/', secure=True))
         assert request.scheme == 'https'
+
+
+class TestWSGIRequestProxy(TestCase):
+    def test_access_inner_property(self):
+        wsgi_request = factory.get('/')
+
+        sentinel = object()
+        wsgi_request.__dict__['inner_property'] = sentinel
+
+        request = Request(wsgi_request)
+
+        assert request.inner_property is sentinel
+
+    def test_access_outer_property(self):
+        wsgi_request = factory.get('/')
+
+        inner_sentinel = object()
+        wsgi_request.__dict__['inner_property'] = inner_sentinel
+
+        request = Request(wsgi_request)
+
+        outer_sentinel = object()
+        request.__dict__['inner_property'] = outer_sentinel
+
+        assert request.inner_property is outer_sentinel


### PR DESCRIPTION
I was profiling our production server and notices that quite a lot of the time it took for our `ListSerializer.to_representation` to run was in `Request.__getattribute__`.

The way `__getattribute__` was implemented was catching `AttributeError` exceptions, which becomes quite a bottleneck when handling thousands of these exceptions for every request. [Catching exceptions is expensive](https://docs.python.org/2/faq/design.html#how-fast-are-exceptions). Fortunately, `__getattr__` is the interpreter-optimized way of doing the exact same thing. I made sure to keep the same traceback in the case of a true `AttributeError`.

On our production server, this change sped up certain requests by about 0.4 seconds, which is a large percent of a request that takes ~3 seconds to process.