### PR TITLE
Remove unreachable code from ManualSchema

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -456,8 +456,6 @@ class ManualSchema(ViewInspector):
             description=self._description
         )
 
-        return self._link
-
 
 class DefaultSchema(object):
     """Allows overriding AutoSchema using DEFAULT_SCHEMA_CLASS setting"""


### PR DESCRIPTION
ManualSchema.get_link had two return statements. Prune the second
(unreachable) return.