### PR TITLE
permissions: Allow permissions to be composed

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -102,6 +102,27 @@ Or, if you're using the `@api_view` decorator with function based views.
 
 __Note:__ when you set new permission classes through class attribute or decorators you're telling the view to ignore the default list set over the __settings.py__ file.
 
+Provided they inherit from `rest_framework.permissions.BasePermission`, permissions can be composed using standard Python bitwise operators. For example, `IsAdminOrReadOnly` could be written:
+
+    from rest_framework.permissions import BasePermission, IsAuthenticated
+    from rest_framework.response import Response
+    from rest_framework.views import APIView
+
+    class ReadOnly(BasePermission):
+        def has_permission(self, request, view):
+            return request.method in SAFE_METHODS
+
+    class ExampleView(APIView):
+        permission_classes = (IsAuthenticated|ReadOnly)
+
+        def get(self, request, format=None):
+            content = {
+                'status': 'request was permitted'
+            }
+            return Response(content)
+
+__Note:__ it only supports & -and- and | -or-.
+
 ---
 
 # API Reference

--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -102,7 +102,7 @@ Or, if you're using the `@api_view` decorator with function based views.
 
 __Note:__ when you set new permission classes through class attribute or decorators you're telling the view to ignore the default list set over the __settings.py__ file.
 
-Provided they inherit from `rest_framework.permissions.BasePermission`, permissions can be composed using standard Python bitwise operators. For example, `IsAdminOrReadOnly` could be written:
+Provided they inherit from `rest_framework.permissions.BasePermission`, permissions can be composed using standard Python bitwise operators. For example, `IsAuthenticatedOrReadOnly` could be written:
 
     from rest_framework.permissions import BasePermission, IsAuthenticated
     from rest_framework.response import Response

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -522,3 +522,45 @@ class CustomPermissionsTests(TestCase):
             detail = response.data.get('detail')
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(detail, self.custom_message)
+
+
+class FakeUser:
+    def __init__(self, auth=False):
+        self.is_authenticated = auth
+
+
+class PermissionsCompositionTests(TestCase):
+    def test_and_false(self):
+        request = factory.get('/1', format='json')
+        request.user = FakeUser(auth=False)
+        composed_perm = permissions.IsAuthenticated & permissions.AllowAny
+        assert composed_perm().has_permission(request, None) is False
+
+    def test_and_true(self):
+        request = factory.get('/1', format='json')
+        request.user = FakeUser(auth=True)
+        composed_perm = permissions.IsAuthenticated & permissions.AllowAny
+        assert composed_perm().has_permission(request, None) is True
+
+    def test_or_false(self):
+        request = factory.get('/1', format='json')
+        request.user = FakeUser(auth=False)
+        composed_perm = permissions.IsAuthenticated | permissions.AllowAny
+        assert composed_perm().has_permission(request, None) is True
+
+    def test_or_true(self):
+        request = factory.get('/1', format='json')
+        request.user = FakeUser(auth=True)
+        composed_perm = permissions.IsAuthenticated | permissions.AllowAny
+        assert composed_perm().has_permission(request, None) is True
+
+    def test_several_levels(self):
+        request = factory.get('/1', format='json')
+        request.user = FakeUser(auth=True)
+        composed_perm = (
+            permissions.IsAuthenticated &
+            permissions.IsAuthenticated &
+            permissions.IsAuthenticated &
+            permissions.IsAuthenticated
+        )
+        assert composed_perm().has_permission(request, None) is True


### PR DESCRIPTION
Implement a system to compose permissions with and / or.
This is performed by returning an `OperationHolder` instance that keeps the
permission classes and type of composition (and / or).
When called it will return a AND/OR instance that will then delegate the
permission check to the operands.

This will allow permissions to look such as:

    permission_classes = [IsAuthenticated & (ReadOnly | IsAdmin)]