### PR TITLE
Warn if BrowsableAPIRenderer.get_filter_form fails

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 
 import base64
 from collections import OrderedDict
+from warnings import warn
 
 from django import forms
 from django.conf import settings
@@ -623,7 +624,8 @@ class BrowsableAPIRenderer(BaseRenderer):
         elif paginator is not None and data is not None:
             try:
                 paginator.get_results(data)
-            except (TypeError, KeyError):
+            except (TypeError, KeyError) as exc:
+                warn('get_filter_form() aborting because pagination failed: %s' % exc)
                 return
         elif not isinstance(data, list):
             return


### PR DESCRIPTION
I spent a bit of time trying to figure out why the filter form wasn't showing up for one custom class, which turned out to be because the paginator uses a hard-coded `results` key and the viewset method in question was using `records`. I fixed that in my code but a warning message for the exception would have made that much easier to find.
