### PR TITLE
Non-required fields with 'allow_null=True' should not imply a default value

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -442,10 +442,10 @@ class Field(object):
         except (KeyError, AttributeError) as exc:
             if self.default is not empty:
                 return self.get_default()
-            if self.allow_null:
-                return None
             if not self.required:
                 raise SkipField()
+            if self.allow_null:
+                return None
             msg = (
                 'Got {exc_type} when attempting to get a value for field '
                 '`{field}` on serializer `{serializer}`.\nThe serializer '

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -372,6 +372,14 @@ class TestNotRequiredOutput:
         serializer.save()
         assert serializer.data == {'included': 'abc'}
 
+    def test_not_required_output_for_allow_null_field(self):
+        class ExampleSerializer(serializers.Serializer):
+            omitted = serializers.CharField(required=False, allow_null=True)
+            included = serializers.CharField()
+
+        serializer = ExampleSerializer({'included': 'abc'})
+        assert 'omitted' not in serializer.data
+
 
 class TestDefaultOutput:
     def setup(self):


### PR DESCRIPTION
Prior to the #5518, all fields with `required=False` and without a explicit default value were not included in the output.

After the patch, even non-required fields now had a default value, which is counter-intuitive if you look at the [`required`](http://www.django-rest-framework.org/api-guide/fields/#required) documentation, which says _Set to false if this field is not required to be present during deserialization_.

This PR restore the original `required=False` behaviour. Now, any `required=False` without a explicit default value should not be returned in the output.
However, it keeps the implicit `default=None` for required fields introduced in #5518.

Question I: Did I wrote the test in the correct class (`TestNotRequiredOutput`) or should it be in the `TestDefaultOutput` class?

Question II: Is there a reason that the implicit default `None` value for `allow_null` is not in the `Field.get_default` function? Looking at the `except` handling code, at first it did not _sound right_. 

Question III: Should I add to the documentation that `allow_null` implicitly set a `default=None` for required fields?

That issue is already closed and it is not my intention to reopen it, but it's a special case that I did not fully understand why not forcing a explicit default value. E.g, what about `allow_blank`? And `many=True`? Shouldn't they have a implicit default value too, using the same logic?