### PR TITLE
Allow rest_framework.request.Request instances

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -153,6 +153,12 @@ class Request(object):
 
     def __init__(self, request, parsers=None, authenticators=None,
                  negotiator=None, parser_context=None):
+        # If we're being passed our own Request object, unwrap the underlying
+        # HttpRequest. This allows for some backwards compatibilty to 3.7.3
+        # for select users who carefully reuse ViewSets.
+        if isinstance(request, Request):
+            request = request._request
+
         assert isinstance(request, HttpRequest), (
             'The `request` argument must be an instance of '
             '`django.http.HttpRequest`, not `{}.{}`.'

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -33,10 +33,13 @@ class TestInitializer(TestCase):
 
         message = (
             'The `request` argument must be an instance of '
-            '`django.http.HttpRequest`, not `rest_framework.request.Request`.'
+            '`django.http.HttpRequest`, not `NoneType`.'
         )
         with self.assertRaisesMessage(AssertionError, message):
-            Request(request)
+            Request(None)
+
+        other_request = Request(request)
+        assert other_request._request is request._request
 
 
 class PlainTextParser(BaseParser):


### PR DESCRIPTION
Instead of flat-out erroring (which can cause unhandled exceptions)
let's perhaps be nicer to users who are considerately and carefully
reusing ViewSets in other ViewSets. This means accessing the private
attribute for them and then (and only then) raising an AssertionError if
it isn't a Django HttpResponse instance.

See also #5618
