### PR TITLE
ErrorDetail: add __eq__/__ne__ and __repr__

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 
 from rest_framework import status
+from rest_framework.compat import unicode_to_repr
 from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 
@@ -72,6 +73,22 @@ class ErrorDetail(six.text_type):
         self = super(ErrorDetail, cls).__new__(cls, string)
         self.code = code
         return self
+
+    def __eq__(self, other):
+        r = super(ErrorDetail, self).__eq__(other)
+        try:
+            return r and self.code == other.code
+        except AttributeError:
+            return r
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return unicode_to_repr('ErrorDetail(string=%r, code=%r)' % (
+            six.text_type(self),
+            self.code,
+        ))
 
 
 class APIException(Exception):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -53,6 +53,33 @@ class ExceptionTestCase(TestCase):
             'code': 'throttled'}
 
 
+class ErrorDetailTests(TestCase):
+
+    def test_eq(self):
+        assert ErrorDetail('msg') == ErrorDetail('msg')
+        assert ErrorDetail('msg', 'code') == ErrorDetail('msg', code='code')
+
+        assert ErrorDetail('msg') == 'msg'
+        assert ErrorDetail('msg', 'code') == 'msg'
+
+    def test_ne(self):
+        assert ErrorDetail('msg1') != ErrorDetail('msg2')
+        assert ErrorDetail('msg') != ErrorDetail('msg', code='invalid')
+
+        assert ErrorDetail('msg1') != 'msg2'
+        assert ErrorDetail('msg1', 'code') != 'msg2'
+
+    def test_repr(self):
+        assert repr(ErrorDetail('msg1')) == \
+            'ErrorDetail(string={!r}, code=None)'.format('msg1')
+        assert repr(ErrorDetail('msg1', 'code')) == \
+            'ErrorDetail(string={!r}, code={!r})'.format('msg1', 'code')
+
+    def test_str(self):
+        assert str(ErrorDetail('msg1')) == 'msg1'
+        assert str(ErrorDetail('msg1', 'code')) == 'msg1'
+
+
 class TranslationTests(TestCase):
 
     @translation.override('fr')


### PR DESCRIPTION
This mainly adds `__eq__` to handle `code` in comparisons.

When comparing an ErrorDetail to a string (missing `code` there) the
ErrorDetail's `code` is ignored, but otherwise it is taken into account.