### PR TITLE
[wip] Make DRF compatible with namespaces

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -339,7 +339,8 @@ class HyperlinkedRelatedField(RelatedField):
                 self.view_name, request
             )
         except AttributeError:
-            expected_viewname = self.view_name
+            # by default, expect the 'rest_framework' namespace
+            expected_viewname = 'rest_framework:' + self.view_name
 
         if match.view_name != expected_viewname:
             self.fail('incorrect_match')

--- a/rest_framework/reverse.py
+++ b/rest_framework/reverse.py
@@ -60,10 +60,27 @@ def _reverse(viewname, args=None, kwargs=None, request=None, format=None, **extr
     if format is not None:
         kwargs = kwargs or {}
         kwargs['format'] = format
+    if request:
+        extra.setdefault('current_app', current_app(request))
     url = django_reverse(viewname, args=args, kwargs=kwargs, **extra)
     if request:
         return request.build_absolute_uri(url)
     return url
+
+
+def current_app(request):
+    """
+    Get the current app for the request.
+
+    This code is copied from the URL tag.
+    """
+    try:
+        return request.current_app
+    except AttributeError:
+        try:
+            return request.resolver_match.namespace
+        except AttributeError:
+            return None
 
 
 reverse_lazy = lazy(reverse, six.text_type)

--- a/rest_framework/reverse.py
+++ b/rest_framework/reverse.py
@@ -34,10 +34,29 @@ def preserve_builtin_query_params(url, request=None):
 
 def reverse(viewname, args=None, kwargs=None, request=None, format=None, **extra):
     """
+    Extends `django.urls.reverse` with behavior specific to rest framework.
+
+    The `viewname` will be prepended with the 'rest_framework' application
+    namespace if no namspace is included in the `viewname` argument. The
+    framework fundamentally assumes that the router urls will be included with
+    the 'rest_framework' namespace, so ensure that your root url patterns are
+    configured accordingly. Assuming you use the default router, you can check
+    this with:
+
+        from django.urls import reverse
+
+        reverse('rest_framework:api-root')
+
     If versioning is being used then we pass any `reverse` calls through
     to the versioning scheme instance, so that the resulting URL
     can be modified if needed.
+
+    Optionally takes a `request` object (see `_reverse` for details).
     """
+    # prepend the 'rest_framework' application namespace
+    if ':' not in viewname:
+        viewname = 'rest_framework:' + viewname
+
     scheme = getattr(request, 'versioning_scheme', None)
     if scheme is not None:
         try:
@@ -56,6 +75,8 @@ def _reverse(viewname, args=None, kwargs=None, request=None, format=None, **extr
     """
     Same as `django.urls.reverse`, but optionally takes a request
     and returns a fully qualified URL, using the request to get the base URL.
+
+    Additionally, the request is used to determine the `current_app` instance.
     """
     if format is not None:
         kwargs = kwargs or {}

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -305,10 +305,7 @@ class APIRootView(views.APIView):
     def get(self, request, *args, **kwargs):
         # Return a plain {"name": "hyperlink"} response.
         ret = OrderedDict()
-        namespace = request.resolver_match.namespace
         for key, url_name in self.api_root_dict.items():
-            if namespace:
-                url_name = namespace + ':' + url_name
             try:
                 ret[key] = reverse(
                     url_name,

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -101,6 +101,10 @@ class BaseRouter(object):
             self._urls = self.get_urls()
         return self._urls
 
+    @property
+    def urlpatterns(self):
+        return (self.urls, 'rest_framework')
+
 
 class SimpleRouter(BaseRouter):
 

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -96,7 +96,7 @@ def optional_login(request):
     Include a login snippet if REST framework's login view is in the URLconf.
     """
     try:
-        login_url = reverse('rest_framework:login')
+        login_url = reverse('rest_framework_auth:login')
     except NoReverseMatch:
         return ''
 
@@ -112,7 +112,7 @@ def optional_docs_login(request):
     Include a login snippet if REST framework's login view is in the URLconf.
     """
     try:
-        login_url = reverse('rest_framework:login')
+        login_url = reverse('rest_framework_auth:login')
     except NoReverseMatch:
         return 'log in'
 
@@ -128,7 +128,7 @@ def optional_logout(request, user):
     Include a logout snippet if REST framework's logout view is in the URLconf.
     """
     try:
-        logout_url = reverse('rest_framework:logout')
+        logout_url = reverse('rest_framework_auth:logout')
     except NoReverseMatch:
         snippet = format_html('<li class="navbar-text">{user}</li>', user=escape(user))
         return mark_safe(snippet)

--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -27,7 +27,7 @@ else:
     logout = views.LogoutView.as_view()
 
 
-app_name = 'rest_framework'
+app_name = 'rest_framework_auth'
 urlpatterns = [
     url(r'^login/$', login, login_kwargs, name='login'),
     url(r'^logout/$', logout, name='logout'),

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -135,6 +135,13 @@ class NamespaceVersioning(BaseVersioning):
         )
 
     def get_versioned_viewname(self, viewname, request):
+        """
+        The incoming `viewname` should be prefixed with the 'rest_framework'
+        application namespace. We want to replace this with the version
+        instance namespace.
+        """
+        if viewname.startswith('rest_framework:'):
+            viewname = viewname[len('rest_framework:'):]
         return request.version + ':' + viewname
 
 

--- a/tests/test_lazy_hyperlinks.py
+++ b/tests/test_lazy_hyperlinks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.db import models
 from django.test import TestCase, override_settings
 
@@ -28,8 +28,12 @@ def dummy_view(request):
     pass
 
 
-urlpatterns = [
+patterns = [
     url(r'^example/(?P<pk>[0-9]+)/$', dummy_view, name='example-detail'),
+]
+
+urlpatterns = [
+    url(r'^', include((patterns, 'rest_framework')))
 ]
 
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.utils.datastructures import MultiValueDict
@@ -146,7 +146,9 @@ class TestProxiedPrimaryKeyRelatedField(APISimpleTestCase):
 
 
 @override_settings(ROOT_URLCONF=[
-    url(r'^example/(?P<name>.+)/$', lambda: None, name='example'),
+    url(r'^', include(
+        ([url(r'^example/(?P<name>.+)/$', lambda: None, name='example')], 'rest_framework')
+    )),
 ])
 class TestHyperlinkedRelatedField(APISimpleTestCase):
     def setUp(self):

--- a/tests/test_relations_hyperlink.py
+++ b/tests/test_relations_hyperlink.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.test import TestCase, override_settings
 
 from rest_framework import serializers
@@ -449,3 +449,39 @@ class HyperlinkedNullableOneToOneTests(TestCase):
             {'url': 'http://testserver/onetoonetarget/2/', 'name': 'target-2', 'nullable_source': None},
         ]
         assert serializer.data == expected
+
+
+class HyperlinkedNamespaceTests(TestCase):
+    def setUp(self):
+        target = ForeignKeyTarget(name='target-1')
+        target.save()
+        new_target = ForeignKeyTarget(name='target-2')
+        new_target.save()
+        for idx in range(1, 4):
+            source = ForeignKeySource(name='source-%d' % idx, target=target)
+            source.save()
+
+    def results(self):
+        queryset = ForeignKeySource.objects.all()
+        serializer = ForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        expected = [
+            {'url': 'http://testserver/foreignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/3/', 'name': 'source-3', 'target': 'http://testserver/foreignkeytarget/1/'}
+        ]
+        with self.assertNumQueries(1):
+            assert serializer.data == expected
+
+    def test_foreign_key_retrieve_no_namespace(self):
+        patterns = [
+            url(r'^', include(urlpatterns, namespace=None))
+        ]
+        with override_settings(ROOT_URLCONF=patterns):
+            self.results()
+
+    def test_foreign_key_retrieve_namespace(self):
+        patterns = [
+            url(r'^', include(urlpatterns, namespace='api'))
+        ]
+        with override_settings(ROOT_URLCONF=patterns):
+            self.results()

--- a/tests/test_relations_hyperlink.py
+++ b/tests/test_relations_hyperlink.py
@@ -18,7 +18,7 @@ def dummy_view(request, pk):
     pass
 
 
-urlpatterns = [
+patterns = [
     url(r'^dummyurl/(?P<pk>[0-9]+)/$', dummy_view, name='dummy-url'),
     url(r'^manytomanysource/(?P<pk>[0-9]+)/$', dummy_view, name='manytomanysource-detail'),
     url(r'^manytomanytarget/(?P<pk>[0-9]+)/$', dummy_view, name='manytomanytarget-detail'),
@@ -27,6 +27,10 @@ urlpatterns = [
     url(r'^nullableforeignkeysource/(?P<pk>[0-9]+)/$', dummy_view, name='nullableforeignkeysource-detail'),
     url(r'^onetoonetarget/(?P<pk>[0-9]+)/$', dummy_view, name='onetoonetarget-detail'),
     url(r'^nullableonetoonesource/(?P<pk>[0-9]+)/$', dummy_view, name='nullableonetoonesource-detail'),
+]
+
+urlpatterns = [
+    url(r'^', include((patterns, 'rest_framework')))
 ]
 
 
@@ -473,15 +477,15 @@ class HyperlinkedNamespaceTests(TestCase):
             assert serializer.data == expected
 
     def test_foreign_key_retrieve_no_namespace(self):
-        patterns = [
-            url(r'^', include(urlpatterns, namespace=None))
+        url_conf = [
+            url(r'^', include((patterns, 'rest_framework'), namespace=None))
         ]
-        with override_settings(ROOT_URLCONF=patterns):
+        with override_settings(ROOT_URLCONF=url_conf):
             self.results()
 
     def test_foreign_key_retrieve_namespace(self):
-        patterns = [
-            url(r'^', include(urlpatterns, namespace='api'))
+        url_conf = [
+            url(r'^', include((patterns, 'rest_framework'), namespace='api'))
         ]
-        with override_settings(ROOT_URLCONF=patterns):
+        with override_settings(ROOT_URLCONF=url_conf):
             self.results()

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -1,21 +1,29 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import url
+from django.conf.urls import include, url
+from django.http import HttpResponse
 from django.test import TestCase, override_settings
 from django.urls import NoReverseMatch
 
-from rest_framework.reverse import reverse
+from rest_framework.reverse import current_app, reverse
 from rest_framework.test import APIRequestFactory
 
 factory = APIRequestFactory()
 
 
-def null_view(request):
-    pass
+def mock_view(request):
+    return HttpResponse('')
+
+
+apppatterns = ([
+    url(r'^home$', mock_view, name='home'),
+], 'app')
 
 
 urlpatterns = [
-    url(r'^view$', null_view, name='view'),
+    url(r'^view$', mock_view, name='view'),
+    url(r'^app2/', include(apppatterns, namespace='app2')),
+    url(r'^app1/', include(apppatterns, namespace='app1')),
 ]
 
 
@@ -54,3 +62,85 @@ class ReverseTests(TestCase):
 
         url = reverse('view', request=request)
         assert url == 'http://testserver/view'
+
+
+@override_settings(ROOT_URLCONF='tests.test_reverse')
+class NamespaceTests(TestCase):
+    """
+    Ensure reverse can handle namespaces.
+
+    Note: It's necessary to use self.client() here, as the
+          RequestFactory does not setup the resolver_match.
+    """
+
+    def request(self, url):
+        return self.client.get(url).wsgi_request
+
+    def test_application_namespace(self):
+        url = reverse('app:home')
+        assert url == '/app1/home'
+
+        # instance namespace provided by current_app
+        url = reverse('app:home', current_app='app2')
+        assert url == '/app2/home'
+
+    def test_instance_namespace(self):
+        url = reverse('app1:home')
+        assert url == '/app1/home'
+
+        url = reverse('app2:home')
+        assert url == '/app2/home'
+
+    def test_application_namespace_with_request(self):
+        # request's current app affects result
+        request1 = self.request('/app1/home')
+        request2 = self.request('/app2/home')
+
+        # sanity check
+        assert current_app(request1) == 'app1'
+        assert current_app(request2) == 'app2'
+
+        assert reverse('app:home', request=request1) == 'http://testserver/app1/home'
+        assert reverse('app:home', request=request2) == 'http://testserver/app2/home'
+
+    def test_instance_namespace_with_request(self):
+        # request's current app is not relevant
+        request1 = self.request('/app1/home')
+        request2 = self.request('/app2/home')
+
+        # sanity check
+        assert current_app(request1) == 'app1'
+        assert current_app(request2) == 'app2'
+
+        assert reverse('app1:home', request=request1) == 'http://testserver/app1/home'
+        assert reverse('app2:home', request=request1) == 'http://testserver/app2/home'
+        assert reverse('app1:home', request=request2) == 'http://testserver/app1/home'
+        assert reverse('app2:home', request=request2) == 'http://testserver/app2/home'
+
+
+@override_settings(ROOT_URLCONF='tests.test_reverse')
+class CurrentAppTests(TestCase):
+    """
+    Test current_app() function.
+
+    Note: It's necessary to use self.client() here, as the
+          RequestFactory does not setup the resolver_match.
+    """
+
+    def request(self, url):
+        return self.client.get(url).wsgi_request
+
+    def test_no_namespace(self):
+        request = self.request('/view')
+        assert current_app(request) == ''
+
+    def test_namespace(self):
+        request = self.request('/app1/home')
+        assert current_app(request) == 'app1'
+
+        request = self.request('/app2/home')
+        assert current_app(request) == 'app2'
+
+    def test_factory_incompatibility(self):
+        request = factory.get('/app1/home')
+        assert current_app(request) is None

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -145,9 +145,9 @@ class TestSimpleRouter(TestCase):
 
 class TestRootView(URLPatternsTestCase, TestCase):
     urlpatterns = [
-        url(r'^non-namespaced/', include(namespaced_router.urls)),
-        url(r'^namespaced1/', include((namespaced_router.urls, 'namespaced1'), namespace='namespaced1')),
-        url(r'^namespaced2/', include((namespaced_router.urls, 'namespaced2'), namespace='namespaced2')),
+        url(r'^non-namespaced/', include(namespaced_router.urlpatterns)),
+        url(r'^namespaced1/', include(namespaced_router.urlpatterns, namespace='namespaced1')),
+        url(r'^namespaced2/', include(namespaced_router.urlpatterns, namespace='namespaced2')),
     ]
 
     def test_retrieve_namespaced_root(self):
@@ -167,8 +167,8 @@ class TestCustomLookupFields(URLPatternsTestCase, TestCase):
     Ensure that custom lookup fields are correctly routed.
     """
     urlpatterns = [
-        url(r'^example/', include(notes_router.urls)),
-        url(r'^example2/', include(kwarged_notes_router.urls)),
+        url(r'^example/', include(notes_router.urlpatterns)),
+        url(r'^example2/', include(kwarged_notes_router.urlpatterns)),
     ]
 
     def setUp(self):
@@ -225,8 +225,8 @@ class TestLookupUrlKwargs(URLPatternsTestCase, TestCase):
     Setup a deep lookup_field, but map it to a simple URL kwarg.
     """
     urlpatterns = [
-        url(r'^example/', include(notes_router.urls)),
-        url(r'^example2/', include(kwarged_notes_router.urls)),
+        url(r'^example/', include(notes_router.urlpatterns)),
+        url(r'^example2/', include(kwarged_notes_router.urlpatterns)),
     ]
 
     def setUp(self):
@@ -414,7 +414,7 @@ class TestDynamicListAndDetailRouter(TestCase):
 
 class TestEmptyPrefix(URLPatternsTestCase, TestCase):
     urlpatterns = [
-        url(r'^empty-prefix/', include(empty_prefix_router.urls)),
+        url(r'^empty-prefix/', include(empty_prefix_router.urlpatterns)),
     ]
 
     def test_empty_prefix_list(self):
@@ -431,7 +431,7 @@ class TestEmptyPrefix(URLPatternsTestCase, TestCase):
 
 class TestRegexUrlPath(URLPatternsTestCase, TestCase):
     urlpatterns = [
-        url(r'^regex/', include(regex_url_path_router.urls)),
+        url(r'^regex/', include(regex_url_path_router.urlpatterns)),
     ]
 
     def test_regex_url_path_list(self):

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -146,12 +146,16 @@ class TestSimpleRouter(TestCase):
 class TestRootView(URLPatternsTestCase, TestCase):
     urlpatterns = [
         url(r'^non-namespaced/', include(namespaced_router.urls)),
-        url(r'^namespaced/', include((namespaced_router.urls, 'namespaced'), namespace='namespaced')),
+        url(r'^namespaced1/', include((namespaced_router.urls, 'namespaced1'), namespace='namespaced1')),
+        url(r'^namespaced2/', include((namespaced_router.urls, 'namespaced2'), namespace='namespaced2')),
     ]
 
     def test_retrieve_namespaced_root(self):
-        response = self.client.get('/namespaced/')
-        assert response.data == {"example": "http://testserver/namespaced/example/"}
+        response = self.client.get('/namespaced1/')
+        assert response.data == {"example": "http://testserver/namespaced1/example/"}
+
+        response = self.client.get('/namespaced2/')
+        assert response.data == {"example": "http://testserver/namespaced2/example/"}
 
     def test_retrieve_non_namespaced_root(self):
         response = self.client.get('/non-namespaced/')

--- a/tests/test_urlconf.py
+++ b/tests/test_urlconf.py
@@ -1,0 +1,127 @@
+"""
+Test rest framework assumptions about the configuration of the root urlconf.
+"""
+from django.conf.urls import include, url
+
+from rest_framework import routers, viewsets
+from rest_framework.reverse import NoReverseMatch, reverse
+from rest_framework.test import APITestCase, URLPatternsTestCase
+
+
+class MockViewSet(viewsets.ViewSet):
+    def list(self, request, *args, **kwargs):
+        pass
+
+
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'example', MockViewSet, base_name='example')
+
+
+class TestUrlsAppNameRequired(APITestCase, URLPatternsTestCase):
+    urlpatterns = [
+        url(r'^api/', include(router.urls)),
+    ]
+
+    def test_reverse(self):
+        """
+        The 'rest_framework' namespace must be present.
+        """
+        with self.assertRaises(NoReverseMatch):
+            reverse('example-list')
+
+
+class TestUrlpatternsAppName(APITestCase, URLPatternsTestCase):
+    urlpatterns = [
+        url(r'^api/', include(router.urlpatterns)),
+    ]
+
+    def test_reverse(self):
+        self.assertEqual(reverse('example-list'), '/api/example')
+
+    def test_app_name_reverse(self):
+        self.assertEqual(reverse('rest_framework:example-list'), '/api/example')
+
+
+class TestUrlpatternsNamespace(APITestCase, URLPatternsTestCase):
+    urlpatterns = [
+        url(r'^api/v1/', include(router.urlpatterns, namespace='v1')),
+        url(r'^api/v2/', include(router.urlpatterns, namespace='v2')),
+    ]
+
+    def test_reverse(self):
+        self.assertEqual(reverse('example-list'), '/api/v2/example')
+
+    def test_app_name_reverse(self):
+        self.assertEqual(reverse('rest_framework:example-list'), '/api/v2/example')
+
+    def test_namespace_reverse(self):
+        self.assertEqual(reverse('v1:example-list'), '/api/v1/example')
+        self.assertEqual(reverse('v2:example-list'), '/api/v2/example')
+
+
+class TestAppUrlpatternsAppName(APITestCase, URLPatternsTestCase):
+    apppatterns = ([
+        url(r'^api/', include(router.urlpatterns)),
+    ], 'api')
+
+    urlpatterns = [
+        url(r'^', include(apppatterns)),
+    ]
+
+    def test_reverse(self):
+        """
+        Nesting the router.urlpatterns in an app with an app_name will
+        break url resolution.
+        """
+        with self.assertRaises(NoReverseMatch):
+            reverse('example-list')
+
+
+class TestAppUrlpatterns(APITestCase, URLPatternsTestCase):
+    apppatterns = ([
+        url(r'^api/', include(router.urlpatterns)),
+    ], None)
+
+    urlpatterns = [
+        url(r'^', include(apppatterns)),
+    ]
+
+    def test_reverse(self):
+        self.assertEqual(reverse('example-list'), '/api/example')
+
+
+class TestAppUrlsAppName(APITestCase, URLPatternsTestCase):
+    apppatterns = ([
+        url(r'^api/', include(router.urls)),
+    ], 'rest_framework')
+
+    urlpatterns = [
+        url(r'^', include(apppatterns)),
+    ]
+
+    def test_reverse(self):
+        self.assertEqual(reverse('example-list'), '/api/example')
+
+    def test_app_name_reverse(self):
+        self.assertEqual(reverse('rest_framework:example-list'), '/api/example')
+
+
+class TestAppUrlsNamespace(APITestCase, URLPatternsTestCase):
+    apppatterns = ([
+        url(r'^', include(router.urls)),
+    ], 'rest_framework')
+
+    urlpatterns = [
+        url(r'^api/v1/', include(apppatterns, namespace='v1')),
+        url(r'^api/v2/', include(apppatterns, namespace='v2')),
+    ]
+
+    def test_reverse(self):
+        self.assertEqual(reverse('example-list'), '/api/v2/example')
+
+    def test_app_name_reverse(self):
+        self.assertEqual(reverse('rest_framework:example-list'), '/api/v2/example')
+
+    def test_namespace_reverse(self):
+        self.assertEqual(reverse('v1:example-list'), '/api/v1/example')
+        self.assertEqual(reverse('v2:example-list'), '/api/v2/example')

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -62,7 +62,7 @@ router.register(r'actions-alt', ActionViewSet, base_name='actions-alt')
 
 
 urlpatterns = [
-    url(r'^api/', include(router.urls)),
+    url(r'^api/', include(router.urlpatterns)),
 ]
 
 


### PR DESCRIPTION
Fixes #5551
Fixes #5659

Hi all, this should hopefully add namespace support for DRF. This is a breaking change (although minor?), as it requires users to reconfigure their application routes. Most cases should be straightforward, although anyone using multiple routers or with an unusual setup might have issues. 
In general, DRF now assumes the "rest_framework" *application* namespace. This means that users must include the application namespace in their root urlconf. eg, we previously recommended that users do:

```python
urlpatterns = [
    url(r'^api/', include(router.urls))
    ...
]
```

After the PR, url configs should look like:
```python
# root urlconf
urlpatterns = [
    url(r'^api/', include(router.urlpatterns)), 

    # the above `urlpatterns` is shorthand for
    url(r'^api/', include((router.urls, 'rest_framework'))),

    # and namespaces work
    url(r'^api/', include(router.urlpatterns, namespace='api')),
]
```

If users have multiple routers, they could combine them like so:

```python
# root urlconf
urlpatterns = [
    # combined
    url(r'^api/', include((router1.urls + router2.urls, 'rest_framework))),

    # separate namespaces
    url(r'^api1/', include(router1.urlpatterns, namespace='api1')),
    url(r'^api2/', include(router2.urlpatterns, namespace='api2')),
]
```

Note that routers urls inside an *app's* urls will break when an intermediate `app_name` is present:

```python
# api_app/urls.py
app_name = 'api_app'
urlpatterns = [
    url(r'^api/', include(router.urlpatterns)),
    ...
]

# root urlconf
urlpatterns = [
    url(r'^', include('api_app.urls'))
]
```

The above is not an issue if the app uses just the `rest_framework` namespace
```python
# api_app/urls.py
app_name = 'rest_framework
urlpatterns = [
    url(r'^api/', include(router.urls)),
    ...
]


# root urlconf
urlpatterns = [
    url(r'^', include('api_app.urls'))
]
```

Additionally, non-DRF views can be added to the `router.urls`, although it will also need to be included under the 'rest_framework' application namespace.

----

Overall, the changes to the framework are fairly minimal. Most of the changes are to the test urlpatterns.
- DRF now expects the 'rest_framework' application namespace.
- `reverse` now prepends the 'rest_framework' application namespace to its viewname, unless another namespace has been provided.
- `reverse` now uses the `request` object to derive its `current_app`, a la Django's URL template tag.
- Routers now have a `urlpatterns` patterns, which is simply `(router.urls, 'rest_framework')`. 
- Auth urls, now have a namespace of 'rest_framework_auth'.

**TODO:**
- [ ] add docs
- [ ] add tests for url conf behaviors (eg, the above examples `router.urls` & `router.urlpatterns`)