### PR TITLE
Fix URL pattern parsing in schema generation

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -32,7 +32,7 @@ except ImportError:
 def get_regex_pattern(urlpattern):
     if hasattr(urlpattern, 'pattern'):
         # Django 2.0
-        return urlpattern.pattern.regex.pattern
+        return str(urlpattern.pattern)
     else:
         # Django < 2.0
         return urlpattern.regex.pattern
@@ -254,6 +254,14 @@ try:
     from pytz.exceptions import InvalidTimeError
 except ImportError:
     InvalidTimeError = Exception
+
+# Django 1.x url routing syntax. Remove when dropping Django 1.11 support.
+try:
+    from django.urls import include, path, re_path # noqa
+except ImportError:
+    from django.conf.urls import include, url # noqa
+    path = None
+    re_path = url
 
 
 # `separators` argument to `json.dumps()` differs between 2.x and 3.x

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import re
 from collections import MutableMapping, OrderedDict
 
-import coreapi
 import pytest
 from django.conf.urls import include, url
 from django.core.cache import cache
@@ -15,6 +14,7 @@ from django.utils import six
 from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
+import coreapi
 from rest_framework import permissions, serializers, status
 from rest_framework.renderers import (
     AdminRenderer, BaseRenderer, BrowsableAPIRenderer, DocumentationRenderer,

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import re
 from collections import MutableMapping, OrderedDict
 
+import coreapi
 import pytest
 from django.conf.urls import include, url
 from django.core.cache import cache
@@ -14,7 +15,6 @@ from django.utils import six
 from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
-import coreapi
 from rest_framework import permissions, serializers, status
 from rest_framework.renderers import (
     AdminRenderer, BaseRenderer, BrowsableAPIRenderer, DocumentationRenderer,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,7 +1,6 @@
 import unittest
 
 import pytest
-
 from django.conf.urls import include, url
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
@@ -27,7 +26,6 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from .models import BasicModel
-
 
 factory = APIRequestFactory()
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pytest
+
 from django.conf.urls import include, url
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
@@ -9,7 +10,7 @@ from django.test import TestCase, override_settings
 from rest_framework import (
     filters, generics, pagination, permissions, serializers
 )
-from rest_framework.compat import coreapi, coreschema, get_regex_pattern
+from rest_framework.compat import coreapi, coreschema, get_regex_pattern, path
 from rest_framework.decorators import (
     api_view, detail_route, list_route, schema
 )
@@ -26,6 +27,7 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from .models import BasicModel
+
 
 factory = APIRequestFactory()
 
@@ -316,6 +318,59 @@ class TestSchemaGenerator(TestCase):
             url(r'^example/?$', ExampleListView.as_view()),
             url(r'^example/(?P<pk>\d+)/?$', ExampleDetailView.as_view()),
             url(r'^example/(?P<pk>\d+)/sub/?$', ExampleDetailView.as_view()),
+        ]
+
+    def test_schema_for_regular_views(self):
+        """
+        Ensure that schema generation works for APIView classes.
+        """
+        generator = SchemaGenerator(title='Example API', patterns=self.patterns)
+        schema = generator.get_schema()
+        expected = coreapi.Document(
+            url='',
+            title='Example API',
+            content={
+                'example': {
+                    'create': coreapi.Link(
+                        url='/example/',
+                        action='post',
+                        fields=[]
+                    ),
+                    'list': coreapi.Link(
+                        url='/example/',
+                        action='get',
+                        fields=[]
+                    ),
+                    'read': coreapi.Link(
+                        url='/example/{id}/',
+                        action='get',
+                        fields=[
+                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                        ]
+                    ),
+                    'sub': {
+                        'list': coreapi.Link(
+                            url='/example/{id}/sub/',
+                            action='get',
+                            fields=[
+                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            ]
+                        )
+                    }
+                }
+            }
+        )
+        assert schema == expected
+
+
+@unittest.skipUnless(coreapi, 'coreapi is not installed')
+@unittest.skipUnless(path, 'needs Django 2')
+class TestSchemaGeneratorDjango2(TestCase):
+    def setUp(self):
+        self.patterns = [
+            path('example/', ExampleListView.as_view()),
+            path('example/<int:pk>/', ExampleDetailView.as_view()),
+            path('example/<int:pk>/sub/', ExampleDetailView.as_view()),
         ]
 
     def test_schema_for_regular_views(self):


### PR DESCRIPTION
- Call `str(pattern)` to get non-escaped route.
- Strip converters from route to comply with uritemplate format.  Background: https://github.com/encode/django-rest-framework/issues/5675#issuecomment-352829363

Closes #5675
