### PR TITLE
Use {% load static %} instead of {% load staticfiles %} in templates

### DIFF
--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -395,7 +395,7 @@ Once the API documentation URLs are installed, you'll be able to include both th
         /static/rest_framework/js/coreapi-0.1.1.js
         /docs/schema.js
     -->
-    {% load staticfiles %}
+    {% load static %}
     <script src="{% static 'rest_framework/js/coreapi-0.1.1.js' %}"></script>
     <script src="{% url 'api-docs:schema-js' %}"></script>
 

--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load rest_framework %}
 

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load rest_framework %}
 

--- a/rest_framework/templates/rest_framework/docs/error.html
+++ b/rest_framework/templates/rest_framework/docs/error.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
     <head>

--- a/rest_framework/templates/rest_framework/docs/index.html
+++ b/rest_framework/templates/rest_framework/docs/index.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
     <head>

--- a/rest_framework/templates/rest_framework/docs/langs/javascript-intro.html
+++ b/rest_framework/templates/rest_framework/docs/langs/javascript-intro.html
@@ -1,5 +1,5 @@
 {% load rest_framework %}
-{% load staticfiles %}
+{% load static %}
 <pre class="highlight javascript hide" data-language="javascript"><code>{% code html %}<!-- Load the JavaScript client library -->
 <script src="{% static 'rest_framework/js/coreapi-0.1.1.js' %}"></script>
 <script src="{% url 'api-docs:schema-js' %}"></script>{% endcode %}</code></pre>

--- a/rest_framework/templates/rest_framework/login_base.html
+++ b/rest_framework/templates/rest_framework/login_base.html
@@ -1,5 +1,4 @@
 {% extends "rest_framework/base.html" %}
-{% load staticfiles %}
 {% load rest_framework %}
 
 {% block body %}


### PR DESCRIPTION
Starting with Django 1.10, it is preferable to load the `static` template tag library instead of `staticfiles`. If `django.contrib.staticfiles` is in `INSTALLED_APPS`, the `static` template tag library will use the `staticfiles` app to determine static paths. For additional details, see:

https://docs.djangoproject.com/en/dev/releases/1.10/#django-contrib-staticfiles

> The static template tag now uses `django.contrib.staticfiles` if it’s in `INSTALLED_APPS`. This is especially useful for third-party apps which can now always use `{% load static %}` (instead of `{% load staticfiles %}` or `{% load static from staticfiles %}`) and not worry about whether or not the `staticfiles` app is installed.

The `staticfiles` template tag library will be deprecated and removed in a future Django version.