### PR TITLE
Formalize URLPatternsTestCase

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -292,7 +292,7 @@ similar way as with `RequestsClient`.
 
 ---
 
-# Test cases
+# API Test cases
 
 REST framework includes the following test case classes, that mirror the existing Django test case classes, but use `APIClient` instead of Django's default `Client`.
 
@@ -321,6 +321,32 @@ You can use any of REST framework's test case classes as you would for the regul
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             self.assertEqual(Account.objects.count(), 1)
             self.assertEqual(Account.objects.get().name, 'DabApps')
+
+---
+
+# URLPatternsTestCase
+
+REST framework also provides a test case class for isolating `urlpatterns` on a per-class basis. Note that this inherits from Django's `SimpleTestCase`, and will most likely need to be mixed with another test case class.
+
+## Example
+
+    from django.urls import include, path, reverse
+    from rest_framework.test import APITestCase, URLPatternsTestCase
+
+
+    class AccountTests(APITestCase, URLPatternsTestCase):
+        urlpatterns = [
+            path('api/', include('api.urls')),
+        ]
+
+        def test_create_account(self):
+            """
+            Ensure we can create a new account object.
+            """
+            url = reverse('account-list')
+            response = self.client.get(url, format='json')
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(response.data), 1)
 
 ---
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -12,7 +12,7 @@ from rest_framework import fields, serializers
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.test import (
-    APIClient, APIRequestFactory, force_authenticate
+    APIClient, APIRequestFactory, URLPatternsTestCase, force_authenticate
 )
 
 
@@ -283,3 +283,30 @@ class TestAPIRequestFactory(TestCase):
             content_type='application/json',
         )
         assert request.META['CONTENT_TYPE'] == 'application/json'
+
+
+class TestUrlPatternTestCase(URLPatternsTestCase):
+    urlpatterns = [
+        url(r'^$', view),
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        assert urlpatterns is not cls.urlpatterns
+        super(TestUrlPatternTestCase, cls).setUpClass()
+        assert urlpatterns is cls.urlpatterns
+
+    @classmethod
+    def tearDownClass(cls):
+        assert urlpatterns is cls.urlpatterns
+        super(TestUrlPatternTestCase, cls).tearDownClass()
+        assert urlpatterns is not cls.urlpatterns
+
+    def test_urlpatterns(self):
+        assert self.client.get('/').status_code == 200
+
+
+class TestExistingPatterns(TestCase):
+    def test_urlpatterns(self):
+        # sanity test to ensure that this test module does not have a '/' route
+        assert self.client.get('/').status_code == 404

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -7,31 +7,10 @@ from rest_framework.decorators import APIView
 from rest_framework.relations import PKOnlyObject
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.test import APIRequestFactory, APITestCase
+from rest_framework.test import (
+    APIRequestFactory, APITestCase, URLPatternsTestCase
+)
 from rest_framework.versioning import NamespaceVersioning
-
-
-@override_settings(ROOT_URLCONF='tests.test_versioning')
-class URLPatternsTestCase(APITestCase):
-    """
-    Isolates URL patterns used during testing on the test class itself.
-    For example:
-
-    class MyTestCase(URLPatternsTestCase):
-        urlpatterns = [
-            ...
-        ]
-
-        def test_something(self):
-            ...
-    """
-    def setUp(self):
-        global urlpatterns
-        urlpatterns = self.urlpatterns
-
-    def tearDown(self):
-        global urlpatterns
-        urlpatterns = []
 
 
 class RequestVersionView(APIView):
@@ -163,7 +142,7 @@ class TestRequestVersion:
         assert response.data == {'version': None}
 
 
-class TestURLReversing(URLPatternsTestCase):
+class TestURLReversing(URLPatternsTestCase, APITestCase):
     included = [
         url(r'^namespaced/$', dummy_view, name='another'),
         url(r'^example/(?P<pk>\d+)/$', dummy_pk_view, name='example-detail')
@@ -329,7 +308,7 @@ class TestAllowedAndDefaultVersion:
         assert response.data == {'version': 'v2'}
 
 
-class TestHyperlinkedRelatedField(URLPatternsTestCase):
+class TestHyperlinkedRelatedField(URLPatternsTestCase, APITestCase):
     included = [
         url(r'^namespaced/(?P<pk>\d+)/$', dummy_pk_view, name='namespaced'),
     ]
@@ -361,7 +340,7 @@ class TestHyperlinkedRelatedField(URLPatternsTestCase):
             self.field.to_internal_value('/v2/namespaced/3/')
 
 
-class TestNamespaceVersioningHyperlinkedRelatedFieldScheme(URLPatternsTestCase):
+class TestNamespaceVersioningHyperlinkedRelatedFieldScheme(URLPatternsTestCase, APITestCase):
     nested = [
         url(r'^namespaced/(?P<pk>\d+)/$', dummy_pk_view, name='nested'),
     ]


### PR DESCRIPTION
In working on #5609, I found myself reusing the `URLPatternsTestCase` from the API versioning tests. This PR formalizes it with tests and docs, as well as refactoring the router tests (per #5609). If we don't want to formalize this, an alternative would be to just move this under the `tests.utils` module, and use it internally.