### PR TITLE
Pass python_requires argument to setuptools

### DIFF
--- a/docs/topics/project-management.md
+++ b/docs/topics/project-management.md
@@ -105,6 +105,11 @@ The following template should be used for the description of the issue, and serv
     Checklist:
 
     - [ ] Create pull request for [release notes](https://github.com/encode/django-rest-framework/blob/master/docs/topics/release-notes.md) based on the [*.*.* milestone](https://github.com/encode/django-rest-framework/milestones/***).
+    - [ ] Update supported versions:
+        - [ ] `setup.py` `python_requires` list
+        - [ ] `setup.py` Python & Django version trove classifiers
+        - [ ] `README` Python & Django versions
+        - [ ] `docs` Python & Django versions
     - [ ] Update the translations from [transifex](http://www.django-rest-framework.org/topics/project-management/#translations).
     - [ ] Ensure the pull request increments the version to `*.*.*` in [`restframework/__init__.py`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/__init__.py).
     - [ ] Confirm with @tomchristie that release is finalized and ready to go.

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     install_requires=[],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Helps pip decide what version of the library to install.

https://packaging.python.org/tutorials/distributing-packages/#python-requires

> If your project only runs on certain Python versions, setting the
> python_requires argument to the appropriate PEP 440 version specifier
> string will prevent pip from installing the project on other Python
> versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440)
> for the Python version, used to specify the Requires-Python defined in
> PEP 345.