### PR TITLE
Improve composite field child errors

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1834,7 +1834,7 @@ class TestUnvalidatedListField(FieldValues):
 
 class TestDictField(FieldValues):
     """
-    Values for `ListField` with CharField as child.
+    Values for `DictField` with CharField as child.
     """
     valid_inputs = [
         ({'a': 1, 'b': '2', 3: 3}, {'a': '1', 'b': '2', '3': '3'}),
@@ -1868,7 +1868,7 @@ class TestDictField(FieldValues):
 
 class TestDictFieldWithNullChild(FieldValues):
     """
-    Values for `ListField` with allow_null CharField as child.
+    Values for `DictField` with allow_null CharField as child.
     """
     valid_inputs = [
         ({'a': None, 'b': '2', 3: 3}, {'a': None, 'b': '2', '3': '3'}),
@@ -1883,7 +1883,7 @@ class TestDictFieldWithNullChild(FieldValues):
 
 class TestUnvalidatedDictField(FieldValues):
     """
-    Values for `ListField` with no `child` argument.
+    Values for `DictField` with no `child` argument.
     """
     valid_inputs = [
         ({'a': 1, 'b': [4, 5, 6], 1: 123}, {'a': 1, 'b': [4, 5, 6], '1': 123}),

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1794,6 +1794,25 @@ class TestListField(FieldValues):
         assert exc_info.value.detail == ['Expected a list of items but got type "dict".']
 
 
+class TestNestedListField(FieldValues):
+    """
+    Values for nested `ListField` with IntegerField as child.
+    """
+    valid_inputs = [
+        ([[1, 2], [3]], [[1, 2], [3]]),
+        ([[]], [[]])
+    ]
+    invalid_inputs = [
+        (['not a list'], {0: ['Expected a list of items but got type "str".']}),
+        ([[1, 2, 'error'], ['error']], {0: {2: ['A valid integer is required.']}, 1: {0: ['A valid integer is required.']}}),
+        ([{'one': 'two'}], {0: ['Expected a list of items but got type "dict".']})
+    ]
+    outputs = [
+        ([[1, 2], [3]], [[1, 2], [3]]),
+    ]
+    field = serializers.ListField(child=serializers.ListField(child=serializers.IntegerField()))
+
+
 class TestEmptyListField(FieldValues):
     """
     Values for `ListField` with allow_empty=False flag.
@@ -1864,6 +1883,23 @@ class TestDictField(FieldValues):
         field = serializers.DictField(allow_null=True)
         output = field.run_validation(None)
         assert output is None
+
+
+class TestNestedDictField(FieldValues):
+    """
+    Values for nested `DictField` with CharField as child.
+    """
+    valid_inputs = [
+        ({0: {'a': 1, 'b': '2'}, 1: {3: 3}}, {'0': {'a': '1', 'b': '2'}, '1': {'3': '3'}}),
+    ]
+    invalid_inputs = [
+        ({0: {'a': 1, 'b': None}, 1: {'c': None}}, {'0': {'b': ['This field may not be null.']}, '1': {'c': ['This field may not be null.']}}),
+        ({0: 'not a dict'}, {'0': ['Expected a dictionary of items but got type "str".']}),
+    ]
+    outputs = [
+        ({0: {'a': 1, 'b': '2'}, 1: {3: 3}}, {'0': {'a': '1', 'b': '2'}, '1': {'3': '3'}}),
+    ]
+    field = serializers.DictField(child=serializers.DictField(child=serializers.CharField()))
 
 
 class TestDictFieldWithNullChild(FieldValues):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1767,7 +1767,7 @@ class TestListField(FieldValues):
     ]
     invalid_inputs = [
         ('not a list', ['Expected a list of items but got type "str".']),
-        ([1, 2, 'error'], ['A valid integer is required.']),
+        ([1, 2, 'error', 'error'], {2: ['A valid integer is required.'], 3: ['A valid integer is required.']}),
         ({'one': 'two'}, ['Expected a list of items but got type "dict".'])
     ]
     outputs = [
@@ -1840,7 +1840,7 @@ class TestDictField(FieldValues):
         ({'a': 1, 'b': '2', 3: 3}, {'a': '1', 'b': '2', '3': '3'}),
     ]
     invalid_inputs = [
-        ({'a': 1, 'b': None}, ['This field may not be null.']),
+        ({'a': 1, 'b': None, 'c': None}, {'b': ['This field may not be null.'], 'c': ['This field may not be null.']}),
         ('not a dict', ['Expected a dictionary of items but got type "str".']),
     ]
     outputs = [


### PR DESCRIPTION
Fixes #3274

This is an extension of the discussion in #5644. Errors raised on composite fields (`DictField` & `ListField`) are confusing, since child validation errors don't contain any indication of what index/key failed.

As stated by the [django docs](https://docs.djangoproject.com/en/2.0/ref/contrib/postgres/fields/#hstorefield), the hstore field accepts nulls as values.

```python
class Product(models.Model):
    attributes = HStoreField()

class ProductSerializer(serializers.ModelSerializer):
    class Meta:
        model = Product
        fields = ['attributes']
```

With the below input data, we currently exhibit the following error:

```python
>>> q = ProductSerializer(data={"attributes": {"first": "value", "second": None}})
>>> q.is_valid()
>>> q.errors
{'attributes': ['This field may not be null.']}
```

The above error is not helpful, since it fails to mention that this applies to the `"second"` key. The proposed solution is to nest the errors by index/key. 

before:
`{'attributes': ['This field may not be null.']}`

after:
`{'attributes': {'second': ["This field may not be null."]}}`

**TODO:**
- [x] Check if #3274 is fixed by this.
- [x] Test nested error handling
- [x] ~~Errors should be tested against HTML forms.~~ ListField/DictField inputs are non-functional.
