### PR TITLE
Changes ternary conditionals to be PEP308 compliant

### DIFF
--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -33,8 +33,8 @@ And now we can add a `.save()` method to our model class:
         representation of the code snippet.
         """
         lexer = get_lexer_by_name(self.language)
-        linenos = self.linenos and 'table' or False
-        options = self.title and {'title': self.title} or {}
+        linenos = 'table' if self.linenos else False
+        options = {'title': self.title} if self.title else {}
         formatter = HtmlFormatter(style=self.style, linenos=linenos,
                                   full=True, **options)
         self.highlighted = highlight(self.code, lexer, formatter)

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -148,7 +148,7 @@ class SimpleRouter(BaseRouter):
     ]
 
     def __init__(self, trailing_slash=True):
-        self.trailing_slash = trailing_slash and '/' or ''
+        self.trailing_slash = '/' if trailing_slash else ''
         super(SimpleRouter, self).__init__()
 
     def get_default_base_name(self, viewset):


### PR DESCRIPTION
## Description

Updates the tutorial and the codebase to be be PEP308-compliant with regards to conditional ternary operations `this if condition else that`.

I came across this from following the tutorial and found that the example was using `condition and this or that`-style conditional which seemed not very Pythonic. The codebase only uses this style once and this pull request also changes that instance.