### PR TITLE
Add link to Classy DRF in docs

### DIFF
--- a/docs/api-guide/views.md
+++ b/docs/api-guide/views.md
@@ -42,6 +42,13 @@ For example:
             usernames = [user.username for user in User.objects.all()]
             return Response(usernames)
 
+---
+
+**Note**: The full methods, attributes on, and relations between Django REST Framework's `APIView`, `GenericAPIView`, various `Mixins`, and `Viewsets` can be initially complex. In addition to the documentation here, the [Classy Django REST Framework][classy-drf] resource provides a browsable reference, with full methods and attributes, for each of Django REST Framework's class-based views.
+
+---
+
+
 ## API policy attributes
 
 The following attributes control the pluggable aspects of API views.
@@ -212,3 +219,5 @@ You may pass `None` in order to exclude the view from schema generation.
 [settings]: settings.md
 [throttling]: throttling.md
 [schemas]: schemas.md
+[classy-drf]: http://www.cdrf.co
+


### PR DESCRIPTION
Closes #5636 as per https://github.com/encode/django-rest-framework/issues/5636#issuecomment-348143281

Adds Note linking to Classy DRF near beginning of `Views` docs. This should be prominent enough. 