### PR TITLE
Fix `override_settings` compat

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
-from rest_framework.settings import APISettings
+from rest_framework.settings import APISettings, api_settings
 
 
 class TestSettings(TestCase):
@@ -27,6 +27,23 @@ class TestSettings(TestCase):
             APISettings({
                 'MAX_PAGINATE_BY': 100
             })
+
+    def test_compatibility_with_override_settings(self):
+        """
+        Ref #5658 & #2466: Documented usage of api_settings
+        is bound at import time:
+
+            from rest_framework.settings import api_settings
+
+        setting_changed signal hook must ensure bound instance
+        is refreshed.
+        """
+        assert api_settings.PAGE_SIZE is None, "Checking a known default should be None"
+
+        with override_settings(REST_FRAMEWORK={'PAGE_SIZE': 10}):
+            assert api_settings.PAGE_SIZE == 10, "Setting should have been updated"
+
+        assert api_settings.PAGE_SIZE is None, "Setting should have been restored"
 
 
 class TestSettingTypes(TestCase):


### PR DESCRIPTION
Closes #2466 Ref #5658

As per #2466, the `override_settings` integration was updating the APISettings object correctly but was not functioning as expected since the documented usage `from rest_framework.settings import api_settings` is bound at import time.

This PR adds a (failing) test checking compat and adjusts the code to refresh APISettings in place, rather than replace the instance. `override_settings` then works as expected. 

Fix was suggested by @daggaz — thanks for that! (PRs always welcome! 🙂)