### PR TITLE
Update to use the Django 2.0 release in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
 deps =
         django110: Django>=1.10,<1.11
         django111: Django>=1.11,<2.0
-        django20: Django>=2.0rc1,<2.1
+        django20: Django>=2.0,<2.1
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
Was previously using a release candidate as the minimum version.