### PR TITLE
Easier way to set view name

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -400,7 +400,7 @@ This should be a function with the following signature:
 
     view_name(cls, suffix=None)
 
-* `cls`: The view class.  Typically the name function would inspect the name of the class when generating a descriptive name, by accessing `cls.__name__`.
+* `cls`: The view class. Typically the name function would inspect the name of the class when generating a descriptive name, by accessing `cls.__name__`. You can set a different name by setting `view_name` variable in your view.
 * `suffix`: The optional suffix used when differentiating individual views in a viewset.
 
 Default: `'rest_framework.views.get_view_name'`

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -30,7 +30,7 @@ def get_view_name(view_cls, suffix=None):
 
     This function is the default for the `VIEW_NAME_FUNCTION` setting.
     """
-    name = view_cls.__name__
+    name = view_cls.view_name if hasattr(view_cls, 'view_name') else view_cls.__name__
     name = formatting.remove_trailing_string(name, 'View')
     name = formatting.remove_trailing_string(name, 'ViewSet')
     name = formatting.camelcase_to_spaces(name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ class CustomNameResourceInstance(APIView):
 
 
 class CustomNameByVariableResourceInstance(APIView):
-    view_name = "Foo"
+    view_name = "Bar"
 
 
 class ResourceViewSet(ModelViewSet):
@@ -94,11 +94,11 @@ class BreadcrumbTests(TestCase):
         ]
 
     def test_resource_instance_customnamebyvar_breadcrumbs(self):
-        url = '/resource/customname'
+        url = '/resource/customnamebyvar'
         assert get_breadcrumbs(url) == [
             ('Root', '/'),
             ('Resource Root', '/resource/'),
-            ('Foo', '/resource/customname')
+            ('Bar', '/resource/customnamebyvar')
         ]
 
     def test_nested_resource_breadcrumbs(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,10 @@ class CustomNameResourceInstance(APIView):
         return "Foo"
 
 
+class CustomNameByVariableResourceInstance(APIView):
+    view_name = "Foo"
+
+
 class ResourceViewSet(ModelViewSet):
     serializer_class = ModelSerializer
     queryset = BasicModel.objects.all()
@@ -50,6 +54,7 @@ urlpatterns = [
     url(r'^$', Root.as_view()),
     url(r'^resource/$', ResourceRoot.as_view()),
     url(r'^resource/customname$', CustomNameResourceInstance.as_view()),
+    url(r'^resource/customnamebyvar$', CustomNameByVariableResourceInstance.as_view()),
     url(r'^resource/(?P<key>[0-9]+)$', ResourceInstance.as_view()),
     url(r'^resource/(?P<key>[0-9]+)/$', NestedResourceRoot.as_view()),
     url(r'^resource/(?P<key>[0-9]+)/(?P<other>[A-Za-z]+)$', NestedResourceInstance.as_view()),
@@ -81,6 +86,14 @@ class BreadcrumbTests(TestCase):
         ]
 
     def test_resource_instance_customname_breadcrumbs(self):
+        url = '/resource/customname'
+        assert get_breadcrumbs(url) == [
+            ('Root', '/'),
+            ('Resource Root', '/resource/'),
+            ('Foo', '/resource/customname')
+        ]
+
+    def test_resource_instance_customnamebyvar_breadcrumbs(self):
         url = '/resource/customname'
         assert get_breadcrumbs(url) == [
             ('Root', '/'),


### PR DESCRIPTION
Added the functionality to change the displayed view name in the BrowsableApiView by setting view_name variable in your class based view. No need to override the function get_view_name(cls, suffix) for a static name.
