### PR TITLE
Drop compat wrapper for TimeDelta.total_seconds()

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -84,14 +84,6 @@ def unicode_http_header(value):
     return value
 
 
-def total_seconds(timedelta):
-    # TimeDelta.total_seconds() is only available in Python 2.7
-    if hasattr(timedelta, 'total_seconds'):
-        return timedelta.total_seconds()
-    else:
-        return (timedelta.days * 86400.0) + float(timedelta.seconds) + (timedelta.microseconds / 1000000.0)
-
-
 def distinct(queryset, base):
     if settings.DATABASES[queryset.db]["ENGINE"] == "django.db.backends.oracle":
         # distinct analogue for Oracle users

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -13,7 +13,7 @@ from django.utils import six, timezone
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
-from rest_framework.compat import coreapi, total_seconds
+from rest_framework.compat import coreapi
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -39,7 +39,7 @@ class JSONEncoder(json.JSONEncoder):
             representation = obj.isoformat()
             return representation
         elif isinstance(obj, datetime.timedelta):
-            return six.text_type(total_seconds(obj))
+            return six.text_type(obj.total_seconds())
         elif isinstance(obj, decimal.Decimal):
             # Serializers will coerce decimals to strings by default.
             return float(obj)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -13,15 +13,6 @@ class CompatTests(TestCase):
         compat.django.VERSION = self.original_django_version
         compat.transaction = self.original_transaction
 
-    def test_total_seconds(self):
-        class MockTimedelta(object):
-            days = 1
-            seconds = 1
-            microseconds = 100
-        timedelta = MockTimedelta()
-        expected = (timedelta.days * 86400.0) + float(timedelta.seconds) + (timedelta.microseconds / 1000000.0)
-        assert compat.total_seconds(timedelta) == expected
-
     def test_set_rollback_for_transaction_in_managed_mode(self):
         class MockTransaction(object):
             called_rollback = False


### PR DESCRIPTION
`TimeDelta.total_seconds()` was introduced in Python 2.7 and 3.2. It is available on all supported Python versions.

https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds
https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds