### PR TITLE
Fix race condition in validators

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -251,6 +251,7 @@ class CreateOnlyDefault(object):
     def set_context(self, serializer_field):
         self.is_update = serializer_field.parent.instance is not None
         if callable(self.default) and hasattr(self.default, 'set_context') and not self.is_update:
+            self.default = copy.deepcopy(self.default)
             self.default.set_context(serializer_field)
 
     def __call__(self):
@@ -475,6 +476,7 @@ class Field(object):
             raise SkipField()
         if callable(self.default):
             if hasattr(self.default, 'set_context'):
+                self.default = copy.deepcopy(self.default)
                 self.default.set_context(self)
             return self.default()
         return self.default
@@ -532,6 +534,7 @@ class Field(object):
         errors = []
         for validator in self.validators:
             if hasattr(validator, 'set_context'):
+                validator = copy.deepcopy(validator)
                 validator.set_context(self)
 
             try:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -341,6 +341,28 @@ class TestUniquenessTogetherValidation(TestCase):
         validator.filter_queryset(attrs=data, queryset=queryset)
         assert queryset.called_with == {'race_name': 'bar', 'position': 1}
 
+    def test_validator_instances_with_context_are_not_used_twice(self):
+        """
+        Every instance of a serializer should use unique instances of validators
+        when calling `set_context`.
+        """
+        def data():
+            return {'race_name': 'example', 'position': 3}
+
+        def check_validators(serializer):
+            for validator in serializer.validators:
+                assert not hasattr(validator, 'instance')
+
+        serializer = UniquenessTogetherSerializer(self.instance, data=data())
+        check_validators(serializer)
+        serializer.run_validators({})
+        check_validators(serializer)
+
+        another_serializer = UniquenessTogetherSerializer(data=data())
+        check_validators(another_serializer)
+        another_serializer.run_validators(data())
+        check_validators(another_serializer)
+
 
 # Tests for `UniqueForDateValidator`
 # ----------------------------------


### PR DESCRIPTION
This fixes encode/django-rest-framework#5760 and also includes the failing test from encode/django-rest-framework#5761.

It implements the last mentioned possible fix mentioned in the issue's initial comment.