### PR TITLE
Test Serializer exclude for declared fields

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1102,6 +1102,17 @@ class ModelSerializer(Serializer):
         if exclude is not None:
             # If `Meta.exclude` is included, then remove those fields.
             for field_name in exclude:
+                assert field_name not in self._declared_fields, (
+                    "Cannot both declare the field '{field_name}' and include "
+                    "it in the {serializer_class} 'exclude' option. Remove the "
+                    "field or, if inherited from a parent serializer, disable "
+                    "with `{field_name} = None`."
+                    .format(
+                        field_name=field_name,
+                        serializer_class=self.__class__.__name__
+                    )
+                )
+
                 assert field_name in fields, (
                     "The field '{field_name}' was included on serializer "
                     "{serializer_class} in the 'exclude' option, but does "

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -900,6 +900,16 @@ class TestSerializerMetaClass(TestCase):
             "Cannot set both 'fields' and 'exclude' options on serializer ExampleSerializer."
         )
 
+    def test_declared_fields_with_exclude_option(self):
+        class ExampleSerializer(serializers.ModelSerializer):
+            text = serializers.CharField()
+
+            class Meta:
+                model = MetaClassTestModel
+                exclude = ('text',)
+
+        assert list(ExampleSerializer().fields) == ['id', 'text']
+
 
 class Issue2704TestCase(TestCase):
     def test_queryset_all(self):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -908,7 +908,13 @@ class TestSerializerMetaClass(TestCase):
                 model = MetaClassTestModel
                 exclude = ('text',)
 
-        assert list(ExampleSerializer().fields) == ['id', 'text']
+        expected = (
+            "Cannot both declare the field 'text' and include it in the "
+            "ExampleSerializer 'exclude' option. Remove the field or, if "
+            "inherited from a parent serializer, disable with `text = None`."
+        )
+        with self.assertRaisesMessage(AssertionError, expected):
+            ExampleSerializer().fields
 
 
 class Issue2704TestCase(TestCase):


### PR DESCRIPTION
- First commit adds a test for the existing behavior. 
- Second commit would fix #5596.

I'm not particularly inclined towards the change in behavior, but it was fairly trivial to implement. 

Thoughts @xordoquy, @carltongibson?