### PR TITLE
Move isort/lint commands out of test runner

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,0 @@
-[settings]
-skip=.tox
-atomic=true
-multi_line_output=5
-known_standard_library=types
-known_third_party=pytest,_pytest,django
-known_first_party=rest_framework

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       - { python: "3.6", env: DJANGO=master }
       - { python: "3.6", env: DJANGO=1.11 }
       - { python: "3.6", env: DJANGO=2.0 }
-      - { python: "2.7", env: TOXENV=lint }
+      - { python: "3.6", env: "TOXENV=isort,lint" }
       - { python: "2.7", env: TOXENV=docs }
 
       - python: "3.6"

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 from __future__ import print_function
 
-import subprocess
 import sys
 
 import pytest
@@ -11,33 +10,10 @@ PYTEST_ARGS = {
     'fast': ['tests', '--tb=short', '-q', '-s', '-rw'],
 }
 
-FLAKE8_ARGS = ['rest_framework', 'tests']
-
-ISORT_ARGS = ['--recursive', '--check-only', '-o' 'uritemplate', '-p', 'tests', 'rest_framework', 'tests']
-
 
 def exit_on_failure(ret, message=None):
     if ret:
         sys.exit(ret)
-
-
-def flake8_main(args):
-    print('Running flake8 code linting')
-    ret = subprocess.call(['flake8'] + args)
-    print('flake8 failed' if ret else 'flake8 passed')
-    return ret
-
-
-def isort_main(args):
-    print('Running isort code checking')
-    ret = subprocess.call(['isort'] + args)
-
-    if ret:
-        print('isort failed: Some modules have incorrectly ordered imports. Fix by running `isort --recursive .`')
-    else:
-        print('isort passed')
-
-    return ret
 
 
 def split_class_and_function(string):
@@ -56,22 +32,6 @@ def is_class(string):
 
 
 if __name__ == "__main__":
-    try:
-        sys.argv.remove('--nolint')
-    except ValueError:
-        run_flake8 = True
-        run_isort = True
-    else:
-        run_flake8 = False
-        run_isort = False
-
-    try:
-        sys.argv.remove('--lintonly')
-    except ValueError:
-        run_tests = True
-    else:
-        run_tests = False
-
     try:
         sys.argv.remove('--fast')
     except ValueError:
@@ -110,11 +70,4 @@ if __name__ == "__main__":
     else:
         pytest_args = PYTEST_ARGS[style]
 
-    if run_tests:
-        exit_on_failure(pytest.main(pytest_args))
-
-    if run_flake8:
-        exit_on_failure(flake8_main(FLAKE8_ARGS))
-
-    if run_isort:
-        exit_on_failure(isort_main(ISORT_ARGS))
+    exit_on_failure(pytest.main(pytest_args))

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,11 @@ license_file = LICENSE.md
 [flake8]
 ignore = E501
 banned-modules = json = use from rest_framework.utils import json!
+
+[isort]
+skip = .tox
+atomic = true
+multi_line_output = 5
+known_standard_library = types
+known_third_party = pytest,_pytest,django
+known_first_party = rest_framework

--- a/tox.ini
+++ b/tox.ini
@@ -37,12 +37,15 @@ deps =
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt
 
-[testenv:lint]
-basepython = python2.7
-commands = ./runtests.py --lintonly
+[testenv:isort]
+commands = isort --recursive --check-only rest_framework tests {posargs}
 deps =
-        -rrequirements/requirements-codestyle.txt
-        -rrequirements/requirements-testing.txt
+       -rrequirements/requirements-codestyle.txt
+
+[testenv:lint]
+commands = flake8 rest_framework tests {posargs}
+deps =
+       -rrequirements/requirements-codestyle.txt
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
In general, it doesn't seem necessary to integrate linting and sorting into the test runner. This method complicates running isort with specific options, such as `--diff`. Moving the command into tox simplifies this, and options can be provided after the `--` options separator. eg, 

```
$ tox -e isort -- --diff
```

Note that the lint travis build runs both the `isort` and `lint` builds.