### PR TITLE
Fix schema generation for PrimaryKeyRelatedField

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -50,6 +50,14 @@ def field_to_schema(field):
             title=title,
             description=description
         )
+    elif isinstance(field, serializers.PrimaryKeyRelatedField):
+        schema_cls = coreschema.String
+        model = getattr(field.queryset, 'model', None)
+        if model is not None:
+            model_field = model._meta.pk
+            if isinstance(model_field, models.AutoField):
+                schema_cls = coreschema.Integer
+        return schema_cls(title=title, description=description)
     elif isinstance(field, serializers.RelatedField):
         return coreschema.String(title=title, description=description)
     elif isinstance(field, serializers.MultipleChoiceField):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -25,7 +25,7 @@ from rest_framework.utils import formatting
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
-from .models import BasicModel
+from .models import BasicModel, ForeignKeySource
 
 factory = APIRequestFactory()
 
@@ -553,6 +553,51 @@ class TestSchemaGeneratorWithRestrictedViewSets(TestCase):
                         fields=[]
                     ),
                 },
+            }
+        )
+        assert schema == expected
+
+
+class ForeignKeySourceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ForeignKeySource
+        fields = ('id', 'name', 'target')
+
+
+class ForeignKeySourceView(generics.CreateAPIView):
+    queryset = ForeignKeySource.objects.all()
+    serializer_class = ForeignKeySourceSerializer
+
+
+@unittest.skipUnless(coreapi, 'coreapi is not installed')
+class TestSchemaGeneratorWithForeignKey(TestCase):
+    def setUp(self):
+        self.patterns = [
+            url(r'^example/?$', ForeignKeySourceView.as_view()),
+        ]
+
+    def test_schema_for_regular_views(self):
+        """
+        Ensure that AutoField foreign keys are output as Integer.
+        """
+        generator = SchemaGenerator(title='Example API', patterns=self.patterns)
+        schema = generator.get_schema()
+
+        expected = coreapi.Document(
+            url='',
+            title='Example API',
+            content={
+                'example': {
+                    'create': coreapi.Link(
+                        url='/example/',
+                        action='post',
+                        encoding='application/json',
+                        fields=[
+                            coreapi.Field('name', required=True, location='form', schema=coreschema.String(title='Name')),
+                            coreapi.Field('target', required=True, location='form', schema=coreschema.Integer(description='Target', title='Target')),
+                        ]
+                    )
+                }
             }
         )
         assert schema == expected


### PR DESCRIPTION
By default all subclasses of RelatedField are output as string fields in
the schema, which works well for StringRelatedField, SlugRelatedField or
HyperlinkedRelatedField.

Handle the common case of a PrimaryKeyRelatedField pointing to an
AutoField.