### PR TITLE
Rework dynamic list/detail actions

### DIFF
--- a/docs/api-guide/metadata.md
+++ b/docs/api-guide/metadata.md
@@ -67,7 +67,7 @@ If you have specific requirements for creating schema endpoints that are accesse
 
 For example, the following additional route could be used on a viewset to provide a linkable schema endpoint.
 
-    @list_route(methods=['GET'])
+    @action(methods=['GET'], detail=False)
     def schema(self, request):
         meta = self.metadata_class()
         data = meta.determine_metadata(request, self)

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -81,62 +81,45 @@ Router URL patterns can also be namespaces.
 
 If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters on the serializers correctly reflect the namespace. In the example above you'd need to include a parameter such as `view_name='api:user-detail'` for serializer fields hyperlinked to the user detail view.
 
-### Extra link and actions
+### Routing for extra actions
 
-Any methods on the viewset decorated with `@detail_route` or `@list_route` will also be routed.
-For example, given a method like this on the `UserViewSet` class:
+Any method on the viewset decorated with `@action` will be included in the generated routes. For example, given a method like this on the `UserViewSet` class:
 
     from myapp.permissions import IsAdminOrIsSelf
-    from rest_framework.decorators import detail_route
+    from rest_framework.decorators import action
 
     class UserViewSet(ModelViewSet):
         ...
 
-        @detail_route(methods=['post'], permission_classes=[IsAdminOrIsSelf])
+        @action(methods=['post'], detail=True, permission_classes=[IsAdminOrIsSelf])
         def set_password(self, request, pk=None):
             ...
 
-The following URL pattern would additionally be generated:
+The following route would be generated:
 
-* URL pattern: `^users/{pk}/set_password/$`  Name: `'user-set-password'`
+* URL pattern: `^users/{pk}/set_password/$`
+* URL name: `'user-set-password'`
 
-If you do not want to use the default URL generated for your custom action, you can instead use the url_path parameter to customize it.
+By default, the URL pattern is based on the method name, and the URL name is the combination of the `ViewSet.basename` and the hyphenated method name.
+If you don't want to use the default URL or default name, you can instead pass the `url_path` and `url_name` arguments to the `@action` decorator.
 
 For example, if you want to change the URL for our custom action to `^users/{pk}/change-password/$`, you could write:
 
     from myapp.permissions import IsAdminOrIsSelf
-    from rest_framework.decorators import detail_route
+    from rest_framework.decorators import action
 
     class UserViewSet(ModelViewSet):
         ...
 
-        @detail_route(methods=['post'], permission_classes=[IsAdminOrIsSelf], url_path='change-password')
+        @action(methods=['post'], detail=True, permission_classes=[IsAdminOrIsSelf],
+                url_path='change-password', url_name='change_password')
         def set_password(self, request, pk=None):
             ...
 
 The above example would now generate the following URL pattern:
 
-* URL pattern: `^users/{pk}/change-password/$`  Name: `'user-change-password'`
-
-In the case you do not want to use the default name generated for your custom action, you can use the url_name parameter to customize it.
-
-For example, if you want to change the name of our custom action to `'user-change-password'`, you could write:
-
-    from myapp.permissions import IsAdminOrIsSelf
-    from rest_framework.decorators import detail_route
-
-    class UserViewSet(ModelViewSet):
-        ...
-
-        @detail_route(methods=['post'], permission_classes=[IsAdminOrIsSelf], url_name='change-password')
-        def set_password(self, request, pk=None):
-            ...
-
-The above example would now generate the following URL pattern:
-
-* URL pattern: `^users/{pk}/set_password/$`  Name: `'user-change-password'`
-
-You can also use url_path and url_name parameters together to obtain extra control on URL generation for custom views.
+* URL path: `^users/{pk}/change-password/$`
+* URL name: `'user-change_password'`
 
 For more information see the viewset documentation on [marking extra actions for routing][route-decorators].
 
