### PR TITLE
Corrected docs on router include with namespaces.

### DIFF
--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -72,14 +72,23 @@ Alternatively you can use Django's `include` function, like so…
         url(r'^', include(router.urls)),
     ]
 
-Router URL patterns can also be namespaces.
+Router URL patterns can also be included using _application_ and _instance_ namespaces.
+
+To use an _application namespace_ pass a 2-tuple containing the `router.urls` and the app name.
+To use an _instance namespace_ pass the optional `namespace` parameter.
+
+For example:
 
     urlpatterns = [
         url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        url(r'^api/', include(router.urls, namespace='api')),
+        url(r'^api/', include((router.urls, 'app_name'),  namespace='instance_name')),
     ]
 
-If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters on the serializers correctly reflect the namespace. In the example above you'd need to include a parameter such as `view_name='api:user-detail'` for serializer fields hyperlinked to the user detail view.
+If you pass the optional `namespace` parameter to create an _instance namespace_ then you **must** provide the _application namespace_ as well.
+See Django's [URL namespaces docs][url-namespace-docs] for more.
+
+If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters on the serializers correctly reflect the namespace.
+In the example above you'd need to include a parameter such as `view_name='app_name:user-detail'` for serializer fields hyperlinked to the user detail view.
 
 ### Routing for extra actions
 
@@ -315,3 +324,4 @@ The [`DRF-extensions` package][drf-extensions] provides [routers][drf-extensions
 [drf-extensions-nested-viewsets]: https://chibisov.github.io/drf-extensions/docs/#nested-routes
 [drf-extensions-collection-level-controllers]: https://chibisov.github.io/drf-extensions/docs/#collection-level-controllers
 [drf-extensions-customizable-endpoint-names]: https://chibisov.github.io/drf-extensions/docs/#controller-endpoint-name
+[url-namespace-docs]: https://docs.djangoproject.com/en/1.11/topics/http/urls/#url-namespaces

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -79,7 +79,7 @@ For example:
 
     urlpatterns = [
         url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        url(r'^api/', include((router.urls, 'app_name')),
+        url(r'^api/', include((router.urls, 'app_name'))),
     ]
 
 (`include` also allows an optional `namespace` parameter to also create an _instance namespace_.

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -73,7 +73,7 @@ Alternatively you can use Django's `include` function, like so…
     ]
 
 To include the router URL patterns with an application namespace pass a
-`(router.urls, app_name)` 2-tuple to `include`.
+`(router.urls, 'app_name')` 2-tuple to `include`.
 
 For example:
 
@@ -82,9 +82,8 @@ For example:
         url(r'^api/', include((router.urls, 'app_name'))),
     ]
 
-(`include` also allows an optional `namespace` parameter to also create an _instance namespace_.
-This defaults to `None` and will be set to `app_name` if not provided.
-See Django's [URL namespaces docs][url-namespace-docs] for more details.)
+(You may additionally pass an optional `namespace` parameter to `include` to also
+create an _instance namespace_. See Django's [URL namespaces docs][url-namespace-docs] for more details.)
 
 If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters on the serializers correctly reflect the namespace.
 In the example above you'd need to include a parameter such as `view_name='app_name:user-detail'` for serializer fields hyperlinked to the user detail view.

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -72,18 +72,21 @@ Alternatively you can use Django's `include` function, like so…
         url(r'^', include(router.urls)),
     ]
 
-To include the router URL patterns with an application namespace pass a
-`(router.urls, 'app_name')` 2-tuple to `include`.
-
-For example:
+You may use `include` with an application namespace:
 
     urlpatterns = [
         url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
         url(r'^api/', include((router.urls, 'app_name'))),
     ]
 
-(You may additionally pass an optional `namespace` parameter to `include` to also
-create an _instance namespace_. See Django's [URL namespaces docs][url-namespace-docs] for more details.)
+Or both an application and instance namespace:
+
+    urlpatterns = [
+        url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
+        url(r'^api/', include((router.urls, 'app_name'), namespace='instance_name')),
+    ]
+
+See Django's [URL namespaces docs][url-namespace-docs] and the [`include` API reference][include-api-reference] for more details.
 
 If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters on the serializers correctly reflect the namespace.
 In the example above you'd need to include a parameter such as `view_name='app_name:user-detail'` for serializer fields hyperlinked to the user detail view.

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -88,8 +88,16 @@ Or both an application and instance namespace:
 
 See Django's [URL namespaces docs][url-namespace-docs] and the [`include` API reference][include-api-reference] for more details.
 
-If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters on the serializers correctly reflect the namespace.
-In the example above you'd need to include a parameter such as `view_name='app_name:user-detail'` for serializer fields hyperlinked to the user detail view.
+---
+
+**Note**: If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters
+on the serializers correctly reflect the namespace. In the examples above you'd need to include a parameter such as
+`view_name='app_name:user-detail'` for serializer fields hyperlinked to the user detail view.
+
+The automatic `view_name` generation uses a pattern like `%(model_name)-detail`. Unless your models names actually clash
+you may be better off **not** namespacing your Django REST Framework views when using hyperlinked serializers.
+
+---
 
 ### Routing for extra actions
 
@@ -326,3 +334,4 @@ The [`DRF-extensions` package][drf-extensions] provides [routers][drf-extensions
 [drf-extensions-collection-level-controllers]: https://chibisov.github.io/drf-extensions/docs/#collection-level-controllers
 [drf-extensions-customizable-endpoint-names]: https://chibisov.github.io/drf-extensions/docs/#controller-endpoint-name
 [url-namespace-docs]: https://docs.djangoproject.com/en/1.11/topics/http/urls/#url-namespaces
+[include-api-reference]: https://docs.djangoproject.com/en/2.0/ref/urls/#include

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -72,20 +72,19 @@ Alternatively you can use Django's `include` function, like so…
         url(r'^', include(router.urls)),
     ]
 
-Router URL patterns can also be included using _application_ and _instance_ namespaces.
-
-To use an _application namespace_ pass a 2-tuple containing the `router.urls` and the app name.
-To use an _instance namespace_ pass the optional `namespace` parameter.
+To include the router URL patterns with an application namespace pass a
+`(router.urls, app_name)` 2-tuple to `include`.
 
 For example:
 
     urlpatterns = [
         url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        url(r'^api/', include((router.urls, 'app_name'),  namespace='instance_name')),
+        url(r'^api/', include((router.urls, 'app_name')),
     ]
 
-If you pass the optional `namespace` parameter to create an _instance namespace_ then you **must** provide the _application namespace_ as well.
-See Django's [URL namespaces docs][url-namespace-docs] for more.
+(`include` also allows an optional `namespace` parameter to also create an _instance namespace_.
+This defaults to `None` and will be set to `app_name` if not provided.
+See Django's [URL namespaces docs][url-namespace-docs] for more details.)
 
 If using namespacing with hyperlinked serializers you'll also need to ensure that any `view_name` parameters on the serializers correctly reflect the namespace.
 In the example above you'd need to include a parameter such as `view_name='app_name:user-detail'` for serializer fields hyperlinked to the user detail view.


### PR DESCRIPTION
For Django 2.0 you MUST provide `app_name` when using `namespace`.

Closes #5659 