### PR TITLE
Include woff2 static files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include LICENSE.md
-recursive-include rest_framework/static *.js *.css *.png *.eot *.svg *.ttf *.woff
+recursive-include rest_framework/static *.js *.css *.png *.eot *.svg *.ttf *.woff *.woff2
 recursive-include rest_framework/templates *.html schema.js
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
The `.woff2` fonts aren't being included in the release, and that's causing failures for my build using `whitenoise.storage.CompressedManifestStaticFilesStorage`, which looks for all referenced files from CSS files and compresses them with a static hash on the filename.