@@ -144,18 +127,18 @@ For more information see the viewset documentation on [marking extra actions for
 
 ## SimpleRouter
 
-This router includes routes for the standard set of `list`, `create`, `retrieve`, `update`, `partial_update` and `destroy` actions.  The viewset can also mark additional methods to be routed, using the `@detail_route` or `@list_route` decorators.
+This router includes routes for the standard set of `list`, `create`, `retrieve`, `update`, `partial_update` and `destroy` actions.  The viewset can also mark additional methods to be routed, using the `@action` decorator.
 
 <table border=1>
     <tr><th>URL Style</th><th>HTTP Method</th><th>Action</th><th>URL Name</th></tr>
     <tr><td rowspan=2>{prefix}/</td><td>GET</td><td>list</td><td rowspan=2>{basename}-list</td></tr></tr>
     <tr><td>POST</td><td>create</td></tr>
-    <tr><td>{prefix}/{methodname}/</td><td>GET, or as specified by `methods` argument</td><td>`@list_route` decorated method</td><td>{basename}-{methodname}</td></tr>
+    <tr><td>{prefix}/{url_path}/</td><td>GET, or as specified by `methods` argument</td><td>`@action(detail=False)` decorated method</td><td>{basename}-{url_name}</td></tr>
     <tr><td rowspan=4>{prefix}/{lookup}/</td><td>GET</td><td>retrieve</td><td rowspan=4>{basename}-detail</td></tr></tr>
     <tr><td>PUT</td><td>update</td></tr>
     <tr><td>PATCH</td><td>partial_update</td></tr>
     <tr><td>DELETE</td><td>destroy</td></tr>
-    <tr><td>{prefix}/{lookup}/{methodname}/</td><td>GET, or as specified by `methods` argument</td><td>`@detail_route` decorated method</td><td>{basename}-{methodname}</td></tr>
+    <tr><td>{prefix}/{lookup}/{url_path}/</td><td>GET, or as specified by `methods` argument</td><td>`@action(detail=True)` decorated method</td><td>{basename}-{url_name}</td></tr>
 </table>
 
 By default the URLs created by `SimpleRouter` are appended with a trailing slash.
@@ -180,12 +163,12 @@ This router is similar to `SimpleRouter` as above, but additionally includes a d
     <tr><td>[.format]</td><td>GET</td><td>automatically generated root view</td><td>api-root</td></tr></tr>
     <tr><td rowspan=2>{prefix}/[.format]</td><td>GET</td><td>list</td><td rowspan=2>{basename}-list</td></tr></tr>
     <tr><td>POST</td><td>create</td></tr>
-    <tr><td>{prefix}/{methodname}/[.format]</td><td>GET, or as specified by `methods` argument</td><td>`@list_route` decorated method</td><td>{basename}-{methodname}</td></tr>
+    <tr><td>{prefix}/{url_path}/[.format]</td><td>GET, or as specified by `methods` argument</td><td>`@action(detail=False)` decorated method</td><td>{basename}-{url_name}</td></tr>
     <tr><td rowspan=4>{prefix}/{lookup}/[.format]</td><td>GET</td><td>retrieve</td><td rowspan=4>{basename}-detail</td></tr></tr>
     <tr><td>PUT</td><td>update</td></tr>
     <tr><td>PATCH</td><td>partial_update</td></tr>
     <tr><td>DELETE</td><td>destroy</td></tr>
-    <tr><td>{prefix}/{lookup}/{methodname}/[.format]</td><td>GET, or as specified by `methods` argument</td><td>`@detail_route` decorated method</td><td>{basename}-{methodname}</td></tr>
+    <tr><td>{prefix}/{lookup}/{url_path}/[.format]</td><td>GET, or as specified by `methods` argument</td><td>`@action(detail=True)` decorated method</td><td>{basename}-{url_name}</td></tr>
 </table>
 
 As with `SimpleRouter` the trailing slashes on the URL routes can be removed by setting the `trailing_slash` argument to `False` when instantiating the router.
@@ -212,18 +195,18 @@ The arguments to the `Route` named tuple are:
 
 * `{basename}` - The base to use for the URL names that are created.
 
-**initkwargs**: A dictionary of any additional arguments that should be passed when instantiating the view.  Note that the `suffix` argument is reserved for identifying the viewset type, used when generating the view name and breadcrumb links.
+**initkwargs**: A dictionary of any additional arguments that should be passed when instantiating the view.  Note that the `detail`, `basename`, and `suffix` arguments are reserved for viewset introspection and are also used by the browsable API to generate the view name and breadcrumb links.
 
 ## Customizing dynamic routes
 
-You can also customize how the `@list_route` and `@detail_route` decorators are routed.
-To route either or both of these decorators, include a `DynamicListRoute` and/or `DynamicDetailRoute` named tuple in the `.routes` list.
+You can also customize how the `@action` decorator is routed. Include the `DynamicRoute` named tuple in the `.routes` list, setting the `detail` argument as appropriate for the list-based and detail-based routes. In addition to `detail`, the arguments to `DynamicRoute` are:
 
-The arguments to `DynamicListRoute` and `DynamicDetailRoute` are:
+**url**: A string representing the URL to be routed. May include the same format strings as `Route`, and additionally accepts the `{url_path}` format string.
 
-**url**: A string representing the URL to be routed. May include the same format strings as `Route`, and additionally accepts the `{methodname}` and `{methodnamehyphen}` format strings.
+**name**: The name of the URL as used in `reverse` calls. May include the following format strings:
 
-**name**: The name of the URL as used in `reverse` calls. May include the following format strings: `{basename}`, `{methodname}` and `{methodnamehyphen}`.
+* `{basename}` - The base to use for the URL names that are created.
+* `{url_name}` - The `url_name` provided to the `@action`.
 
 **initkwargs**: A dictionary of any additional arguments that should be passed when instantiating the view.
 
@@ -231,7 +214,7 @@ The arguments to `DynamicListRoute` and `DynamicDetailRoute` are:
 
 The following example will only route to the `list` and `retrieve` actions, and does not use the trailing slash convention.
 
-    from rest_framework.routers import Route, DynamicDetailRoute, SimpleRouter
+    from rest_framework.routers import Route, DynamicRoute, SimpleRouter
 
     class CustomReadOnlyRouter(SimpleRouter):
         """
@@ -250,9 +233,10 @@ The following example will only route to the `list` and `retrieve` actions, and 
                 name='{basename}-detail',
                 initkwargs={'suffix': 'Detail'}
             ),
-            DynamicDetailRoute(
-                url=r'^{prefix}/{lookup}/{methodnamehyphen}$',
-                name='{basename}-{methodnamehyphen}',
+            DynamicRoute(
+                url=r'^{prefix}/{lookup}/{url_path}$',
+                name='{basename}-{url_name}',
+                detail=True,
                 initkwargs={}
             )
         ]
@@ -269,7 +253,7 @@ Let's take a look at the routes our `CustomReadOnlyRouter` would generate for a 
         serializer_class = UserSerializer
         lookup_field = 'username'
 
-        @detail_route()
+        @action(detail=True)
         def group_names(self, request, pk=None):
             """
             Returns a list of all the group names that the given

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -83,7 +83,7 @@ If using namespacing with hyperlinked serializers you'll also need to ensure tha
 
 ### Routing for extra actions
 
-Any method on the viewset decorated with `@action` will be included in the generated routes. For example, given a method like this on the `UserViewSet` class:
+A viewset may [mark extra actions for routing][route-decorators] by decorating a method with the `@action` decorator. These extra actions will be included in the generated routes. For example, given the `set_password` method on the `UserViewSet` class:
 
     from myapp.permissions import IsAdminOrIsSelf
     from rest_framework.decorators import action
@@ -101,7 +101,7 @@ The following route would be generated:
 * URL name: `'user-set-password'`
 
 By default, the URL pattern is based on the method name, and the URL name is the combination of the `ViewSet.basename` and the hyphenated method name.
-If you don't want to use the default URL or default name, you can instead pass the `url_path` and `url_name` arguments to the `@action` decorator.
+If you don't want to use the defaults for either of these values, you can instead provide the `url_path` and `url_name` arguments to the `@action` decorator.
 
 For example, if you want to change the URL for our custom action to `^users/{pk}/change-password/$`, you could write:
 
@@ -120,8 +120,6 @@ The above example would now generate the following URL pattern:
 
 * URL path: `^users/{pk}/change-password/$`
 * URL name: `'user-change_password'`
-
-For more information see the viewset documentation on [marking extra actions for routing][route-decorators].
 
 # API Guide
 

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -239,22 +239,22 @@ The following example will only route to the `list` and `retrieve` actions, and 
         """
         routes = [
             Route(
-            	url=r'^{prefix}$',
-            	mapping={'get': 'list'},
-            	name='{basename}-list',
-            	initkwargs={'suffix': 'List'}
+                url=r'^{prefix}$',
+                mapping={'get': 'list'},
+                name='{basename}-list',
+                initkwargs={'suffix': 'List'}
             ),
             Route(
-            	url=r'^{prefix}/{lookup}$',
+                url=r'^{prefix}/{lookup}$',
                 mapping={'get': 'retrieve'},
                 name='{basename}-detail',
                 initkwargs={'suffix': 'Detail'}
             ),
             DynamicDetailRoute(
-            	url=r'^{prefix}/{lookup}/{methodnamehyphen}$',
-            	name='{basename}-{methodnamehyphen}',
-            	initkwargs={}
-        	)
+                url=r'^{prefix}/{lookup}/{methodnamehyphen}$',
+                name='{basename}-{methodnamehyphen}',
+                initkwargs={}
+            )
         ]
 
 Let's take a look at the routes our `CustomReadOnlyRouter` would generate for a simple viewset.
@@ -283,7 +283,7 @@ Let's take a look at the routes our `CustomReadOnlyRouter` would generate for a 
 
     router = CustomReadOnlyRouter()
     router.register('users', UserViewSet)
-	urlpatterns = router.urls
+    urlpatterns = router.urls
 
 The following mappings would be generated...
 

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -38,6 +38,31 @@ You can determine your currently installed version using `pip freeze`:
 
 ---
 
+## 3.8.x series
+
+### 3.8.0
+
+**Date**: [unreleased][3.8.0-milestone]
+
+* Refactor dynamic route generation and improve viewset action introspectibility. [#5705][gh5705]
+
+    `ViewSet`s have been provided with new attributes and methods that allow
+    it to introspect its set of actions and the details of the current action.
+
+    * Merged `list_route` and `detail_route` into a single `action` decorator.
+    * Get all extra actions on a `ViewSet` with `.get_extra_actions()`.
+    * Extra actions now set the `url_name` and `url_path` on the decorated method.
+    * Enable action url reversing through `.reverse_action()` method (added in 3.7.4)
+    * Example reverse call: `self.reverse_action(self.custom_action.url_name)`
+    * Add `detail` initkwarg to indicate if the current action is operating on a
+      collection or a single instance.
+
+    Additional changes:
+
+    * Deprecated `list_route` & `detail_route` in favor of `action` decorator with `detail` boolean.
+    * Deprecated dynamic list/detail route variants in favor of `DynamicRoute` with `detail` boolean.
+    * Refactored the router's dynamic route generation.
+
 ## 3.7.x series
 
 ### 3.7.7
@@ -947,6 +972,7 @@ For older release notes, [please see the version 2.x documentation][old-release-
 [3.7.5-milestone]: https://github.com/encode/django-rest-framework/milestone/63?closed=1
 [3.7.6-milestone]: https://github.com/encode/django-rest-framework/milestone/64?closed=1
 [3.7.7-milestone]: https://github.com/encode/django-rest-framework/milestone/65?closed=1
+[3.8.0-milestone]: https://github.com/encode/django-rest-framework/milestone/61?closed=1
 
 <!-- 3.0.1 -->
 [gh2013]: https://github.com/encode/django-rest-framework/issues/2013
@@ -1760,3 +1786,6 @@ For older release notes, [please see the version 2.x documentation][old-release-
 [gh5695]: https://github.com/encode/django-rest-framework/issues/5695
 [gh5696]: https://github.com/encode/django-rest-framework/issues/5696
 [gh5697]: https://github.com/encode/django-rest-framework/issues/5697
+
+<!-- 3.8.0 -->
+[gh5705]: https://github.com/encode/django-rest-framework/issues/5705

--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -25,7 +25,7 @@ Here we've used the `ReadOnlyModelViewSet` class to automatically provide the de
 
 Next we're going to replace the `SnippetList`, `SnippetDetail` and `SnippetHighlight` view classes.  We can remove the three views, and again replace them with a single class.
 
-    from rest_framework.decorators import detail_route
+    from rest_framework.decorators import action
     from rest_framework.response import Response
 
     class SnippetViewSet(viewsets.ModelViewSet):
@@ -40,7 +40,7 @@ Next we're going to replace the `SnippetList`, `SnippetDetail` and `SnippetHighl
         permission_classes = (permissions.IsAuthenticatedOrReadOnly,
                               IsOwnerOrReadOnly,)
 
-        @detail_route(renderer_classes=[renderers.StaticHTMLRenderer])
+        @action(detail=True, renderer_classes=[renderers.StaticHTMLRenderer])
         def highlight(self, request, *args, **kwargs):
             snippet = self.get_object()
             return Response(snippet.highlighted)
@@ -50,11 +50,11 @@ Next we're going to replace the `SnippetList`, `SnippetDetail` and `SnippetHighl
 
 This time we've used the `ModelViewSet` class in order to get the complete set of default read and write operations.
 
-Notice that we've also used the `@detail_route` decorator to create a custom action, named `highlight`.  This decorator can be used to add any custom endpoints that don't fit into the standard `create`/`update`/`delete` style.
+Notice that we've also used the `@action` decorator to create a custom action, named `highlight`.  This decorator can be used to add any custom endpoints that don't fit into the standard `create`/`update`/`delete` style.
 
-Custom actions which use the `@detail_route` decorator will respond to `GET` requests by default.  We can use the `methods` argument if we wanted an action that responded to `POST` requests.
+Custom actions which use the `@action` decorator will respond to `GET` requests by default.  We can use the `methods` argument if we wanted an action that responded to `POST` requests.
 
-The URLs for custom actions by default depend on the method name itself. If you want to change the way url should be constructed, you can include url_path as a decorator keyword argument.
+The URLs for custom actions by default depend on the method name itself. If you want to change the way url should be constructed, you can include `url_path` as a decorator keyword argument.
 
 ## Binding ViewSets to URLs explicitly
 

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -130,7 +130,7 @@ def schema(view_inspector):
     return decorator
 
 
-def action(methods=None, detail=True, **kwargs):
+def action(methods=None, detail=True, url_path=None, url_name=None, **kwargs):
     """
     Mark a ViewSet method as a routable action.
 
@@ -143,6 +143,8 @@ def action(methods=None, detail=True, **kwargs):
     def decorator(func):
         func.bind_to_methods = methods
         func.detail = detail
+        func.url_path = url_path or func.__name__
+        func.url_name = url_name or func.__name__.replace('_', '-')
         func.kwargs = kwargs
         return func
     return decorator

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -130,29 +130,43 @@ def schema(view_inspector):
     return decorator
 
 
+def action(methods=None, detail=True, **kwargs):
+    """
+    Mark a ViewSet method as a routable action.
+
+    Set the `detail` boolean to determine if this action should apply to
+    instance/detail requests or collection/list requests.
+    """
+    methods = ['get'] if (methods is None) else methods
+    methods = [method.lower() for method in methods]
+
+    def decorator(func):
+        func.bind_to_methods = methods
+        func.detail = detail
+        func.kwargs = kwargs
+        return func
+    return decorator
+
+
 def detail_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for detail requests.
     """
-    methods = ['get'] if (methods is None) else methods
-
-    def decorator(func):
-        func.bind_to_methods = methods
-        func.detail = True
-        func.kwargs = kwargs
-        return func
-    return decorator
+    warnings.warn(
+        "`detail_route` is pending deprecation and will be removed in 3.10 in favor of "
+        "`action`, which accepts a `detail` bool. Use `@action(detail=True)` instead.",
+        PendingDeprecationWarning, stacklevel=2
+    )
+    return action(methods, detail=True, **kwargs)
 
 
 def list_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for list requests.
     """
-    methods = ['get'] if (methods is None) else methods
-
-    def decorator(func):
-        func.bind_to_methods = methods
-        func.detail = False
-        func.kwargs = kwargs
-        return func
-    return decorator
+    warnings.warn(
+        "`list_route` is pending deprecation and will be removed in 3.10 in favor of "
+        "`action`, which accepts a `detail` bool. Use `@action(detail=False)` instead.",
+        PendingDeprecationWarning, stacklevel=2
+    )
+    return action(methods, detail=False, **kwargs)

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -130,7 +130,7 @@ def schema(view_inspector):
     return decorator
 
 
-def action(methods=None, detail=True, url_path=None, url_name=None, **kwargs):
+def action(methods=None, detail=None, url_path=None, url_name=None, **kwargs):
     """
     Mark a ViewSet method as a routable action.
 
@@ -139,6 +139,10 @@ def action(methods=None, detail=True, url_path=None, url_name=None, **kwargs):
     """
     methods = ['get'] if (methods is None) else methods
     methods = [method.lower() for method in methods]
+
+    assert detail is not None, (
+        "@action() missing required argument: 'detail'"
+    )
 
     def decorator(func):
         func.bind_to_methods = methods

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -284,6 +284,7 @@ class SimpleRouter(BaseRouter):
                 initkwargs = route.initkwargs.copy()
                 initkwargs.update({
                     'basename': basename,
+                    'detail': route.detail,
                 })
 
                 view = viewset.as_view(mapping, **initkwargs)

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -19,12 +19,17 @@ automatically.
 from __future__ import unicode_literals
 
 from functools import update_wrapper
+from inspect import getmembers
 
 from django.utils.decorators import classonlymethod
 from django.views.decorators.csrf import csrf_exempt
 
 from rest_framework import generics, mixins, views
 from rest_framework.reverse import reverse
+
+
+def _is_extra_action(attr):
+    return hasattr(attr, 'bind_to_methods')
 
 
 class ViewSetMixin(object):
@@ -112,8 +117,7 @@ class ViewSetMixin(object):
 
     def initialize_request(self, request, *args, **kwargs):
         """
-        Set the `.action` attribute on the view,
-        depending on the request method.
+        Set the `.action` attribute on the view, depending on the request method.
         """
         request = super(ViewSetMixin, self).initialize_request(request, *args, **kwargs)
         method = request.method.lower()
@@ -134,6 +138,13 @@ class ViewSetMixin(object):
         kwargs.setdefault('request', self.request)
 
         return reverse(url_name, *args, **kwargs)
+
+    @classmethod
+    def get_extra_actions(cls):
+        """
+        Get the methods that are marked as an extra ViewSet `@action`.
+        """
+        return [method for _, method in getmembers(cls, _is_extra_action)]
 
 
 class ViewSet(ViewSetMixin, views.APIView):

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -56,6 +56,9 @@ class ViewSetMixin(object):
         # eg. 'List' or 'Instance'.
         cls.suffix = None
 
+        # The detail initkwarg is reserved for introspecting the viewset type.
+        cls.detail = None
+
         # Setting a basename allows a view to reverse its action urls. This
         # value is provided by the router through the initkwargs.
         cls.basename = None

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -179,6 +179,8 @@ class ActionDecoratorTestCase(TestCase):
 
         assert test_action.bind_to_methods == ['get']
         assert test_action.detail is True
+        assert test_action.url_path == 'test_action'
+        assert test_action.url_name == 'test-action'
 
     def test_detail_route_deprecation(self):
         with pytest.warns(PendingDeprecationWarning) as record:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -173,7 +173,7 @@ class DecoratorTestCase(TestCase):
 class ActionDecoratorTestCase(TestCase):
 
     def test_defaults(self):
-        @action()
+        @action(detail=True)
         def test_action(request):
             pass
 
@@ -181,6 +181,14 @@ class ActionDecoratorTestCase(TestCase):
         assert test_action.detail is True
         assert test_action.url_path == 'test_action'
         assert test_action.url_name == 'test-action'
+
+    def test_detail_required(self):
+        with pytest.raises(AssertionError) as excinfo:
+            @action()
+            def test_action(request):
+                pass
+
+        assert str(excinfo.value) == "@action() missing required argument: 'detail'"
 
     def test_detail_route_deprecation(self):
         with pytest.warns(PendingDeprecationWarning) as record:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,12 +1,14 @@
 from __future__ import unicode_literals
 
+import pytest
 from django.test import TestCase
 
 from rest_framework import status
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.decorators import (
-    api_view, authentication_classes, parser_classes, permission_classes,
-    renderer_classes, schema, throttle_classes
+    action, api_view, authentication_classes, detail_route, list_route,
+    parser_classes, permission_classes, renderer_classes, schema,
+    throttle_classes
 )
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
@@ -166,3 +168,40 @@ class DecoratorTestCase(TestCase):
             return Response({})
 
         assert isinstance(view.cls.schema, CustomSchema)
+
+
+class ActionDecoratorTestCase(TestCase):
+
+    def test_defaults(self):
+        @action()
+        def test_action(request):
+            pass
+
+        assert test_action.bind_to_methods == ['get']
+        assert test_action.detail is True
+
+    def test_detail_route_deprecation(self):
+        with pytest.warns(PendingDeprecationWarning) as record:
+            @detail_route()
+            def view(request):
+                pass
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "`detail_route` is pending deprecation and will be removed in "
+            "3.10 in favor of `action`, which accepts a `detail` bool. Use "
+            "`@action(detail=True)` instead."
+        )
+
+    def test_list_route_deprecation(self):
+        with pytest.warns(PendingDeprecationWarning) as record:
+            @list_route()
+            def view(request):
+                pass
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "`list_route` is pending deprecation and will be removed in "
+            "3.10 in favor of `action`, which accepts a `detail` bool. Use "
+            "`@action(detail=False)` instead."
+        )

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -11,7 +11,7 @@ from django.urls import resolve
 
 from rest_framework import permissions, serializers, viewsets
 from rest_framework.compat import get_regex_pattern
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.routers import DefaultRouter, SimpleRouter
 from rest_framework.test import APIRequestFactory
