### PR TITLE
Fix in documentation

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -493,6 +493,8 @@ The names in the `fields` and `exclude` attributes will normally map to model fi
 
 Alternatively names in the `fields` options can map to properties or methods which take no arguments that exist on the model class.
 
+Since version 3.3.0, it is **mandatory** to provide one of the attributes `fields` or `exclude`.
+
 ## Specifying nested serialization
 
 The default `ModelSerializer` uses primary keys for relationships, but you can also easily generate nested representations using the `depth` option:


### PR DESCRIPTION
- model serializers must provide either "fields" or "exclude" as attribute (since version 3.3.0). In case of doubts, please check the django-rest-framework/rest_framework/serializers.py file, around line 1065.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
