### PR TITLE
Fix support for ListField default values in HTML mode

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1610,7 +1610,8 @@ class ListField(Field):
         # lists in HTML forms.
         if html.is_html_input(dictionary):
             if self.field_name not in dictionary:
-                return empty
+                if not any(k.startswith("%s[" % self.field_name) for k in dictionary):
+                    return empty
             val = dictionary.getlist(self.field_name, [])
             if len(val) > 0:
                 # Support QueryDict lists in HTML input.

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1609,6 +1609,8 @@ class ListField(Field):
         # We override the default field access in order to support
         # lists in HTML forms.
         if html.is_html_input(dictionary):
+            if self.field_name not in dictionary:
+                return empty
             val = dictionary.getlist(self.field_name, [])
             if len(val) > 0:
                 # Support QueryDict lists in HTML input.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -459,6 +459,31 @@ class TestHTMLInput:
         assert serializer.is_valid()
         assert serializer.validated_data == {'scores': [1]}
 
+    def test_querydict_list_input_no_values_uses_default(self):
+        """
+        When there are no values passed in, and default is set
+        The field should return the default value
+        """
+        class TestSerializer(serializers.Serializer):
+            a = serializers.IntegerField(required=True)
+            scores = serializers.ListField(default=lambda: [1, 3])
+
+        serializer = TestSerializer(data=QueryDict('a=1&'))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'a': 1, 'scores': [1, 3]}
+
+    def test_querydict_list_input_no_values_no_default_and_not_required(self):
+        """
+        When there are no keys passed, there is no default, and required=False
+        The field should be skipped
+        """
+        class TestSerializer(serializers.Serializer):
+            scores = serializers.ListField(required=False)
+
+        serializer = TestSerializer(data=QueryDict(''))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {}
+
 
 class TestCreateOnlyDefault:
     def setup(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -472,6 +472,18 @@ class TestHTMLInput:
         assert serializer.is_valid()
         assert serializer.validated_data == {'a': 1, 'scores': [1, 3]}
 
+    def test_querydict_list_input_supports_indexed_keys(self):
+        """
+        When data is passed in the format `scores[0]=1&scores[1]=3`
+        The field should return the correct list, ignoring the default
+        """
+        class TestSerializer(serializers.Serializer):
+            scores = serializers.ListField(default=lambda: [1, 3])
+
+        serializer = TestSerializer(data=QueryDict("scores[0]=5&scores[1]=6"))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'scores': ['5', '6']}
+
     def test_querydict_list_input_no_values_no_default_and_not_required(self):
         """
         When there are no keys passed, there is no default, and required=False
@@ -483,6 +495,19 @@ class TestHTMLInput:
         serializer = TestSerializer(data=QueryDict(''))
         assert serializer.is_valid()
         assert serializer.validated_data == {}
+
+    def test_querydict_list_input_posts_key_but_no_values(self):
+        """
+        When there are no keys passed, there is no default, and required=False
+        The field should return an array of 1 item, blank
+        * Not sure if this is desired behavior, but it is logical at least
+        """
+        class TestSerializer(serializers.Serializer):
+            scores = serializers.ListField(required=False)
+
+        serializer = TestSerializer(data=QueryDict('scores=&'))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'scores': ['']}
 
 
 class TestCreateOnlyDefault:


### PR DESCRIPTION
The ListField handles html forms data differently than json data.  This section
would always return a value (an empty list) for a list field, even when that
field name was not posted at all.  This change checks for the field being
present and returns `empty` if it is not; this lets the standard default-value and
required field handling take over.

* Both tests cases will fail if run against master (key is present, value is `[]`)
* Suggestions for other test cases would be appreciated
* All other tests pass (django 1.11.5 installed)

Change was done where it is to make sure everything was clear.  There may be a better, more general, location to put it.  I wasn't comfortable combining the handling with the first check, because I'm sure there is a reason to call out the `'partial'` condition (for clarity?).  One could certainly delete that line, and just use:

```python
def get_value(self, dictionary):
    if self.field_name not in dictionary:
        return empty
    # no other changes
```

Suggestions welcome

----
refs #5807 
