### PR TITLE
Drop Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
 sudo: false
 
 env:
-    - DJANGO=1.10
     - DJANGO=1.11
     - DJANGO=2.0
     - DJANGO=2.1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 # Requirements
 
 * Python (2.7, 3.4, 3.5, 3.6)
-* Django (1.10, 1.11, 2.0)
+* Django (1.11, 2.0)
 
 # Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ continued development by **[signing up for a paid plan][funding]**.
 REST framework requires the following:
 
 * Python (2.7, 3.4, 3.5, 3.6)
-* Django (1.10, 1.11, 2.0)
+* Django (1.11, 2.0)
 
 The following packages are optional:
 

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,5 +1,4 @@
 # Optional packages which may be used with REST framework.
-pytz==2017.2
 psycopg2-binary==2.7.4
 markdown==2.6.4
 django-guardian==1.4.9

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -6,13 +6,12 @@ from __future__ import unicode_literals
 import base64
 import binascii
 
-from django.contrib.auth import get_user_model
+from django.contrib.auth import authenticate, get_user_model
 from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.six import text_type
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import HTTP_HEADER_ENCODING, exceptions
-from rest_framework.compat import authenticate
 
 
 def get_authorization_header(request):

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -1,7 +1,7 @@
+from django.contrib.auth import authenticate
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
-from rest_framework.compat import authenticate
 
 
 class AuthTokenSerializer(serializers.Serializer):

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -5,7 +5,6 @@ versions of Django/Python, and compatibility wrappers around optional packages.
 
 from __future__ import unicode_literals
 
-import django
 from django.conf import settings
 from django.core import validators
 from django.utils import six
@@ -242,12 +241,6 @@ else:
     def md_filter_add_syntax_highlight(md):
         return False
 
-# pytz is required from Django 1.11. Remove when dropping Django 1.10 support.
-try:
-    import pytz  # noqa
-    from pytz.exceptions import InvalidTimeError
-except ImportError:
-    InvalidTimeError = Exception
 
 # Django 1.x url routing syntax. Remove when dropping Django 1.11 support.
 try:
@@ -298,11 +291,3 @@ class MinLengthValidator(CustomValidatorMessage, validators.MinLengthValidator):
 
 class MaxLengthValidator(CustomValidatorMessage, validators.MaxLengthValidator):
     pass
-
-
-def authenticate(request=None, **credentials):
-    from django.contrib.auth import authenticate
-    if django.VERSION < (1, 11):
-        return authenticate(**credentials)
-    else:
-        return authenticate(request=request, **credentials)

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -29,11 +29,12 @@ from django.utils.functional import lazy
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.timezone import utc
 from django.utils.translation import ugettext_lazy as _
+from pytz.exceptions import InvalidTimeError
 
 from rest_framework import ISO_8601
 from rest_framework.compat import (
-    InvalidTimeError, MaxLengthValidator, MaxValueValidator,
-    MinLengthValidator, MinValueValidator, unicode_repr, unicode_to_repr
+    MaxLengthValidator, MaxValueValidator, MinLengthValidator,
+    MinValueValidator, unicode_repr, unicode_to_repr
 )
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.settings import api_settings

--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -13,22 +13,11 @@ You should make sure your authentication settings include `SessionAuthentication
 """
 from __future__ import unicode_literals
 
-import django
 from django.conf.urls import url
 from django.contrib.auth import views
 
-if django.VERSION < (1, 11):
-    login = views.login
-    login_kwargs = {'template_name': 'rest_framework/login.html'}
-    logout = views.logout
-else:
-    login = views.LoginView.as_view(template_name='rest_framework/login.html')
-    login_kwargs = {}
-    logout = views.LogoutView.as_view()
-
-
 app_name = 'rest_framework'
 urlpatterns = [
-    url(r'^login/$', login, login_kwargs, name='login'),
-    url(r'^logout/$', logout, name='logout'),
+    url(r'^login/$', views.LoginView.as_view(template_name='rest_framework/login.html'), name='login'),
+    url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ skip=.tox
 atomic=true
 multi_line_output=5
 known_standard_library=types
-known_third_party=pytest,_pytest,django
+known_third_party=pytest,_pytest,django,pytz
 known_first_party=rest_framework
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,6 +6,7 @@ import uuid
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
 
 import pytest
+import pytz
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import QueryDict
 from django.test import TestCase, override_settings
@@ -13,13 +14,8 @@ from django.utils import six
 from django.utils.timezone import activate, deactivate, override, utc
 
 import rest_framework
-from rest_framework import compat, exceptions, serializers
+from rest_framework import exceptions, serializers
 from rest_framework.fields import DjangoImageField, is_simple_callable
-
-try:
-    import pytz
-except ImportError:
-    pytz = None
 
 try:
     import typings
@@ -1309,7 +1305,6 @@ class TestNaiveDateTimeField(FieldValues):
     field = serializers.DateTimeField(default_timezone=None)
 
 
-@pytest.mark.skipif(pytz is None, reason='pytz not installed')
 class TestTZWithDateTimeField(FieldValues):
     """
     Valid and invalid values for `DateTimeField` when not using UTC as the timezone.
@@ -1332,7 +1327,6 @@ class TestTZWithDateTimeField(FieldValues):
         cls.field = serializers.DateTimeField(default_timezone=kolkata)
 
 
-@pytest.mark.skipif(pytz is None, reason='pytz not installed')
 @override_settings(TIME_ZONE='UTC', USE_TZ=True)
 class TestDefaultTZDateTimeField(TestCase):
     """
@@ -1392,7 +1386,7 @@ class TestNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     class MockTimezone:
         @staticmethod
         def localize(value, is_dst):
-            raise compat.InvalidTimeError()
+            raise pytz.InvalidTimeError()
 
         def __str__(self):
             return 'America/New_York'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-       {py27,py34,py35}-django110,
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
        {py35,py36}-django21
@@ -9,7 +8,6 @@ envlist =
 
 [travis:env]
 DJANGO =
-    1.10: django110
     1.11: django111
     2.0: django20
     2.1: django21
@@ -22,7 +20,6 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django110: Django>=1.10,<1.11
         django111: Django>=1.11,<2.0
         django20: Django>=2.0,<2.1
         django21: Django>=2.1b1,<2.2


### PR DESCRIPTION
Per the [official recommendation](https://docs.djangoproject.com/en/2.0/releases/2.0/#python-compatibility), we should drop 1.10 support now that 2.0 has been released. 