### PR TITLE
Fixed "typo" in example.

### DIFF
--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -142,7 +142,7 @@ Add the following import at the top of the file:
 And, at the end of the file, add a pattern to include the login and logout views for the browsable API.
 
     urlpatterns += [
-        url(r'^api-auth/', include('rest_framework.urls'),
+        url(r'^api-auth/', include('rest_framework.urls')),
     ]
 
 The `r'^api-auth/'` part of pattern can actually be whatever URL you want to use.


### PR DESCRIPTION
Fixing code "typo" in example.
In the original file, line 145 reads:
        url(r'^api-auth/', include('rest_framework.urls'),
It's missing the closing parenthesis.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
