### PR TITLE
Fix formatting of the 3.7.4 release note

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -73,6 +73,7 @@ You can determine your currently installed version using `pip freeze`:
 
     Note: `AutoSchema.__init__` now ensures `manual_fields` is a list.
     Previously may have been stored internally as `None`.
+
 * Remove ulrparse compatability shim; use six instead [#5579][gh5579]
 * Drop compat wrapper for `TimeDelta.total_seconds()` [#5577][gh5577]
 * Clean up all whitespace throughout project [#5578][gh5578]


### PR DESCRIPTION
## Description

I Was looking through the release notes before upgrading and I noticed that [3.7.4](http://www.django-rest-framework.org/topics/release-notes/#374) wasn't reading nicely. It's because it's missing an empty line after the note:

![screen shot 2017-12-22 at 08 12 31](https://user-images.githubusercontent.com/861044/34288903-198eaf88-e6f0-11e7-9578-5fcde9dcda1e.png)
