### PR TITLE
Fix typo to bring back locale files to installed files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ include README.md
 include LICENSE.md
 recursive-include rest_framework/static *.js *.css *.png *.ico *.eot *.svg *.ttf *.woff *.woff2
 recursive-include rest_framework/templates *.html schema.js
-recursice-include rest_framework/locale *.mo
+recursive-include rest_framework/locale *.mo
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
Resolves #5695

(Tiny typo in https://github.com/encode/django-rest-framework/pull/5696)