### PR TITLE
Minor change to show the current version

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -34,7 +34,7 @@ To upgrade Django REST framework to the latest version, use pip:
 
 You can determine your currently installed version using `pip freeze`:
 
-    pip freeze | grep djangorestframework
+    pip show djangorestframework
 
 ---
 


### PR DESCRIPTION
Show the current version , directly from pip

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description
It is a minor change in the docs.
If there is a large no of system wide installed python packages then `pip freeze | grep djangorestframework` would take a lot of time.
Whereas `pip show` command's purpose is itself to show the package details, so why not use it instead.
