### PR TITLE
Disable HTML inputs for dict/list fields

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -320,6 +320,12 @@ class HTMLFormRenderer(BaseRenderer):
         serializers.ListSerializer: {
             'base_template': 'list_fieldset.html'
         },
+        serializers.ListField: {
+            'base_template': 'list_field.html'
+        },
+        serializers.DictField: {
+            'base_template': 'dict_field.html'
+        },
         serializers.FilePathField: {
             'base_template': 'select.html',
         },

--- a/rest_framework/templates/rest_framework/horizontal/dict_field.html
+++ b/rest_framework/templates/rest_framework/horizontal/dict_field.html
@@ -1,0 +1,11 @@
+<div class="form-group">
+  {% if field.label %}
+    <label class="col-sm-2 control-label {% if style.hide_label %}sr-only{% endif %}">
+      {{ field.label }}
+    </label>
+  {% endif %}
+
+  <div class="col-sm-10">
+    <p class="form-control-static">Dictionaries are not currently supported in HTML input.</p>
+  </div>
+</div>

--- a/rest_framework/templates/rest_framework/horizontal/list_field.html
+++ b/rest_framework/templates/rest_framework/horizontal/list_field.html
@@ -1,0 +1,11 @@
+<div class="form-group">
+  {% if field.label %}
+    <label class="col-sm-2 control-label {% if style.hide_label %}sr-only{% endif %}">
+      {{ field.label }}
+    </label>
+  {% endif %}
+
+  <div class="col-sm-10">
+    <p class="form-control-static">Lists are not currently supported in HTML input.</p>
+  </div>
+</div>

--- a/rest_framework/templates/rest_framework/inline/dict_field.html
+++ b/rest_framework/templates/rest_framework/inline/dict_field.html
@@ -1,0 +1,9 @@
+<div class="form-group">
+  {% if field.label %}
+    <label class="sr-only">
+      {{ field.label }}
+    </label>
+  {% endif %}
+
+  <p class="form-control-static">Dictionaries are not currently supported in HTML input.</p>
+</div>

--- a/rest_framework/templates/rest_framework/inline/list_field.html
+++ b/rest_framework/templates/rest_framework/inline/list_field.html
@@ -1,0 +1,9 @@
+<div class="form-group">
+  {% if field.label %}
+    <label class="sr-only">
+      {{ field.label }}
+    </label>
+  {% endif %}
+
+  <p class="form-control-static">Lists are not currently supported in HTML input.</p>
+</div>

--- a/rest_framework/templates/rest_framework/vertical/dict_field.html
+++ b/rest_framework/templates/rest_framework/vertical/dict_field.html
@@ -1,0 +1,7 @@
+<div class="form-group">
+  {% if field.label %}
+    <label {% if style.hide_label %}class="sr-only"{% endif %}>{{ field.label }}</label>
+  {% endif %}
+
+  <p class="form-control-static">Dictionaries are not currently supported in HTML input.</p>
+</div>

--- a/rest_framework/templates/rest_framework/vertical/list_field.html
+++ b/rest_framework/templates/rest_framework/vertical/list_field.html
@@ -1,0 +1,7 @@
+<div class="form-group">
+  {% if field.label %}
+    <label {% if style.hide_label %}class="sr-only"{% endif %}>{{ field.label }}</label>
+  {% endif %}
+
+  <p class="form-control-static">Lists are not currently supported in HTML input.</p>
+</div>


### PR DESCRIPTION
`ListField` & `DictField` do not seem to have proper HTML form support. Until they do, it would make sense to render a disabled form input, similar to how nested list serializers are currently handled.

Is there any reason not to disable these inputs?

Additionally, I would add tests for this, but I don't see any relevant tests for serializer form rendering.