### PR TITLE
Corrected endpoint in tutorial instructions

### DIFF
--- a/docs/tutorial/7-schemas-and-client-libraries.md
+++ b/docs/tutorial/7-schemas-and-client-libraries.md
@@ -47,7 +47,7 @@ urlpatterns = [
 ]
 ```
 
-If you visit the API root endpoint in a browser you should now see `corejson`
+If you visit the `/schema/` endpoint in a browser you should now see `corejson`
 representation become available as an option.
 
 ![Schema format](../img/corejson-format.png)


### PR DESCRIPTION
Closes #5810

Issue report was correct: corejson is not available on the [root endpoint](https://restframework.herokuapp.com/), but on the [/schema/ endpoint](https://restframework.herokuapp.com/schema/).