### PR TITLE
Fix typo in docstring

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -54,7 +54,7 @@ class SimpleRateThrottle(BaseThrottle):
     A simple cache implementation, that only requires `.get_cache_key()`
     to be overridden.
 
-    The rate (requests / seconds) is set by a `throttle` attribute on the View
+    The rate (requests / seconds) is set by a `rate` attribute on the View
     class.  The attribute is a string of the form 'number_of_requests/period'.
 
     Period should be one of: ('s', 'sec', 'm', 'min', 'h', 'hour', 'd', 'day')


### PR DESCRIPTION
## Description

Title says it all. I was reading the implementation of `SimpleRateThrottle` in order to set custom rate limit for specific API and I found the typo.
