### PR TITLE
Rename '_request' to 'http_request'

### DIFF
--- a/docs/api-guide/requests.md
+++ b/docs/api-guide/requests.md
@@ -130,6 +130,9 @@ As REST framework's `Request` extends Django's `HttpRequest`, all the other stan
 
 Note that due to implementation reasons the `Request` class does not inherit from `HttpRequest` class, but instead extends the class using composition.
 
+# Accessing the HttpRequest
+
+The underlying `HttpRequest` can be accessed through the `.http_request` attribute. While direct manipulation of the `HttpRequest` is discouraged, there are some advanced use cases that may require it. For example, one view may delegate request handling to a secondary view function. In this case, it is necessary to pass the original `HttpRequest` to the delegated view instead of the DRF `Request` object. Be aware that duplicate processing of the `HttpRequest` may have have unintended side effects. For example, if the request stream has already been consumed, it may not be accessible for a second read and will raise an exception.
 
 [cite]: https://groups.google.com/d/topic/django-developers/dxI4qVzrBY4/discussion
 [parsers documentation]: parsers.md

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -121,7 +121,7 @@ class SessionAuthentication(BaseAuthentication):
         """
 
         # Get the session-based user from the underlying HttpRequest object
-        user = getattr(request._request, 'user', None)
+        user = getattr(request.http_request, 'user', None)
 
         # Unauthenticated, CSRF validation not required
         if not user or not user.is_active:

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -295,10 +295,11 @@ class Request(object):
             else:
                 self._full_data = self._data
 
-            # copy data & files refs to the underlying request so that closable
-            # objects are handled appropriately.
-            self.http_request._post = self.POST
-            self.http_request._files = self.FILES
+            # if a form media type, copy data & files refs to the underlying
+            # http request so that closable objects are handled appropriately.
+            if is_form_media_type(self.content_type):
+                self.http_request._post = self.POST
+                self.http_request._files = self.FILES
 
     def _load_stream(self):
         """

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -11,6 +11,7 @@ The wrapped request then offers a richer API, in particular :
 from __future__ import unicode_literals
 
 import sys
+import warnings
 from contextlib import contextmanager
 
 from django.conf import settings
@@ -159,7 +160,7 @@ class Request(object):
             .format(request.__class__.__module__, request.__class__.__name__)
         )
 
-        self._request = request
+        self.http_request = request
         self.parsers = parsers or ()
         self.authenticators = authenticators or ()
         self.negotiator = negotiator or self._default_negotiator()
@@ -180,6 +181,22 @@ class Request(object):
         if force_user is not None or force_token is not None:
             forced_auth = ForcedAuthentication(force_user, force_token)
             self.authenticators = (forced_auth,)
+
+    @property
+    def _request(self):
+        warnings.warn(
+            "`_request` has been deprecated in favor of `http_request`, and will be removed in 3.10",
+            PendingDeprecationWarning, stacklevel=2
+        )
+        return self.http_request
+
+    @_request.setter
+    def _request(self, value):
+        warnings.warn(
+            "`_request` has been deprecated in favor of `http_request`, and will be removed in 3.10",
+            PendingDeprecationWarning, stacklevel=2
+        )
+        self.http_request = value
 
     def _default_negotiator(self):
         return api_settings.DEFAULT_CONTENT_NEGOTIATION_CLASS()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -292,3 +292,22 @@ class TestHttpRequest(TestCase):
         message = "'Request' object has no attribute 'inner_property'"
         with self.assertRaisesMessage(AttributeError, message):
             request.inner_property
+
+    def test_request_deprecation(self):
+        with pytest.warns(PendingDeprecationWarning) as record:
+            Request(factory.get('/'))._request
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "`_request` has been deprecated in favor of "
+            "`http_request`, and will be removed in 3.10"
+        )
+
+        with pytest.warns(PendingDeprecationWarning) as record:
+            Request(factory.get('/'))._request = None
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "`_request` has been deprecated in favor of "
+            "`http_request`, and will be removed in 3.10"
+        )

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -271,23 +271,23 @@ class TestSecure(TestCase):
         assert request.scheme == 'https'
 
 
-class TestWSGIRequestProxy(TestCase):
-    def test_attribute_access(self):
-        wsgi_request = factory.get('/')
-        request = Request(wsgi_request)
+class TestHttpRequest(TestCase):
+    def test_attribute_access_proxy(self):
+        http_request = factory.get('/')
+        request = Request(http_request)
 
         inner_sentinel = object()
-        wsgi_request.inner_property = inner_sentinel
+        http_request.inner_property = inner_sentinel
         assert request.inner_property is inner_sentinel
 
         outer_sentinel = object()
         request.inner_property = outer_sentinel
         assert request.inner_property is outer_sentinel
 
-    def test_exception(self):
+    def test_exception_proxy(self):
         # ensure the exception message is not for the underlying WSGIRequest
-        wsgi_request = factory.get('/')
-        request = Request(wsgi_request)
+        http_request = factory.get('/')
+        request = Request(http_request)
 
         message = "'Request' object has no attribute 'inner_property'"
         with self.assertRaisesMessage(AttributeError, message):


### PR DESCRIPTION
Per @sigmavirus24's suggestion in #5618, this adds the underlying HttpRequest object to the public interface of the DRF Request. `Request._request` has been deprecated in favor of `Request.http_request`.

This also fixes a bug introduced in #5590. POST/FILES should only be set on the Django request when the media type is one of the form types.