@@ -67,12 +67,12 @@ class EmptyPrefixViewSet(viewsets.ModelViewSet):
 
 
 class RegexUrlPathViewSet(viewsets.ViewSet):
-    @list_route(url_path='list/(?P<kwarg>[0-9]{4})')
+    @action(detail=False, url_path='list/(?P<kwarg>[0-9]{4})')
     def regex_url_path_list(self, request, *args, **kwargs):
         kwarg = self.kwargs.get('kwarg', '')
         return Response({'kwarg': kwarg})
 
-    @detail_route(url_path='detail/(?P<kwarg>[0-9]{4})')
+    @action(detail=True, url_path='detail/(?P<kwarg>[0-9]{4})')
     def regex_url_path_detail(self, request, *args, **kwargs):
         pk = self.kwargs.get('pk', '')
         kwarg = self.kwargs.get('kwarg', '')
@@ -112,23 +112,23 @@ class BasicViewSet(viewsets.ViewSet):
     def list(self, request, *args, **kwargs):
         return Response({'method': 'list'})
 
-    @detail_route(methods=['post'])
+    @action(methods=['post'], detail=True)
     def action1(self, request, *args, **kwargs):
         return Response({'method': 'action1'})
 
-    @detail_route(methods=['post'])
+    @action(methods=['post'], detail=True)
     def action2(self, request, *args, **kwargs):
         return Response({'method': 'action2'})
 
