### PR TITLE
Fix readme, add to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
       - { python: "3.6", env: DJANGO=2.0 }
       - { python: "2.7", env: TOXENV=lint }
       - { python: "2.7", env: TOXENV=docs }
+      - python: "2.7"
+        env: TOXENV=readme
+        addons:
+          apt_packages: pandoc
     exclude:
       - { python: "2.7", env: DJANGO=master }
       - { python: "2.7", env: DJANGO=2.0 }

--- a/README.md
+++ b/README.md
@@ -20,15 +20,13 @@ continued development by **[signing up for a paid plan][funding]**.
 The initial aim is to provide a single full-time position on REST framework.
 *Every single sign-up makes a significant impact towards making that possible.*
 
-<p align="center">
-  <a href="http://jobs.rover.com/"><img src="https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/rover-readme.png"/></a>
-  <a href="https://getsentry.com/welcome/"><img src="https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/sentry-readme.png"/></a>
-  <a href="https://getstream.io/try-the-api/?utm_source=drf&utm_medium=banner&utm_campaign=drf"><img src="https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/stream-readme.png"/></a>
-  <a href="https://hello.machinalis.co.uk/"><img src="https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/machinalis-readme.png"/></a>
-  <a href="https://rollbar.com/"><img src="https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/rollbar-readme.png"/></a>
-</p>
+[![][rover-img]][rover-url]
+[![][sentry-img]][sentry-url]
+[![][stream-img]][stream-url]
+[![][machinalis-img]][machinalis-url]
+[![][rollbar-img]][rollbar-url]
 
-*Many thanks to all our [wonderful sponsors][sponsors], and in particular to our premium backers, [Rover](http://jobs.rover.com/), [Sentry](https://getsentry.com/welcome/), [Stream](https://getstream.io/?utm_source=drf&utm_medium=banner&utm_campaign=drf), [Machinalis](https://hello.machinalis.co.uk/), and [Rollbar](https://rollbar.com/).*
+*Many thanks to all our [wonderful sponsors][sponsors], and in particular to our premium backers, [Rover][rover-url], [Sentry][sentry-url], [Stream][stream-url], [Machinalis][machinalis-url], and [Rollbar][rollbar-url].*
 
 ---
 
@@ -187,6 +185,18 @@ Send a description of the issue via email to [rest-framework-security@googlegrou
 
 [funding]: https://fund.django-rest-framework.org/topics/funding/
 [sponsors]: https://fund.django-rest-framework.org/topics/funding/#our-sponsors
+
+[rover-img]: https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/rover-readme.png
+[sentry-img]: https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/sentry-readme.png
+[stream-img]: https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/stream-readme.png
+[machinalis-img]: https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/machinalis-readme.png
+[rollbar-img]: https://raw.githubusercontent.com/encode/django-rest-framework/master/docs/img/premium/rollbar-readme.png
+
+[rover-url]: http://jobs.rover.com/
+[sentry-url]: https://getsentry.com/welcome/
+[stream-url]: https://getstream.io/try-the-api/?utm_source=drf&utm_medium=banner&utm_campaign=drf
+[machinalis-url]: https://hello.machinalis.co.uk/
+[rollbar-url]: https://rollbar.com/
 
 [oauth1-section]: http://www.django-rest-framework.org/api-guide/authentication/#django-rest-framework-oauth
 [oauth2-section]: http://www.django-rest-framework.org/api-guide/authentication/#django-oauth-toolkit

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Full documentation for the project is available at [http://www.django-rest-frame
 
 REST framework is a *collaboratively funded project*. If you use
 REST framework commercially we strongly encourage you to invest in its
-continued development by **[signing up for a paid plan][funding]**.
+continued development by [signing up for a paid plan][funding].
 
 The initial aim is to provide a single full-time position on REST framework.
 *Every single sign-up makes a significant impact towards making that possible.*
@@ -26,7 +26,7 @@ The initial aim is to provide a single full-time position on REST framework.
 [![][machinalis-img]][machinalis-url]
 [![][rollbar-img]][rollbar-url]
 
-*Many thanks to all our [wonderful sponsors][sponsors], and in particular to our premium backers, [Rover][rover-url], [Sentry][sentry-url], [Stream][stream-url], [Machinalis][machinalis-url], and [Rollbar][rollbar-url].*
+Many thanks to all our [wonderful sponsors][sponsors], and in particular to our premium backers, [Rover][rover-url], [Sentry][sentry-url], [Stream][stream-url], [Machinalis][machinalis-url], and [Rollbar][rollbar-url].
 
 ---
 
@@ -47,6 +47,8 @@ There is a live example API for testing purposes, [available here][sandbox].
 **Below**: *Screenshot from the browsable API*
 
 ![Screenshot][image]
+
+----
 
 # Requirements
 

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -9,3 +9,6 @@ transifex-client==0.11
 
 # Pandoc to have a nice pypi page
 pypandoc
+
+# readme_renderer to check readme syntax
+readme_renderer

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ from io import open
 from setuptools import setup
 
 try:
-    from pypandoc import convert
+    from pypandoc import convert_file
 
     def read_md(f):
-        return convert(f, 'rst')
+        return convert_file(f, 'rst')
 except ImportError:
     print("warning: pypandoc module not found, could not convert Markdown to RST")
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
        {py27,py34,py35}-django110,
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
-       {py35,py36}-djangomaster
-       lint,docs
+       {py35,py36}-djangomaster,
+       lint,docs,readme,
 
 [travis:env]
 DJANGO =
@@ -42,3 +42,8 @@ commands = mkdocs build
 deps =
        -rrequirements/requirements-testing.txt
        -rrequirements/requirements-documentation.txt
+
+[testenv:readme]
+commands = ./setup.py check -rs
+deps =
+       -rrequirements/requirements-packaging.txt


### PR DESCRIPTION
Adds a CI build for checking README markdown => restructuredtext conversion.

Fixes #3817.

Requires a few changes:
- The HTML that centers the sponsor images needs to be removed.
- The italics around funding links needs to be removed
- Add hr between image and subsequent section