### PR TITLE
Don't show hidden fields in OPTIONS responses

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -110,6 +110,7 @@ class SimpleMetadata(BaseMetadata):
         return OrderedDict([
             (field_name, self.get_field_info(field))
             for field_name, field in serializer.fields.items()
+            if not isinstance(field, serializers.HiddenField)
         ])
 
     def get_field_info(self, field):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -268,6 +268,27 @@ class TestMetadata:
         view = ExampleView.as_view(versioning_class=scheme)
         view(request=request)
 
+    def test_dont_show_hidden_fields(self):
+        """
+        HiddenField shouldn't show up in SimpleMetadata at all.
+        """
+        class ExampleSerializer(serializers.Serializer):
+            integer_field = serializers.IntegerField(max_value=10)
+            hidden_field = serializers.HiddenField(default=1)
+
+        class ExampleView(views.APIView):
+            """Example view."""
+            def post(self, request):
+                pass
+
+            def get_serializer(self):
+                return ExampleSerializer()
+
+        view = ExampleView.as_view()
+        response = view(request=request)
+        assert response.status_code == status.HTTP_200_OK
+        assert set(response.data['actions']['POST'].keys()) == {'integer_field'}
+
     def test_list_serializer_metadata_returns_info_about_fields_of_child_serializer(self):
         class ExampleSerializer(serializers.Serializer):
             integer_field = serializers.IntegerField(max_value=10)


### PR DESCRIPTION
`HiddenField` is meant to be entirely hidden, but we discovered it showing up in `OPTIONS` requests in `actions`.

This fixes the problem by skipping `HiddenField` instances in `SimpleMetadata.get_serializer_info`, and adds a test.