### PR TITLE
Remove ulrparse compatability shim; use six instead

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -54,12 +54,6 @@ def make_url_resolver(regex, urlpatterns):
         return RegexURLResolver(regex, urlpatterns)
 
 
-try:
-    import urlparse  # Python 2.x
-except ImportError:
-    import urllib.parse as urlparse
-
-
 def unicode_repr(instance):
     # Get the repr of an instance, but ensure it is a unicode string
     # on both python 3 (already the case) and 2 (not the case).

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -9,10 +9,11 @@ from collections import OrderedDict
 
 from django.db import models
 from django.utils.encoding import force_text, smart_text
+from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import exceptions, serializers
-from rest_framework.compat import coreapi, coreschema, uritemplate, urlparse
+from rest_framework.compat import coreapi, coreschema, uritemplate
 from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
 


### PR DESCRIPTION
The `urlparse` shim in `compat.py` duplicates Django's bundled six. Can rely on upstream instead of duplicating their works. Unifies shim with other files already using six.