### PR TITLE
Remove vestigial `BaseSerializer` exception

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -784,8 +784,7 @@ def raise_errors_on_nested_writes(method_name, serializer, validated_data):
     #     profile = ProfileSerializer()
     assert not any(
         isinstance(field, BaseSerializer) and
-        (field.source in validated_data) and
-        isinstance(validated_data[field.source], (list, dict))
+        (field.source in validated_data)
         for field in serializer._writable_fields
     ), (
         'The `.{method_name}()` method does not support writable nested '


### PR DESCRIPTION
Per decision in #5666, DRF should raise an error on efforts to write to a nested serializer.  This PR removes an exception that was allowing writable nested serialization in some cases.