### PR TITLE
RegexField should support unicode when use regex string

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -806,6 +806,8 @@ class RegexField(CharField):
 
     def __init__(self, regex, **kwargs):
         super(RegexField, self).__init__(**kwargs)
+        if isinstance(regex, six.string_types):
+            regex = re.compile(regex, re.UNICODE)
         validator = RegexValidator(regex, message=self.error_messages['invalid'])
         self.validators.append(validator)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -709,6 +709,20 @@ class TestiCompiledRegexField(FieldValues):
     field = serializers.RegexField(regex=re.compile('[a-z][0-9]'))
 
 
+class TestUnicodeRegexField(FieldValues):
+    """
+    Valid and invalid values for `RegexField`.
+    """
+    valid_inputs = {
+        u'hello\u4f60\u597d': u'hello\u4f60\u597d'
+    }
+    invalid_inputs = {
+        u'hello\u4f60\u597d@': ["This value does not match the required pattern."]
+    }
+    outputs = {}
+    field = serializers.RegexField(regex='^\w*$')
+
+
 class TestSlugField(FieldValues):
     """
     Valid and invalid values for `SlugField`.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
