### PR TITLE
Fields should respect error messages in 2.x

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -901,7 +901,7 @@ class ModelSerializer(Serializer):
             kwargs['help_text'] = model_field.help_text
 
         if model_field.error_messages is not None:
-            kwargs['error_messages'] = model.error_messages
+            kwargs['error_messages'] = model_field.error_messages
 
         # TODO: TypedChoiceField?
         if model_field.flatchoices:  # This ModelField contains choices

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -900,6 +900,9 @@ class ModelSerializer(Serializer):
         if model_field.help_text is not None:
             kwargs['help_text'] = model_field.help_text
 
+        if model_field.error_messages is not None:
+            kwargs['error_messages'] = model.error_messages
+
         # TODO: TypedChoiceField?
         if model_field.flatchoices:  # This ModelField contains choices
             kwargs['choices'] = model_field.flatchoices

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1344,7 +1344,8 @@ class SeveralChoicesModel(models.Model):
         max_length=10,
         choices=[('rock', 'Rock'), ('metal', 'Metal'), ('grunge', 'Grunge')],
         blank=True,
-        default='metal'
+        default='metal',
+        error_messages={'invalid_choice': 'The choice %(value)s is invalid. Please choose one of ["rock", "metal", "grunge"]'}
     )
 
 
@@ -1387,6 +1388,13 @@ class SerializerChoiceFields(TestCase):
             serializer.fields['music_genre'].choices,
             BLANK_CHOICE_DASH + [('rock', 'Rock'), ('metal', 'Metal'), ('grunge', 'Grunge')]
         )
+
+    def test_field_propagates_error_messages(self):
+        data = {'color': 'blue', 'music_genre': 'grindcore'}
+        serializer = self.several_choices_serializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        expected_errors = {'music_genre': ['The choice grindcore is invalid. Please choose one of ["rock", "metal", "grunge"]']}
+        self.assertEqual(serializer.errors, expected_errors)
 
 
 # Regression tests for #675


### PR DESCRIPTION
I noticed that in the 2.x branch, error_messages are not propagated for fields, so sometimes I don't get the error message I expect, but rather the default_error_message for the field class. This is a PR to fix that.