-    @detail_route(methods=['post', 'delete'])
+    @action(methods=['post', 'delete'], detail=True)
     def action3(self, request, *args, **kwargs):
         return Response({'method': 'action2'})
 
-    @detail_route()
+    @action(detail=True)
     def link1(self, request, *args, **kwargs):
         return Response({'method': 'link1'})
 
-    @detail_route()
+    @action(detail=True)
     def link2(self, request, *args, **kwargs):
         return Response({'method': 'link2'})
 
@@ -297,7 +297,7 @@ class TestActionKeywordArgs(TestCase):
         class TestViewSet(viewsets.ModelViewSet):
             permission_classes = []
 
-            @detail_route(methods=['post'], permission_classes=[permissions.AllowAny])
+            @action(methods=['post'], detail=True, permission_classes=[permissions.AllowAny])
             def custom(self, request, *args, **kwargs):
                 return Response({
                     'permission_classes': self.permission_classes
@@ -315,14 +315,14 @@ class TestActionKeywordArgs(TestCase):
 
 class TestActionAppliedToExistingRoute(TestCase):
     """
-    Ensure `@detail_route` decorator raises an except when applied
+    Ensure `@action` decorator raises an except when applied
     to an existing route
     """
 
     def test_exception_raised_when_action_applied_to_existing_route(self):
         class TestViewSet(viewsets.ModelViewSet):
 
-            @detail_route(methods=['post'])
+            @action(methods=['post'], detail=True)
             def retrieve(self, request, *args, **kwargs):
                 return Response({
                     'hello': 'world'
@@ -339,27 +339,27 @@ class DynamicListAndDetailViewSet(viewsets.ViewSet):
     def list(self, request, *args, **kwargs):
         return Response({'method': 'list'})
 
-    @list_route(methods=['post'])
+    @action(methods=['post'], detail=False)
     def list_route_post(self, request, *args, **kwargs):
         return Response({'method': 'action1'})
 
-    @detail_route(methods=['post'])
+    @action(methods=['post'], detail=True)
     def detail_route_post(self, request, *args, **kwargs):
         return Response({'method': 'action2'})
 
-    @list_route()
+    @action(detail=False)
     def list_route_get(self, request, *args, **kwargs):
         return Response({'method': 'link1'})
 
-    @detail_route()
+    @action(detail=True)
     def detail_route_get(self, request, *args, **kwargs):
         return Response({'method': 'link2'})
 
-    @list_route(url_path="list_custom-route")
+    @action(detail=False, url_path="list_custom-route")
     def list_custom_route_get(self, request, *args, **kwargs):
         return Response({'method': 'link1'})
 
-    @detail_route(url_path="detail_custom-route")
+    @action(detail=True, url_path="detail_custom-route")
     def detail_custom_route_get(self, request, *args, **kwargs):
         return Response({'method': 'link2'})
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -446,6 +446,12 @@ class TestViewInitkwargs(TestCase):
 
         assert initkwargs['suffix'] == 'List'
 
+    def test_detail(self):
+        match = resolve('/example/notes/')
+        initkwargs = match.func.initkwargs
+
+        assert not initkwargs['detail']
+
     def test_basename(self):
         match = resolve('/example/notes/')
         initkwargs = match.func.initkwargs

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -10,9 +10,7 @@ from rest_framework import (
     filters, generics, pagination, permissions, serializers
 )
 from rest_framework.compat import coreapi, coreschema, get_regex_pattern, path
-from rest_framework.decorators import (
-    api_view, detail_route, list_route, schema
-)
+from rest_framework.decorators import action, api_view, schema
 from rest_framework.request import Request
 from rest_framework.routers import DefaultRouter, SimpleRouter
 from rest_framework.schemas import (
@@ -67,25 +65,25 @@ class ExampleViewSet(ModelViewSet):
     filter_backends = [filters.OrderingFilter]
     serializer_class = ExampleSerializer
 
-    @detail_route(methods=['post'], serializer_class=AnotherSerializer)
+    @action(methods=['post'], detail=True, serializer_class=AnotherSerializer)
     def custom_action(self, request, pk):
         """
         A description of custom action.
         """
         return super(ExampleSerializer, self).retrieve(self, request)
 
-    @detail_route(methods=['post'], serializer_class=AnotherSerializerWithListFields)
+    @action(methods=['post'], detail=True, serializer_class=AnotherSerializerWithListFields)
     def custom_action_with_list_fields(self, request, pk):
         """
         A custom action using both list field and list serializer in the serializer.
         """
         return super(ExampleSerializer, self).retrieve(self, request)
 
-    @list_route()
+    @action(detail=False)
     def custom_list_action(self, request):
         return super(ExampleViewSet, self).list(self, request)
 
-    @list_route(methods=['post', 'get'], serializer_class=EmptySerializer)
+    @action(methods=['post', 'get'], detail=False, serializer_class=EmptySerializer)
     def custom_list_action_multiple_methods(self, request):
         return super(ExampleViewSet, self).list(self, request)
 
@@ -865,11 +863,11 @@ class NamingCollisionViewSet(GenericViewSet):
     """
     permision_class = ()
 
-    @list_route()
+    @action(detail=False)
     def detail(self, request):
         return {}
 
-    @list_route(url_path='detail/export')
+    @action(detail=False, url_path='detail/export')
     def detail_export(self, request):
         return {}
 
@@ -1049,7 +1047,7 @@ def test_head_and_options_methods_are_excluded():
 
     class AViewSet(ModelViewSet):
 
-        @detail_route(methods=['options', 'get'])
+        @action(methods=['options', 'get'], detail=True)
         def custom_action(self, request, pk):
             pass
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -949,7 +949,10 @@ class TestURLNamingCollisions(TestCase):
 
         generator = SchemaGenerator(title='Naming Colisions', patterns=patterns)
         schema = generator.get_schema()
-        desc = schema['detail_0'].description  # not important here
+
+        # not important here
+        desc_0 = schema['detail']['detail_export'].description
+        desc_1 = schema['detail_0'].description
 
         expected = coreapi.Document(
             url='',
@@ -959,12 +962,12 @@ class TestURLNamingCollisions(TestCase):
                     'detail_export': coreapi.Link(
                         url='/from-routercollision/detail/export/',
                         action='get',
-                        description=desc)
+                        description=desc_0)
                 },
                 'detail_0': coreapi.Link(
                     url='/from-routercollision/detail/',
                     action='get',
-                    description=desc
+                    description=desc_1
                 )
             }
         )

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -111,6 +111,16 @@ class InitializeViewSetsTestCase(TestCase):
             self.assertIn(attribute, dir(view))
 
 
+class GetExtraActionTests(TestCase):
+
+    def test_extra_actions(self):
+        view = ActionViewSet()
+        actual = [action.__name__ for action in view.get_extra_actions()]
+        expected = ['custom_detail_action', 'custom_list_action', 'detail_action', 'list_action']
+
+        self.assertEqual(actual, expected)
+
+
 @override_settings(ROOT_URLCONF='tests.test_viewsets')
 class ReverseActionTests(TestCase):
     def test_default_basename(self):

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.test import TestCase, override_settings
 
 from rest_framework import status
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.routers import SimpleRouter
 from rest_framework.test import APIRequestFactory
@@ -39,19 +39,19 @@ class ActionViewSet(GenericViewSet):
     def retrieve(self, request, *args, **kwargs):
         pass
 
-    @list_route()
+    @action(detail=False)
     def list_action(self, request, *args, **kwargs):
         pass
 
-    @list_route(url_name='list-custom')
+    @action(detail=False, url_name='list-custom')
     def custom_list_action(self, request, *args, **kwargs):
         pass
 
-    @detail_route()
+    @action(detail=True)
     def detail_action(self, request, *args, **kwargs):
         pass
 
-    @detail_route(url_name='detail-custom')
+    @action(detail=True, url_name='detail-custom')
     def custom_detail_action(self, request, *args, **kwargs):
         pass
 


### PR DESCRIPTION
Pulling a slightly more manageable chunk out of #5605 for review. The goal is to remove logic from the router in order to make the viewsets and list/detail actions more introspectable.

**Changes:**

- Deprecated `list_route` & `detail_route` in favor of `action` decorator w/ `detail` boolean.
- Deprecated dynamic list/detail route variants in favor of `DynamicRoute` w/ `detail` boolean.
- Added `detail` boolean argument to regular `Route`
- A route's `detail` is now provided as an `initkwarg` to the ViewSet, similar to `suffix`.
- Added `ViewSet.get_extra_actions()` to formalize extra action access.
- Added `url_path` and `url_name` to `action` signature. These values are no longer set/altered by the router, and can be more reliably inspected by the parent viewset.
- Refactored dynamic route generation, replacing protected method w/ internal instance method. 

For the release notes, I've added a section to discuss the changes as a larger feature. 

**TODO:**
- [x] Add release notes
- [x] Replace deprecated functions in tests
- [x] Update docs w/ changes

