### PR TITLE
[WIP/RFC] use field default value if not allow_null

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -499,6 +499,13 @@ class Serializer(BaseSerializer):
             # resolve the pk value.
             check_for_none = attribute.pk if isinstance(attribute, PKOnlyObject) else attribute
             if check_for_none is None:
+                if not field.allow_null:
+                    try:
+                        ret[field.field_name] = field.get_default()
+                    except SkipField:
+                        pass
+                    else:
+                        continue
                 ret[field.field_name] = None
             else:
                 ret[field.field_name] = field.to_representation(attribute)


### PR DESCRIPTION
This is meant to be used with FK remote field lookups (`source =
'foo.bar'`), where `foo` is a model and `bar` is `None` there.

     serializers.CharField(source='foo.bar', default='default')

No existing tests seem to be failing, and new one would be needed.
Not really sure if this is going to fly, so holding back on that for now.