### PR TITLE
Add LimitOffsetPagination.get_count to allow method override

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -460,8 +460,8 @@ class LimitOffsetPagination(BasePagination):
 
     def get_count(self, queryset):
         """
-            Determine an object count, supporting either querysets or regular lists.
-            """
+        Determine an object count, supporting either querysets or regular lists.
+        """
         try:
             return queryset.count()
         except (AttributeError, TypeError):

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -45,16 +45,6 @@ def _divide_with_ceil(a, b):
     return a // b
 
 
-def _get_count(queryset):
-    """
-    Determine an object count, supporting either querysets or regular lists.
-    """
-    try:
-        return queryset.count()
-    except (AttributeError, TypeError):
-        return len(queryset)
-
-
 def _get_displayed_page_numbers(current, final):
     """
     This utility function determines a list of page numbers to display.
@@ -332,7 +322,7 @@ class LimitOffsetPagination(BasePagination):
     template = 'rest_framework/pagination/numbers.html'
 
     def paginate_queryset(self, queryset, request, view=None):
-        self.count = _get_count(queryset)
+        self.count = self.get_count(queryset)
         self.limit = self.get_limit(request)
         if self.limit is None:
             return None
@@ -467,6 +457,15 @@ class LimitOffsetPagination(BasePagination):
                 )
             )
         ]
+
+    def get_count(self, queryset):
+        """
+            Determine an object count, supporting either querysets or regular lists.
+            """
+        try:
+            return queryset.count()
+        except (AttributeError, TypeError):
+            return len(queryset)
 
 
 class CursorPagination(BasePagination):


### PR DESCRIPTION
## Description

This PR:
- removes `pagination._get_count`
- adds `LimitOffsetPagination.get_count` instance method
- modifies `LimitOffsetPagination.paginate_queryset`

I have a custom pagination class that subclasses `LimitOffsetPagination`. When paginating a large queryset with an `.order_by()` clause, the combination of sorting can add a lot of overhead to the pagination calculation, which in turn slows down the entire response. Adding `get_count()` as an instance method gives developers the ability to override it's behavior if necessary. In my case, I will override the method to remove any ordering constraints from the queryset.