### PR TITLE
Fix replaced instance being used when pk-only optimization raises AttributeError

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -163,8 +163,8 @@ class RelatedField(Field):
         if self.use_pk_only_optimization() and self.source_attrs:
             # Optimized case, return a mock object only containing the pk attribute.
             try:
-                instance = get_attribute(instance, self.source_attrs[:-1])
-                value = instance.serializable_value(self.source_attrs[-1])
+                attribute_instance = get_attribute(instance, self.source_attrs[:-1])
+                value = attribute_instance.serializable_value(self.source_attrs[-1])
                 if is_simple_callable(value):
                     # Handle edge case where the relationship `source` argument
                     # points to a `get_relationship()` method on the model


### PR DESCRIPTION
Not sure if this is the right place to put the test or where the situation comes up in the real world when not using ORM hacks (like how we found it), but it *does* test the thing, and the thing *is* broken in a case that it appears to be intended to handle.