### PR TITLE
Add 'dist' build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,19 @@ matrix:
       - { python: "3.6", env: DJANGO=2.0 }
       - { python: "2.7", env: TOXENV=lint }
       - { python: "2.7", env: TOXENV=docs }
-      - python: "2.7"
+
+      - python: "3.6"
+        env: TOXENV=dist
+        script:
+          - python setup.py bdist_wheel
+          - tox --installpkg ./dist/djangorestframework-*.whl
+          - tox  # test sdist
+
+      - python: "3.6"
         env: TOXENV=readme
         addons:
           apt_packages: pandoc
+
     exclude:
       - { python: "2.7", env: DJANGO=master }
       - { python: "2.7", env: DJANGO=2.0 }

--- a/runtests.py
+++ b/runtests.py
@@ -16,8 +16,6 @@ FLAKE8_ARGS = ['rest_framework', 'tests']
 
 ISORT_ARGS = ['--recursive', '--check-only', '-o' 'uritemplate', '-p', 'tests', 'rest_framework', 'tests']
 
-sys.path.append(os.path.dirname(__file__))
-
 
 def exit_on_failure(ret, message=None):
     if ret:
@@ -83,6 +81,20 @@ if __name__ == "__main__":
         style = 'fast'
         run_flake8 = False
         run_isort = False
+
+    try:
+        # Remove the package root directory from `sys.path`, ensuring that rest_framework
+        # is imported from the installed site packages. Used for testing the distribution
+        sys.argv.remove('--no-pkgroot')
+    except ValueError:
+        pass
+    else:
+        sys.path.pop(0)
+
+        # import rest_framework before pytest re-adds the package root directory.
+        import rest_framework
+        package_dir = os.path.join(os.getcwd(), 'rest_framework')
+        assert not rest_framework.__file__.startswith(package_dir)
 
     if len(sys.argv) > 1:
         pytest_args = sys.argv[1:]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
        {py35,py36}-djangomaster,
-       lint,docs,readme,
+       dist,lint,docs,readme,
 
 [travis:env]
 DJANGO =
@@ -18,6 +18,7 @@ DJANGO =
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage -rw
+envdir = {toxworkdir}/venvs/{envname}
 setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
@@ -26,6 +27,13 @@ deps =
         django111: Django>=1.11,<2.0
         django20: Django>=2.0,<2.1
         djangomaster: https://github.com/django/django/archive/master.tar.gz
+        -rrequirements/requirements-testing.txt
+        -rrequirements/requirements-optionals.txt
+
+[testenv:dist]
+commands = ./runtests.py --fast {posargs} --no-pkgroot -rw
+deps =
+        django
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt
 


### PR DESCRIPTION
## Description

This is a continuation of #5624, proposing that the package be moved under a `src` dir. To recap: 

> `tox` *does* create and install the package distribution into the test environment, however this conflicts with the `rest_framework` package that's located on the current path. Because the distribution and local files conflict, you cannot effectively test the distribution's packaged files. eg, the distribution may not be correctly configured (missing templates/static files), but the files on the local path do have them, so the tests pass erroneously.
>
> The solution is to move the package off of the path (usually into a `src` directory), so that the local files are not importable.

This iteration fixes issues with coverage data. Most of the builds do use the local files via an editable install. As such, all coverage data is under `/src/rest_framework` instead of spread across multiple venvs. Testing the distribution is done wit a single build that doesn't collect coverage data. 

As far as I can tell, the only potential downside is that git blame will be hampered a bit, given the file moves. 

## Changes

- ~~Moved package under `src` dir~~
- Added `dist` build.
- Updated support builds (lint, docs) to use python 3.6