### PR TITLE
Fix AttributeError hiding on request authenticators

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -291,6 +291,12 @@ You *may* also override the `.authenticate_header(self, request)` method.  If im
 
 If the `.authenticate_header()` method is not overridden, the authentication scheme will return `HTTP 403 Forbidden` responses when an unauthenticated request is denied access.
 
+---
+
+**Note:** When your custom authenticator is invoked by the request object's `.user` or `.auth` properties, you may see an `AttributeError` re-raised as a `WrappedAttributeError`. This is necessary to prevent the original exception from being suppressed by the outer property access. Python will not recognize that the `AttributeError` orginates from your custom authenticator and will instead assume that the request object does not have a `.user` or `.auth` property. These errors should be fixed or otherwise handled by your authenticator.
+
+---
+
 ## Example
 
 The following example will authenticate any incoming request as the user given by the username in a custom request header named 'X_USERNAME'.

--- a/docs/api-guide/requests.md
+++ b/docs/api-guide/requests.md
@@ -90,6 +90,10 @@ You won't typically need to access this property.
 
 ---
 
+**Note:** You may see a `WrappedAttributeError` raised when calling the `.user` or `.auth` properties. These errors originate from an authenticator as a standard `AttributeError`, however it's necessary that they be re-raised as a different exception type in order to prevent them from being suppressed by the outer property access. Python will not recognize that the `AttributeError` orginates from the authenticator and will instaed assume that the request object does not have a `.user` or `.auth` property. The authenticator will need to be fixed.
+
+---
+
 # Browser enhancements
 
 REST framework supports a few browser enhancements such as browser-based `PUT`, `PATCH` and `DELETE` forms.

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -10,6 +10,9 @@ The wrapped request then offers a richer API, in particular :
 """
 from __future__ import unicode_literals
 
+import sys
+from contextlib import contextmanager
+
 from django.conf import settings
 from django.http import QueryDict
 from django.http.multipartparser import parse_header
@@ -57,6 +60,24 @@ class override_method(object):
     def __exit__(self, *args, **kwarg):
         self.view.request = self.request
         self.view.action = self.action
+
+
+class WrappedAttributeError(Exception):
+    pass
+
+
+@contextmanager
+def wrap_attributeerrors():
+    """
+    Used to re-raise AttributeErrors caught during authentication, preventing
+    these errors from otherwise being handled by the attribute access protocol.
+    """
+    try:
+        yield
+    except AttributeError:
+        info = sys.exc_info()
+        exc = WrappedAttributeError(str(info[1]))
+        six.reraise(type(exc), exc, info[2])
 
 
 class Empty(object):
@@ -191,7 +212,8 @@ class Request(object):
         by the authentication classes provided to the request.
         """
         if not hasattr(self, '_user'):
-            self._authenticate()
+            with wrap_attributeerrors():
+                self._authenticate()
         return self._user
 
     @user.setter
@@ -214,7 +236,8 @@ class Request(object):
         request, such as an authentication token.
         """
         if not hasattr(self, '_auth'):
-            self._authenticate()
+            with wrap_attributeerrors():
+                self._authenticate()
         return self._auth
 
     @auth.setter
@@ -233,7 +256,8 @@ class Request(object):
         to authenticate the request, or `None`.
         """
         if not hasattr(self, '_authenticator'):
-            self._authenticate()
+            with wrap_attributeerrors():
+                self._authenticate()
         return self._authenticator
 
     def _load_data_and_files(self):
@@ -316,7 +340,7 @@ class Request(object):
 
         try:
             parsed = parser.parse(stream, media_type, self.parser_context)
-        except:
+        except Exception:
             # If we get an exception during parsing, fill in empty data and
             # re-raise.  Ensures we don't simply repeat the error when
             # attempting to render the browsable renderer response, or when

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -19,7 +19,7 @@ from django.utils import six
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.parsers import BaseParser, FormParser, MultiPartParser
-from rest_framework.request import Request
+from rest_framework.request import Request, WrappedAttributeError
 from rest_framework.response import Response
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.views import APIView
@@ -227,10 +227,10 @@ class TestUserSetter(TestCase):
 
         # The DRF request object does not have a user and should run authenticators
         expected = r"no attribute 'MISSPELLED_NAME_THAT_DOESNT_EXIST'"
-        with pytest.raises(AttributeError, match=expected):
+        with pytest.raises(WrappedAttributeError, match=expected):
             request.user
 
-        with pytest.raises(AttributeError, match=expected):
+        with pytest.raises(WrappedAttributeError, match=expected):
             login(request, self.user)
 
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -200,9 +200,9 @@ class TestUserSetter(TestCase):
 
     def test_user_can_logout(self):
         self.request.user = self.user
-        self.assertFalse(self.request.user.is_anonymous)
+        assert not self.request.user.is_anonymous
         logout(self.request)
-        self.assertTrue(self.request.user.is_anonymous)
+        assert self.request.user.is_anonymous
 
     def test_logged_in_user_is_set_on_wrapped_request(self):
         login(self.request, self.user)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -230,6 +230,13 @@ class TestUserSetter(TestCase):
         with pytest.raises(WrappedAttributeError, match=expected):
             request.user
 
+        # python 2 hasattr fails for *any* exception, not just AttributeError
+        if six.PY2:
+            return
+
+        with pytest.raises(WrappedAttributeError, match=expected):
+            hasattr(request, 'user')
+
         with pytest.raises(WrappedAttributeError, match=expected):
             login(request, self.user)
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -8,6 +8,7 @@ import tempfile
 
 from django.conf.urls import url
 from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.contrib.auth.models import User
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -185,7 +186,8 @@ class TestUserSetter(TestCase):
         # available to login and logout functions
         self.wrapped_request = factory.get('/')
         self.request = Request(self.wrapped_request)
-        SessionMiddleware().process_request(self.request)
+        SessionMiddleware().process_request(self.wrapped_request)
+        AuthenticationMiddleware().process_request(self.wrapped_request)
 
         User.objects.create_user('ringo', 'starr@thebeatles.com', 'yellow')
         self.user = authenticate(username='ringo', password='yellow')


### PR DESCRIPTION
Fixes #4033. There is an existing test for the issue, however there are a couple of issues:
- No authentication middleware is used, so the `request.user` is never set. Because of this, `__getattribute__` will re-raise the `AttributeError`. However, typical use does include an authentication middleware and will yield a `user` on the underlying request, as demonstrated by #4033.  
- The `SessionMiddleware` is applied to the DRF request object instead of the underlying Django request, which doesn't mirror how middleware is actually applied.

