### PR TITLE
Allow traversing nullable related fields

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -174,7 +174,7 @@ class RelatedField(Field):
                 pass
 
         # Standard case, return the object instance.
-        return get_attribute(instance, self.source_attrs)
+        return super(RelatedField, self).get_attribute(instance)
 
     def get_choices(self, cutoff=None):
         queryset = self.get_queryset()


### PR DESCRIPTION
This allows you to have a related field that traverses nullable relations. A default is required to have the value in the output, but the current behaviour is to throw an AttributeError.

Closes #5848

