### PR TITLE
Fix 0 value IntegerField in TemplateHTMLRenderer

### DIFF
--- a/rest_framework/templates/rest_framework/horizontal/input.html
+++ b/rest_framework/templates/rest_framework/horizontal/input.html
@@ -6,7 +6,7 @@
   {% endif %}
 
   <div class="col-sm-10">
-    <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value %}value="{{ field.value }}"{% endif %} {% if style.autofocus and style.input_type != "hidden" %}autofocus{% endif %}>
+    <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value is not None and field.value != "" %}value="{{ field.value }}"{% endif %} {% if style.autofocus and style.input_type != "hidden" %}autofocus{% endif %}>
 
     {% if field.errors %}
       {% for error in field.errors %}

--- a/rest_framework/templates/rest_framework/inline/input.html
+++ b/rest_framework/templates/rest_framework/inline/input.html
@@ -5,5 +5,5 @@
     </label>
   {% endif %}
 
-  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value %}value="{{ field.value }}"{% endif %} {% if style.autofocus and style.input_type != "hidden" %}autofocus{% endif %}>
+  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value is not None and field.value != '' %}value="{{ field.value }}"{% endif %} {% if style.autofocus and style.input_type != "hidden" %}autofocus{% endif %}>
 </div>

--- a/rest_framework/templates/rest_framework/vertical/input.html
+++ b/rest_framework/templates/rest_framework/vertical/input.html
@@ -3,7 +3,7 @@
     <label {% if style.hide_label %}class="sr-only"{% endif %}>{{ field.label }}</label>
   {% endif %}
 
-  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value %}value="{{ field.value }}"{% endif %} {% if style.autofocus and style.input_type != "hidden" %}autofocus{% endif %}>
+  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value is not None and field.value != "" %}value="{{ field.value }}"{% endif %} {% if style.autofocus and style.input_type != "hidden" %}autofocus{% endif %}>
 
   {% if field.errors %}
     {% for error in field.errors %}


### PR DESCRIPTION
Signed-off-by: Nikhil Sheoran <nikhilsheoran96@gmail.com>

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description
Fixes #5767
The current implementation of `TemplateHTMLRenderer's input.html` for various template packs checked `{% if field.value %}` which gave incorrect validation for IntegerField with 0 as input. This PR fixes it by checking `{% if field.value is not None and field.value != "" %}`