### PR TITLE
Represent serializer DictField as an Object in schema

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -34,6 +34,11 @@ def field_to_schema(field):
             title=title,
             description=description
         )
+    elif isinstance(field, serializers.DictField):
+        return coreschema.Object(
+            title=title,
+            description=description
+        )
     elif isinstance(field, serializers.Serializer):
         return coreschema.Object(
             properties=OrderedDict([

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -51,6 +51,10 @@ class ExampleSerializer(serializers.Serializer):
     hidden = serializers.HiddenField(default='hello')
 
 
+class AnotherSerializerWithDictField(serializers.Serializer):
+    a = serializers.DictField()
+
+
 class AnotherSerializerWithListFields(serializers.Serializer):
     a = serializers.ListField(child=serializers.IntegerField())
     b = serializers.ListSerializer(child=serializers.CharField())
@@ -71,6 +75,13 @@ class ExampleViewSet(ModelViewSet):
     def custom_action(self, request, pk):
         """
         A description of custom action.
+        """
+        return super(ExampleSerializer, self).retrieve(self, request)
+
+    @detail_route(methods=['post'], serializer_class=AnotherSerializerWithDictField)
+    def custom_action_with_dict_field(self, request, pk):
+        """
+        A custom action using a dict field in the serializer.
         """
         return super(ExampleSerializer, self).retrieve(self, request)
 
@@ -198,6 +209,16 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
                             coreapi.Field('c', required=True, location='form', schema=coreschema.String(title='C')),
                             coreapi.Field('d', required=False, location='form', schema=coreschema.String(title='D')),
+                        ]
+                    ),
+                    'custom_action_with_dict_field': coreapi.Link(
+                        url='/example/{id}/custom_action_with_dict_field/',
+                        action='post',
+                        encoding='application/json',
+                        description='A custom action using a dict field in the serializer.',
+                        fields=[
+                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
+                            coreapi.Field('a', required=True, location='form', schema=coreschema.Object(title='A')),
                         ]
                     ),
                     'custom_action_with_list_fields': coreapi.Link(


### PR DESCRIPTION
DictFields were incorrectly being output as String in the schema.
This pull request outputs an Object instead and adds a unit test.