### PR TITLE
get_error_detail: use error_list to get code(s)

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -233,10 +233,21 @@ def get_error_detail(exc_info):
     with the `code` populated.
     """
     code = getattr(exc_info, 'code', None) or 'invalid'
-    return [
-        ErrorDetail(msg, code=code)
-        for msg in exc_info.messages
-    ]
+
+    try:
+        error_dict = exc_info.error_dict
+    except AttributeError:
+        return [
+            ErrorDetail(error.message % (error.params or ()),
+                        code=error.code if error.code else code)
+            for error in exc_info.error_list]
+    return {
+        k: [
+            ErrorDetail(error.message % (error.params or ()),
+                        code=error.code if error.code else code)
+            for error in errors
+        ] for k, errors in error_dict.items()
+    }
 
 
 class CreateOnlyDefault(object):


### PR DESCRIPTION
This is necessary to get code(s) for validation errors.

Via e.g. `password_validation.validate_password` and `get_error_detail` used in https://github.com/encode/django-rest-framework/blob/75cf06e40f11da7b942c73e90234cde67c94dd28/rest_framework/serializers.py#L471 then.

TODO:

- [x] clean up (uncovered/unnecessary code)