### PR TITLE
Localize DateTime field representations

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -27,7 +27,7 @@ from django.utils.encoding import is_protected_type, smart_text
 from django.utils.formats import localize_input, sanitize_separators
 from django.utils.functional import lazy
 from django.utils.ipv6 import clean_ipv6_address
-from django.utils.timezone import utc
+from django.utils.timezone import utc, localtime
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import ISO_8601
@@ -1211,6 +1211,9 @@ class DateTimeField(Field):
 
         if output_format is None or isinstance(value, six.string_types):
             return value
+
+        if api_settings.LOCALIZE_DATETIME_REPRESENTATIONS:
+            value = localtime(value)
 
         if output_format.lower() == ISO_8601:
             value = self.enforce_timezone(value)


### PR DESCRIPTION
This pull request modifies fields.DateTimeField.to_representation() to check a new api_settings value, and localize the DateTime if the value is truthy.

I was surprised that DRF didn't do this already when the timezone for a request has been activated. Googling around brought me to people who are subclassing the DateTime field and adding this functionality, so I thought built-in localization of datetimes might be useful.