### PR TITLE
Fix packaging?

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include LICENSE.md
 recursive-include rest_framework/static *.js *.css *.png *.eot *.svg *.ttf *.woff
-recursive-include rest_framework/templates *.html
+recursive-include rest_framework/templates *.html schema.js
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 from io import open
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 try:
     from pypandoc import convert
@@ -26,31 +26,6 @@ def get_version(package):
     """
     init_py = open(os.path.join(package, '__init__.py')).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
-
-
-def get_packages(package):
-    """
-    Return root package and all sub-packages.
-    """
-    return [dirpath
-            for dirpath, dirnames, filenames in os.walk(package)
-            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
-
-
-def get_package_data(package):
-    """
-    Return all files under the root package, that are not in a
-    package themselves.
-    """
-    walk = [(dirpath.replace(package + os.sep, '', 1), filenames)
-            for dirpath, dirnames, filenames in os.walk(package)
-            if not os.path.exists(os.path.join(dirpath, '__init__.py'))]
-
-    filepaths = []
-    for base, filenames in walk:
-        filepaths.extend([os.path.join(base, filename)
-                          for filename in filenames])
-    return {package: filepaths}
 
 
 version = get_version('rest_framework')
@@ -84,8 +59,8 @@ setup(
     long_description=read_md('README.md'),
     author='Tom Christie',
     author_email='tom@tomchristie.com',  # SEE NOTE BELOW (*)
-    packages=get_packages('rest_framework'),
-    package_data=get_package_data('rest_framework'),
+    packages=find_packages(exclude=['tests*']),
+    include_package_data=True,
     install_requires=[],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
I've punted on moving the package under a `src` directory, and just made the minimum necessary changes. Also, fixes #5615.

----

I don't know if we want to accept this as is, given that I moved the package contents into a `src` directory. If we're willing to accept that change, the move is for a good reason. `tox` *does* create and install the package distribution into the test environment, however this conflicts with the `rest_framework` package that's located on the current path. Because the distribution and local files conflict, you cannot effectively test the distribution's packaged files. eg, the distribution may not be correctly configured (missing templates/static files), but the files on the local path *do* have them, so the tests pass erroneously.

The solution is to move the package off of the path (usually into a `src` directory), so that the local files are not importable.

The alternative would be to not move the package into `src` and accept that we may accidentally leave out files from time to time. This is *probably* fine, given that the manifest won't change very often.
