### PR TITLE
Test staticfiles

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 from __future__ import print_function
 
-import os
 import subprocess
 import sys
 
@@ -81,20 +80,6 @@ if __name__ == "__main__":
         style = 'fast'
         run_flake8 = False
         run_isort = False
-
-    try:
-        # Remove the package root directory from `sys.path`, ensuring that rest_framework
-        # is imported from the installed site packages. Used for testing the distribution
-        sys.argv.remove('--no-pkgroot')
-    except ValueError:
-        pass
-    else:
-        sys.path.pop(0)
-
-        # import rest_framework before pytest re-adds the package root directory.
-        import rest_framework
-        package_dir = os.path.join(os.getcwd(), 'rest_framework')
-        assert not rest_framework.__file__.startswith(package_dir)
 
     if len(sys.argv) > 1:
         pytest_args = sys.argv[1:]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,17 @@
+import os
+import sys
+
 import django
 
 
-def pytest_configure():
+def pytest_addoption(parser):
+    parser.addoption('--no-pkgroot', action='store_true', default=False,
+                     help='Remove package root directory from sys.path, ensuring that '
+                          'rest_framework is imported from the installed site-packages. '
+                          'Used for testing the distribution.')
+
+
+def pytest_configure(config):
     from django.conf import settings
 
     settings.configure(
@@ -63,5 +73,13 @@ def pytest_configure():
         settings.INSTALLED_APPS += (
             'guardian',
         )
+
+    if config.getoption('--no-pkgroot'):
+        sys.path.pop(0)
+
+        # import rest_framework before pytest re-adds the package root directory.
+        import rest_framework
+        package_dir = os.path.join(os.getcwd(), 'rest_framework')
+        assert not rest_framework.__file__.startswith(package_dir)
 
     django.setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import django
+
+
 def pytest_configure():
     from django.conf import settings
 
@@ -61,8 +64,4 @@ def pytest_configure():
             'guardian',
         )
 
-    try:
-        import django
-        django.setup()
-    except AttributeError:
-        pass
+    django.setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,6 @@
 def pytest_configure():
     from django.conf import settings
 
-    MIDDLEWARE = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-    )
-
     settings.configure(
         DEBUG_PROPAGATE_EXCEPTIONS=True,
         DATABASES={
@@ -31,8 +24,12 @@ def pytest_configure():
                 }
             },
         ],
-        MIDDLEWARE=MIDDLEWARE,
-        MIDDLEWARE_CLASSES=MIDDLEWARE,
+        MIDDLEWARE=(
+            'django.middleware.common.CommonMiddleware',
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+        ),
         INSTALLED_APPS=(
             'django.contrib.auth',
             'django.contrib.contenttypes',

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
         -rrequirements/requirements-optionals.txt
 
 [testenv:dist]
-commands = ./runtests.py --fast {posargs} --no-pkgroot -rw
+commands = ./runtests.py --fast {posargs} --no-pkgroot --staticfiles -rw
 deps =
         django
         -rrequirements/requirements-testing.txt


### PR DESCRIPTION
Test for #5692. This is committed in the same vein as #5700, which is based off of d12005cf902e3969b5002593eab83bb63feda840 (added the dist build). Tests will fail locally (as expected), but the merge commit in CI causes this to pass (as expected, since master contains the fixed MANIFEST.in).

By default `ManifestStaticFilesStorage` is strict in that missing static files will raise exceptions during the `collectstatic` call. The missing .woff2 and .ico files would have been caught by this.