### PR TITLE
Fixed active timezone handling for non ISO8601 datetimes. 

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1212,8 +1212,9 @@ class DateTimeField(Field):
         if output_format is None or isinstance(value, six.string_types):
             return value
 
+        value = self.enforce_timezone(value)
+
         if output_format.lower() == ISO_8601:
-            value = self.enforce_timezone(value)
             value = value.isoformat()
             if value.endswith('+00:00'):
                 value = value[:-6] + 'Z'


### PR DESCRIPTION
Updates and closes #5821. 

* Adds (previously failing) test for non-ISO8601 formatted datetimes, when overriding active timezone. (Thanks @hakib.)
* Applies `enforce_timezone` in all cases, not just ISO 8601 datetimes. 