### PR TITLE
not required read_only Fields with allow_null

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -442,6 +442,8 @@ class Field(object):
         except (KeyError, AttributeError) as exc:
             if self.default is not empty:
                 return self.get_default()
+            if self.read_only and self.allow_null:
+                return None
             if not self.required:
                 raise SkipField()
             if self.allow_null:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -384,10 +384,16 @@ class TestNotRequiredOutput:
     def test_not_required_output_for_allow_null_field(self):
         class ExampleSerializer(serializers.Serializer):
             omitted = serializers.CharField(required=False, allow_null=True)
+            ommited_read_only = serializers.CharField(
+                required=False,
+                read_only=True,
+                allow_null=True
+            )
             included = serializers.CharField()
 
         serializer = ExampleSerializer({'included': 'abc'})
         assert 'omitted' not in serializer.data
+        assert serializer.data['ommited_read_only'] is None
 
 
 class TestDefaultOutput:


### PR DESCRIPTION
## Description

Since #5639 we are unable to render fields that were rendered previously with `allow_null=True`.
Backward compatibility is not preserved, because `required=True` and `read_only=True` are conflicting, so in our case, some fields just disappeared and it seems there is no way to get them back.

I'm not sure about the fix, but the regression test is probably right.