### PR TITLE
Compat cleanup

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -248,8 +248,9 @@ else:
     def md_filter_add_syntax_highlight(md):
         return False
 
+# pytz is required from Django 1.11. Remove when dropping Django 1.10 support.    
 try:
-    import pytz  # noqa
+    import pytz  # noqa 
     from pytz.exceptions import InvalidTimeError
 except ImportError:
     InvalidTimeError = Exception

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -17,13 +17,15 @@ from django.utils import six
 from django.views.generic import View
 
 try:
-    from django.urls import (
-        NoReverseMatch, URLPattern as RegexURLPattern, URLResolver as RegexURLResolver, ResolverMatch, Resolver404, get_script_prefix, reverse, reverse_lazy, resolve
+    from django.urls import (  # noqa
+        URLPattern as RegexURLPattern,
+        URLResolver as RegexURLResolver,
     )
-
 except ImportError:
-    from django.core.urlresolvers import (  # Will be removed in Django 2.0
-        NoReverseMatch, RegexURLPattern, RegexURLResolver, ResolverMatch, Resolver404, get_script_prefix, reverse, reverse_lazy, resolve
+    # Will be removed in Django 2.0
+    from django.urls import (  # noqa
+        RegexURLPattern,
+        RegexURLResolver,
     )
 
 

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -18,14 +18,14 @@ from django.views.generic import View
 
 try:
     from django.urls import (  # noqa
-        URLPattern as RegexURLPattern,
-        URLResolver as RegexURLResolver,
+        URLPattern,
+        URLResolver,
     )
 except ImportError:
     # Will be removed in Django 2.0
     from django.urls import (  # noqa
-        RegexURLPattern,
-        RegexURLResolver,
+        RegexURLPattern as URLPattern,
+        RegexURLResolver as URLResolver,
     )
 
 
@@ -42,11 +42,11 @@ def make_url_resolver(regex, urlpatterns):
     try:
         # Django 2.0
         from django.urls.resolvers import RegexPattern
-        return RegexURLResolver(RegexPattern(regex), urlpatterns)
+        return URLResolver(RegexPattern(regex), urlpatterns)
 
     except ImportError:
         # Django < 2.0
-        return RegexURLResolver(regex, urlpatterns)
+        return URLResolver(regex, urlpatterns)
 
 
 def unicode_repr(instance):

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -248,7 +248,7 @@ else:
     def md_filter_add_syntax_highlight(md):
         return False
 
-# pytz is required from Django 1.11. Remove when dropping Django 1.10 support.    
+# pytz is required from Django 1.11. Remove when dropping Django 1.10 support.
 try:
     import pytz  # noqa 
     from pytz.exceptions import InvalidTimeError

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -3,7 +3,6 @@ The `compat` module provides support for backwards compatibility with older
 versions of Django/Python, and compatibility wrappers around optional packages.
 """
 
-# flake8: noqa
 from __future__ import unicode_literals
 
 import inspect
@@ -11,15 +10,9 @@ import inspect
 import django
 from django.apps import apps
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.core.validators import \
-    MaxLengthValidator as DjangoMaxLengthValidator
-from django.core.validators import MaxValueValidator as DjangoMaxValueValidator
-from django.core.validators import \
-    MinLengthValidator as DjangoMinLengthValidator
-from django.core.validators import MinValueValidator as DjangoMinValueValidator
+from django.core import validators
+from django.core.exceptions import ImproperlyConfigured
 from django.db import connection, models, transaction
-from django.template import Context, RequestContext, Template
 from django.utils import six
 from django.views.generic import View
 
@@ -152,7 +145,7 @@ except ImportError:
 guardian = None
 try:
     if 'guardian' in settings.INSTALLED_APPS:
-        import guardian
+        import guardian  # noqa
 except ImportError:
     pass
 
@@ -229,7 +222,7 @@ if markdown is not None and pygments is not None:
 
     class CodeBlockPreprocessor(Preprocessor):
         pattern = re.compile(
-            r'^\s*``` *([^\n]+)\n(.+?)^\s*```', re.M|re.S)
+            r'^\s*``` *([^\n]+)\n(.+?)^\s*```', re.M | re.S)
 
         formatter = HtmlFormatter()
 
@@ -239,9 +232,9 @@ if markdown is not None and pygments is not None:
                     lexer = get_lexer_by_name(m.group(1))
                 except (ValueError, NameError):
                     lexer = TextLexer()
-                code = m.group(2).replace('\t','    ')
+                code = m.group(2).replace('\t', '    ')
                 code = pygments.highlight(code, lexer, self.formatter)
-                code = code.replace('\n\n', '\n&nbsp;\n').replace('\n', '<br />').replace('\\@','@')
+                code = code.replace('\n\n', '\n&nbsp;\n').replace('\n', '<br />').replace('\\@', '@')
                 return '\n\n%s\n\n' % code
             ret = self.pattern.sub(repl, "\n".join(lines))
             return ret.split("\n")
@@ -254,7 +247,7 @@ else:
         return False
 
 try:
-    import pytz
+    import pytz  # noqa
     from pytz.exceptions import InvalidTimeError
 except ImportError:
     InvalidTimeError = Exception
@@ -279,21 +272,27 @@ class CustomValidatorMessage(object):
 
     Ref: https://github.com/encode/django-rest-framework/pull/5452
     """
+
     def __init__(self, *args, **kwargs):
         self.message = kwargs.pop('message', self.message)
         super(CustomValidatorMessage, self).__init__(*args, **kwargs)
 
-class MinValueValidator(CustomValidatorMessage, DjangoMinValueValidator):
+
+class MinValueValidator(CustomValidatorMessage, validators.MinValueValidator):
     pass
 
-class MaxValueValidator(CustomValidatorMessage, DjangoMaxValueValidator):
+
+class MaxValueValidator(CustomValidatorMessage, validators.MaxValueValidator):
     pass
 
-class MinLengthValidator(CustomValidatorMessage, DjangoMinLengthValidator):
+
+class MinLengthValidator(CustomValidatorMessage, validators.MinLengthValidator):
     pass
 
-class MaxLengthValidator(CustomValidatorMessage, DjangoMaxLengthValidator):
+
+class MaxLengthValidator(CustomValidatorMessage, validators.MaxLengthValidator):
     pass
+
 
 def set_rollback():
     if hasattr(transaction, 'set_rollback'):
@@ -318,4 +317,3 @@ def authenticate(request=None, **credentials):
         return authenticate(**credentials)
     else:
         return authenticate(request=request, **credentials)
-

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db.models import Manager
 from django.db.models.query import QuerySet
+from django.urls import NoReverseMatch, Resolver404, get_script_prefix, resolve
 from django.utils import six
 from django.utils.encoding import (
     python_2_unicode_compatible, smart_text, uri_to_iri
@@ -13,9 +14,6 @@ from django.utils.encoding import (
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import (
-    NoReverseMatch, Resolver404, get_script_prefix, resolve
-)
 from rest_framework.fields import (
     Field, empty, get_attribute, is_simple_callable, iter_options
 )

--- a/rest_framework/reverse.py
+++ b/rest_framework/reverse.py
@@ -3,11 +3,11 @@ Provide urlresolver functions that return fully qualified URLs or view names
 """
 from __future__ import unicode_literals
 
+from django.urls import reverse as django_reverse
+from django.urls import NoReverseMatch
 from django.utils import six
 from django.utils.functional import lazy
 
-from rest_framework.compat import reverse as django_reverse
-from rest_framework.compat import NoReverseMatch
 from rest_framework.settings import api_settings
 from rest_framework.utils.urls import replace_query_param
 

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -20,9 +20,9 @@ from collections import OrderedDict, namedtuple
 
 from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
+from django.urls import NoReverseMatch
 
 from rest_framework import views
-from rest_framework.compat import NoReverseMatch
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.schemas import SchemaGenerator

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -15,7 +15,7 @@ from django.utils import six
 
 from rest_framework import exceptions
 from rest_framework.compat import (
-    RegexURLPattern, RegexURLResolver, coreapi, coreschema, get_regex_pattern
+    URLPattern, URLResolver, coreapi, coreschema, get_regex_pattern
 )
 from rest_framework.request import clone_request
 from rest_framework.settings import api_settings
@@ -165,7 +165,7 @@ class EndpointEnumerator(object):
 
         for pattern in patterns:
             path_regex = prefix + get_regex_pattern(pattern)
-            if isinstance(pattern, RegexURLPattern):
+            if isinstance(pattern, URLPattern):
                 path = self.get_path_from_regex(path_regex)
                 callback = pattern.callback
                 if self.should_include_endpoint(path, callback):
@@ -173,7 +173,7 @@ class EndpointEnumerator(object):
                         endpoint = (path, method, callback)
                         api_endpoints.append(endpoint)
 
-            elif isinstance(pattern, RegexURLResolver):
+            elif isinstance(pattern, URLResolver):
                 nested_endpoints = self.get_api_endpoints(
                     patterns=pattern.url_patterns,
                     prefix=path_regex

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -5,14 +5,12 @@ from collections import OrderedDict
 
 from django import template
 from django.template import loader
+from django.urls import NoReverseMatch, reverse
 from django.utils import six
 from django.utils.encoding import force_text, iri_to_uri
 from django.utils.html import escape, format_html, smart_urlquote
 from django.utils.safestring import SafeData, mark_safe
-
-from rest_framework.compat import (
-    NoReverseMatch, apply_markdown, pygments_highlight, reverse
-)
+from rest_framework.compat import apply_markdown, pygments_highlight
 from rest_framework.renderers import HTMLFormRenderer
 from rest_framework.utils.urls import replace_query_param
 

--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -2,14 +2,14 @@ from __future__ import unicode_literals
 
 from django.conf.urls import include, url
 
-from rest_framework.compat import RegexURLResolver, get_regex_pattern
+from rest_framework.compat import URLResolver, get_regex_pattern
 from rest_framework.settings import api_settings
 
 
 def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required):
     ret = []
     for urlpattern in urlpatterns:
-        if isinstance(urlpattern, RegexURLResolver):
+        if isinstance(urlpattern, URLResolver):
             # Set of included URL patterns
             regex = get_regex_pattern(urlpattern)
             namespace = urlpattern.namespace

--- a/rest_framework/utils/breadcrumbs.py
+++ b/rest_framework/utils/breadcrumbs.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from rest_framework.compat import get_script_prefix, resolve
+from django.urls import get_script_prefix, resolve
 
 
 def get_breadcrumbs(url, request=None):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -6,12 +6,13 @@ import unittest
 from django.contrib.auth.models import Group, Permission, User
 from django.db import models
 from django.test import TestCase
+from django.urls import ResolverMatch
 
 from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
     status, views
 )
-from rest_framework.compat import ResolverMatch, guardian
+from rest_framework.compat import guardian
 from rest_framework.filters import DjangoObjectPermissionsFilter
 from rest_framework.routers import DefaultRouter
 from rest_framework.test import APIRequestFactory

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 from django.conf.urls import url
 from django.test import TestCase, override_settings
+from django.urls import NoReverseMatch
 
-from rest_framework.compat import NoReverseMatch
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory
 

--- a/tests/test_urlpatterns.py
+++ b/tests/test_urlpatterns.py
@@ -4,8 +4,9 @@ from collections import namedtuple
 
 from django.conf.urls import include, url
 from django.test import TestCase
+from django.urls import Resolver404
 
-from rest_framework.compat import Resolver404, make_url_resolver
+from rest_framework.compat import make_url_resolver
 from rest_framework.test import APIRequestFactory
 from rest_framework.urlpatterns import format_suffix_patterns
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
-
-from rest_framework.compat import NoReverseMatch
+from django.urls import NoReverseMatch
 
 
 class MockObject(object):


### PR DESCRIPTION
- flake8 was globally disabled on the `compat` module, which is why whitespace issues went undetected by the linter. Removed the global noqa and re-added where necessary to individual lines.
- simplified and removed unnecessary imports (eg, unnecessary urls imports, old templates imports).
- `RegexURLPattern` => `URLPattern`
- `RegexURLResolver` => `URLResolver`