### PR TITLE
feat: easier to extend the payload returning the token without having…

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -205,7 +205,17 @@ The `obtain_auth_token` view will return a JSON response when valid `username` a
 
     { 'token' : '9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b' }
 
-Note that the default `obtain_auth_token` view explicitly uses JSON requests and responses, rather than using default renderer and parser classes in your settings.  If you need a customized version of the `obtain_auth_token` view, you can do so by overriding the `ObtainAuthToken` view class, and using that in your url conf instead.
+Note that the default `obtain_auth_token` view explicitly uses JSON requests and responses, rather than using default renderer and parser classes in your settings.  If you need a customized version of the `obtain_auth_token` view, you can do so by inheriting from `ObtainAuthToken` and overriding the `get_data` function, and using that in your url conf instead.
+
+Example:
+
+```
+class CustomAuthToken(ObtainAuthToken):
+
+    def get_data(self, user, token, created):
+        return {'token': token.key, 'user_id': user.pk}
+
+```
 
 By default there are no permissions or throttling applied to the  `obtain_auth_token` view. If you do wish to apply throttling you'll need to override the view class,
 and include them using the `throttle_classes` attribute.

--- a/rest_framework/authtoken/views.py
+++ b/rest_framework/authtoken/views.py
@@ -12,13 +12,17 @@ class ObtainAuthToken(APIView):
     renderer_classes = (renderers.JSONRenderer,)
     serializer_class = AuthTokenSerializer
 
+    def get_data(self, user, token, created):
+        return {'token': token.key}
+
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data,
                                            context={'request': request})
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']
         token, created = Token.objects.get_or_create(user=user)
-        return Response({'token': token.key})
+        data = self.get_data(user, token, created)
+        return Response(data)
 
 
 obtain_auth_token = ObtainAuthToken.as_view()


### PR DESCRIPTION
# Problem

Usually we want to extend the information here, **reusing the token**, not reimplementing the whole method. 

I find it counterintuitive having to copy the whole function again, like [suggested here](https://github.com/encode/django-rest-framework/pull/4385#issuecomment-239163918) it's not what you'd expect at first, and I start wondering if I might be doing something wrong. 

Another solution is calling `super` and having to scrap the `response` for the token, like [suggested here](https://github.com/encode/django-rest-framework/issues/2414#issuecomment-199954531) usually if you modify this function, you want something related to the user, and you will have to request it again (or the token), because it was already requested in the serializer inside the `super`.

# Use cases

* Returning the groups a user belongs to (that's what I intend to use it for)
* Returning a user id

## Similar PR

https://github.com/encode/django-rest-framework/pull/4385
https://github.com/encode/django-rest-framework/pull/2978
https://github.com/encode/django-rest-framework/pull/2151

## Tickets related

https://github.com/encode/django-rest-framework/issues/2414

Hope it helps!

Regards!
