### PR TITLE
compare Field.method to the Link method in AutoSchema manual fields

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -187,7 +187,7 @@ class AutoSchema(ViewInspector):
             for f in self._manual_fields:
                 
                 try:
-                    if f.method in method:
+                    if method in f.method:
                         by_name[f.name] = f
                 except AttributeError:
                         by_name[f.name] = f

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -171,6 +171,7 @@ class AutoSchema(ViewInspector):
 
         * `manual_fields`: list of `coreapi.Field` instances that
             will be added to auto-generated fields, overwriting on `Field.name`
+            if the link method matches the manual field method.
         """
 
         self._manual_fields = manual_fields
@@ -184,7 +185,14 @@ class AutoSchema(ViewInspector):
         if self._manual_fields is not None:
             by_name = {f.name: f for f in fields}
             for f in self._manual_fields:
-                by_name[f.name] = f
+                
+                try:
+                    if f.method in method:
+                        by_name[f.name] = f
+                except AttributeError:
+                        by_name[f.name] = f
+                        warnings.warn('coreapi.Field has no attribute "method", please update coreapi')
+                
             fields = list(by_name.values())
 
         if fields and any([field.location in ('form', 'body') for field in fields]):


### PR DESCRIPTION
## Description
when adding a manual field to AutoSchema it appears on all methods of a Link objects. 
When you add a 'body' parameter it ends up on the GET method of a link as well. (although allowed, normally GET requests do not do anything with body or form parameters and as such they do not show up in request.data

This pull request adds a check if a manual field specified a method to which it belongs.

i.e inside your endpoint view add: 

```
schema = AutoSchema(manual_fields=[
        coreapi.Field(
            "my_extra_field",
            required=True,
            location="body",
            schema=coreschema.String(),
            method=("POST",) 
        ),
    ])

# method=("GET", "POST") would place the field on both get and post endpoints, works teh same for put and patch.
```

This field will now only appear in a 'POST' Link 

See the necessary patch in core-api as well [https://github.com/core-api/python-client/pull/147](https://github.com/core-api/python-client/pull/147)
