### PR TITLE
AttributeError: 'NoneType' object has no attribute '_meta'

### DIFF
--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -93,6 +93,7 @@ def _get_forward_relationships(opts):
             # manytomany do not have to_fields
             to_field=None,
             has_through_model=(
+                (getattr(field.remote_field, 'through', None) is not None) and
                 not field.remote_field.through._meta.auto_created
             ),
             reverse=False


### PR DESCRIPTION
I follow the official guide to extend the default User model, so that user can login with email instead of username.  I checked my code and it is same as (at least two or three) online tutorials, including the official one.  When I build a basic serializer as other models, and tried to list all users, I got `AttributeError: 'NoneType' object has no attribute '_meta'` error:

File "/rest_framework/utils/model_meta.py", line 96, in _get_forward_relationships
  not field.remote_field.through._meta.auto_created

Where:
field = auth.User.groups
field.remote_field.model = <class 'django.contrib.auth.models.Group'>

Referring to the function `def _get_reverse_relationships(opts):` below, which guard with None check, I added this None check in `_get_forward_relationships` and the serializer works.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
