### PR TITLE
Perform type check on passed request argument

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -11,7 +11,7 @@ The wrapped request then offers a richer API, in particular :
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.http import QueryDict
+from django.http import HttpRequest, QueryDict
 from django.http.multipartparser import parse_header
 from django.http.request import RawPostDataException
 from django.utils import six
@@ -132,6 +132,12 @@ class Request(object):
 
     def __init__(self, request, parsers=None, authenticators=None,
                  negotiator=None, parser_context=None):
+        assert isinstance(request, HttpRequest), (
+            'The `request` argument must be an instance of '
+            '`django.http.HttpRequest`, not `{}.{}`.'
+            .format(request.__class__.__module__, request.__class__.__name__)
+        )
+
         self._request = request
         self.parsers = parsers or ()
         self.authenticators = authenticators or ()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -9,12 +9,11 @@ from rest_framework import (
     exceptions, metadata, serializers, status, versioning, views
 )
 from rest_framework.renderers import BrowsableAPIRenderer
-from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from .models import BasicModel
 
-request = Request(APIRequestFactory().options('/'))
+request = APIRequestFactory().options('/')
 
 
 class TestMetadata:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -25,6 +25,18 @@ from rest_framework.views import APIView
 factory = APIRequestFactory()
 
 
+class TestInitializer(TestCase):
+    def test_request_type(self):
+        request = Request(factory.get('/'))
+
+        message = (
+            'The `request` argument must be an instance of '
+            '`django.http.HttpRequest`, not `rest_framework.request.Request`.'
+        )
+        with self.assertRaisesMessage(AssertionError, message):
+            Request(request)
+
+
 class PlainTextParser(BaseParser):
     media_type = 'text/plain'
 


### PR DESCRIPTION
Fixes #2771 by implementing a simple check on the `request` argument's type. 