### PR TITLE
Escape docstring markup that causes sphinx error.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -885,14 +885,14 @@ class ModelSerializer(Serializer):
         descriptive messages when something goes wrong, but this method is
         essentially just:
 
-            return ExampleModel.objects.create(**validated_data)
+            return ExampleModel.objects.create(\*\*validated_data)
 
         If there are many to many fields present on the instance then they
         cannot be set until the model is instantiated, in which case the
         implementation is like so:
 
             example_relationship = validated_data.pop('example_relationship')
-            instance = ExampleModel.objects.create(**validated_data)
+            instance = ExampleModel.objects.create(\*\*validated_data)
             instance.example_relationship = example_relationship
             return instance
 


### PR DESCRIPTION
Our Sphinx build recently start failing on a class that subclasses `serializers.HyperlinkedModelSerializer`: https://github.com/pulp/pulp/blob/3.0-dev/pulpcore/pulpcore/app/serializers/base.py#L105

Delving into this issue showed that sphinx 1.7 does not like unescaped asterisks. I know you guys are unaffected by this since you don't use sphinx, but any project that subclasses an offending docstring will run into this error.