### PR TITLE
using rsplit to get module and classname for imports

### DIFF
--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -179,8 +179,7 @@ def import_from_string(val, setting_name):
     """
     try:
         # Nod to tastypie's use of importlib.
-        parts = val.split('.')
-        module_path, class_name = '.'.join(parts[:-1]), parts[-1]
+        module_path, class_name = val.rsplit('.', 1)
         module = import_module(module_path)
         return getattr(module, class_name)
     except (ImportError, AttributeError) as e:


### PR DESCRIPTION
## Description

While checking the code to steal the import parts to a project of my own I came across this two lines that could be rewritten, nothing fancy but hey, one line less