### PR TITLE
Add docs note re generated BooleanField being `required=False` 

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -124,7 +124,7 @@ A boolean representation.
 
 When using HTML encoded form input be aware that omitting a value will always be treated as setting a field to `False`, even if it has a `default=True` option specified. This is because HTML checkbox inputs represent the unchecked state by omitting the value, so REST framework treats omission as if it is an empty checkbox input.
 
-Note that default `BooleanField` instances will be generated with a `required=False` option (since Django `models.BooleanField` is always `blank=True`). For JSON-only APIs you may wish explicitly declare BooleanFields in order to control this. ([An example configuring serialiser generation to use a `BooleanField` subclass with `required=True` may be found here][required-by-default-boolean-field].)
+Note that default `BooleanField` instances will be generated with a `required=False` option (since Django `models.BooleanField` is always `blank=True`). If you want to change this behaviour explicitly declare the `BooleanField` on the serializer class.
 
 Corresponds to `django.db.models.fields.BooleanField`.
 
@@ -684,4 +684,3 @@ The [django-rest-framework-hstore][django-rest-framework-hstore] package provide
 [django-rest-framework-hstore]: https://github.com/djangonauts/django-rest-framework-hstore
 [django-hstore]: https://github.com/djangonauts/django-hstore
 [python-decimal-rounding-modes]: https://docs.python.org/3/library/decimal.html#rounding-modes
-[required-by-default-boolean-field]: http://notes.noumenal.es/2017/12/13/required-by-default.html

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -124,7 +124,7 @@ A boolean representation.
 
 When using HTML encoded form input be aware that omitting a value will always be treated as setting a field to `False`, even if it has a `default=True` option specified. This is because HTML checkbox inputs represent the unchecked state by omitting the value, so REST framework treats omission as if it is an empty checkbox input.
 
-Note that default `BooleanField` instances will be generated with a `required=False` option (since Django `models.BooleanField` is always `blank=True`). For JSON-only APIs you may wish explicitly declare BooleanFields in order to control this.
+Note that default `BooleanField` instances will be generated with a `required=False` option (since Django `models.BooleanField` is always `blank=True`). For JSON-only APIs you may wish explicitly declare BooleanFields in order to control this. ([An example configuring serialiser generation to use a `BooleanField` subclass with `required=True` may be found here][required-by-default-boolean-field].)
 
 Corresponds to `django.db.models.fields.BooleanField`.
 

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -124,6 +124,8 @@ A boolean representation.
 
 When using HTML encoded form input be aware that omitting a value will always be treated as setting a field to `False`, even if it has a `default=True` option specified. This is because HTML checkbox inputs represent the unchecked state by omitting the value, so REST framework treats omission as if it is an empty checkbox input.
 
+Note that default `BooleanField` instances will be generated with a `required=False` option (since Django `models.BooleanField` is always `blank=True`). For JSON-only APIs you may wish explicitly declare BooleanFields in order to control this.
+
 Corresponds to `django.db.models.fields.BooleanField`.
 
 **Signature:** `BooleanField()`
@@ -682,3 +684,4 @@ The [django-rest-framework-hstore][django-rest-framework-hstore] package provide
 [django-rest-framework-hstore]: https://github.com/djangonauts/django-rest-framework-hstore
 [django-hstore]: https://github.com/djangonauts/django-hstore
 [python-decimal-rounding-modes]: https://docs.python.org/3/library/decimal.html#rounding-modes
+[required-by-default-boolean-field]: http://notes.noumenal.es/2017/12/13/required-by-default.html

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -588,7 +588,7 @@ Normally if a `ModelSerializer` does not generate the fields you need by default
 
 ### `.serializer_field_mapping`
 
-A mapping of Django model classes to REST framework serializer classes. You can override this mapping to alter the default serializer classes that should be used for each model class. ([An example using `serializer_field_mapping` with a `BooleanField` subclass may be found here][required-by-default-boolean-field].)
+A mapping of Django model classes to REST framework serializer classes. You can override this mapping to alter the default serializer classes that should be used for each model class.
 
 ### `.serializer_related_field`
 
@@ -1181,5 +1181,3 @@ The [drf-writable-nested][drf-writable-nested] package provides writable nested 
 [drf-serializer-extensions]: https://github.com/evenicoulddoit/django-rest-framework-serializer-extensions
 [djangorestframework-queryfields]: http://djangorestframework-queryfields.readthedocs.io/
 [drf-writable-nested]: http://github.com/beda-software/drf-writable-nested
-[required-by-default-boolean-field]: http://notes.noumenal.es/2017/12/13/required-by-default.html
-

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -588,7 +588,7 @@ Normally if a `ModelSerializer` does not generate the fields you need by default
 
 ### `.serializer_field_mapping`
 
-A mapping of Django model classes to REST framework serializer classes. You can override this mapping to alter the default serializer classes that should be used for each model class.
+A mapping of Django model classes to REST framework serializer classes. You can override this mapping to alter the default serializer classes that should be used for each model class. ([An example using `serializer_field_mapping` with a `BooleanField` subclass may be found here][required-by-default-boolean-field].)
 
 ### `.serializer_related_field`
 
@@ -1181,3 +1181,5 @@ The [drf-writable-nested][drf-writable-nested] package provides writable nested 
 [drf-serializer-extensions]: https://github.com/evenicoulddoit/django-rest-framework-serializer-extensions
 [djangorestframework-queryfields]: http://djangorestframework-queryfields.readthedocs.io/
 [drf-writable-nested]: http://github.com/beda-software/drf-writable-nested
+[required-by-default-boolean-field]: http://notes.noumenal.es/2017/12/13/required-by-default.html
+


### PR DESCRIPTION
Closes #5664

1. Explains/explicitly states that BooleanField is generated with `required=False`, because `models.BooleanField` is always `blank=True`. This has come up a few times so should (help to) clear up confusions.
2. Additionally adds link to [a worked example configuring serialiser generation to use a BooleanField subclass with `required=True`](http://notes.noumenal.es/2017/12/13/required-by-default.html). This should be helpful, as it's not hard but it's not trivial either.
3. Finally adds same link to `.serializer_field_mapping` docs, since an example (especially needing to use `deepcopy`) may be handy there too. 

