### PR TITLE
Add UNAUTHENTICATED_USER = None note

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -202,6 +202,8 @@ Default: `'version'`
 #### UNAUTHENTICATED_USER
 
 The class that should be used to initialize `request.user` for unauthenticated requests.
+(If removing authentication entirely, e.g. by removing `django.contrib.auth` from
+`INSTALLED_APPS`, set `UNAUTHENTICATED_USER` to `None`.)
 
 Default: `django.contrib.auth.models.AnonymousUser`
 


### PR DESCRIPTION
When removing authentication entirely you cannot import `django.contrib.auth.models.AnonymousUser`

Closes #3494

Adds a note to the `UNAUTHENTICATED_USER` setting docs saying to set to `None`. 

* #3494 has been sat there forever. It's never going to be addressed directly, so beyond this I don't see what we can do. 
* I think removing `django.contrib.auth` is sufficiently beyond the core case that we can expect users to have discovered this (or do so with a quick search). 