### PR TITLE
[WIP] Integrate coreapi v3. 

### DIFF
--- a/requirements-coreapi-3.txt
+++ b/requirements-coreapi-3.txt
@@ -1,0 +1,17 @@
+attrs==17.4.0
+certifi==2018.1.18
+chardet==3.0.4
+-e git+https://github.com/core-api/python-client.git@b56b1d64fcebd765d458f546b3c38762fd65f042#egg=coreapi
+coverage==4.5.1
+Django==2.0.2
+idna==2.6
+pluggy==0.6.0
+py==1.5.2
+pytest==3.4.0
+pytest-cov==2.5.1
+pytest-django==3.1.2
+pytz==2018.3
+requests==2.18.4
+six==1.11.0
+uritemplate==3.0.0
+urllib3==1.22

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -4,5 +4,4 @@ psycopg2==2.7.3
 markdown==2.6.4
 django-guardian==1.4.9
 django-filter==1.1.0
-coreapi==2.3.1
-coreschema==0.0.4
+-e git+https://github.com/core-api/python-client.git@b56b1d64fcebd765d458f546b3c38762fd65f042#egg=coreapi

--- a/rest_framework/authtoken/views.py
+++ b/rest_framework/authtoken/views.py
@@ -1,5 +1,5 @@
 import coreapi
-import coreschema
+from coreapi import typesys
 from rest_framework import parsers, renderers
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.serializers import AuthTokenSerializer
@@ -20,7 +20,7 @@ class ObtainAuthToken(APIView):
                 name="username",
                 required=True,
                 location='form',
-                schema=coreschema.String(
+                schema=typesys.String(
                     title="Username",
                     description="Valid username for authentication",
                 ),
@@ -29,7 +29,7 @@ class ObtainAuthToken(APIView):
                 name="password",
                 required=True,
                 location='form',
-                schema=coreschema.String(
+                schema=typesys.String(
                     title="Password",
                     description="Valid password for authentication",
                 ),

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -113,17 +113,11 @@ except ImportError:
 try:
     import coreapi
     import uritemplate
+    from coreapi import typesys
 except ImportError:
     coreapi = None
     uritemplate = None
-
-
-# coreschema is optional
-try:
-    import coreschema
-except ImportError:
-    coreschema = None
-
+    typesys = None
 
 # django-crispy-forms is optional
 try:
@@ -256,7 +250,7 @@ except ImportError:
 try:
     from django.urls import include, path, re_path, register_converter  # noqa
 except ImportError:
-    from django.conf.urls import include, url # noqa
+    from django.conf.urls import include, url  # noqa
     path = None
     register_converter = None
     re_path = url

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -16,7 +16,7 @@ from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import coreapi, coreschema, distinct, guardian
+from rest_framework.compat import coreapi, distinct, guardian, typesys
 from rest_framework.settings import api_settings
 
 
@@ -33,7 +33,6 @@ class BaseFilterBackend(object):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
-        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return []
 
 
@@ -131,13 +130,12 @@ class SearchFilter(BaseFilterBackend):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
-        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
                 name=self.search_param,
                 required=False,
                 location='query',
-                schema=coreschema.String(
+                schema=typesys.String(
                     title=force_text(self.search_title),
                     description=force_text(self.search_description)
                 )
@@ -262,13 +260,12 @@ class OrderingFilter(BaseFilterBackend):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
-        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
                 name=self.ordering_param,
                 required=False,
                 location='query',
-                schema=coreschema.String(
+                schema=typesys.String(
                     title=force_text(self.ordering_title),
                     description=force_text(self.ordering_description)
                 )

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -16,7 +16,7 @@ from django.utils.encoding import force_text
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import coreapi, coreschema
+from rest_framework.compat import coreapi, typesys
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -289,13 +289,12 @@ class PageNumberPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
-        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(
                 name=self.page_query_param,
                 required=False,
                 location='query',
-                schema=coreschema.Integer(
+                schema=typesys.Integer(
                     title='Page',
                     description=force_text(self.page_query_description)
                 )
@@ -307,7 +306,7 @@ class PageNumberPagination(BasePagination):
                     name=self.page_size_query_param,
                     required=False,
                     location='query',
-                    schema=coreschema.Integer(
+                    schema=typesys.Integer(
                         title='Page size',
                         description=force_text(self.page_size_query_description)
                     )
@@ -446,13 +445,12 @@ class LimitOffsetPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
-        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
                 name=self.limit_query_param,
                 required=False,
                 location='query',
-                schema=coreschema.Integer(
+                schema=typesys.Integer(
                     title='Limit',
                     description=force_text(self.limit_query_description)
                 )
@@ -461,7 +459,7 @@ class LimitOffsetPagination(BasePagination):
                 name=self.offset_query_param,
                 required=False,
                 location='query',
-                schema=coreschema.Integer(
+                schema=typesys.Integer(
                     title='Offset',
                     description=force_text(self.offset_query_description)
                 )
@@ -797,13 +795,12 @@ class CursorPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
-        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(
                 name=self.cursor_query_param,
                 required=False,
                 location='query',
-                schema=coreschema.String(
+                schema=typesys.String(
                     title='Cursor',
                     description=force_text(self.cursor_query_description)
                 )
@@ -815,7 +812,7 @@ class CursorPagination(BasePagination):
                     name=self.page_size_query_param,
                     required=False,
                     location='query',
-                    schema=coreschema.Integer(
+                    schema=typesys.Integer(
                         title='Page size',
                         description=force_text(self.page_size_query_description)
                     )

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -897,4 +897,4 @@ class CoreJSONRenderer(BaseRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         indent = bool(renderer_context.get('indent', 0))
         codec = coreapi.codecs.CoreJSONCodec()
-        return codec.dump(data, indent=indent)
+        return codec.encode(data, indent=indent)

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -16,7 +16,7 @@ from django.utils import six
 
 from rest_framework import exceptions
 from rest_framework.compat import (
-    URLPattern, URLResolver, coreapi, coreschema, get_original_route
+    URLPattern, URLResolver, coreapi, get_original_route
 )
 from rest_framework.request import clone_request
 from rest_framework.settings import api_settings
@@ -260,7 +260,6 @@ class SchemaGenerator(object):
 
     def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None):
         assert coreapi, '`coreapi` must be installed for schema support.'
-        assert coreschema, '`coreschema` must be installed for schema support.'
 
         if url and not url.endswith('/'):
             url += '/'

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -14,7 +14,7 @@ from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import exceptions, serializers
-from rest_framework.compat import coreapi, coreschema, uritemplate
+from rest_framework.compat import coreapi, typesys, uritemplate
 from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
 
@@ -29,18 +29,18 @@ def field_to_schema(field):
 
     if isinstance(field, (serializers.ListSerializer, serializers.ListField)):
         child_schema = field_to_schema(field.child)
-        return coreschema.Array(
+        return typesys.Array(
             items=child_schema,
             title=title,
             description=description
         )
     elif isinstance(field, serializers.DictField):
-        return coreschema.Object(
+        return typesys.Object(
             title=title,
             description=description
         )
     elif isinstance(field, serializers.Serializer):
-        return coreschema.Object(
+        return typesys.Object(
             properties=OrderedDict([
                 (key, field_to_schema(value))
                 for key, value
@@ -50,59 +50,59 @@ def field_to_schema(field):
             description=description
         )
     elif isinstance(field, serializers.ManyRelatedField):
-        return coreschema.Array(
-            items=coreschema.String(),
+        return typesys.Array(
+            items=typesys.String(),
             title=title,
             description=description
         )
     elif isinstance(field, serializers.PrimaryKeyRelatedField):
-        schema_cls = coreschema.String
+        schema_cls = typesys.String
         model = getattr(field.queryset, 'model', None)
         if model is not None:
             model_field = model._meta.pk
             if isinstance(model_field, models.AutoField):
-                schema_cls = coreschema.Integer
+                schema_cls = typesys.Integer
         return schema_cls(title=title, description=description)
     elif isinstance(field, serializers.RelatedField):
-        return coreschema.String(title=title, description=description)
+        return typesys.String(title=title, description=description)
     elif isinstance(field, serializers.MultipleChoiceField):
-        return coreschema.Array(
-            items=coreschema.Enum(enum=list(field.choices)),
+        return typesys.Array(
+            items=typesys.Enum(enum=list(field.choices)),
             title=title,
             description=description
         )
     elif isinstance(field, serializers.ChoiceField):
-        return coreschema.Enum(
+        return typesys.Enum(
             enum=list(field.choices),
             title=title,
             description=description
         )
     elif isinstance(field, serializers.BooleanField):
-        return coreschema.Boolean(title=title, description=description)
+        return typesys.Boolean(title=title, description=description)
     elif isinstance(field, (serializers.DecimalField, serializers.FloatField)):
-        return coreschema.Number(title=title, description=description)
+        return typesys.Number(title=title, description=description)
     elif isinstance(field, serializers.IntegerField):
-        return coreschema.Integer(title=title, description=description)
+        return typesys.Integer(title=title, description=description)
     elif isinstance(field, serializers.DateField):
-        return coreschema.String(
+        return typesys.String(
             title=title,
             description=description,
             format='date'
         )
     elif isinstance(field, serializers.DateTimeField):
-        return coreschema.String(
+        return typesys.String(
             title=title,
             description=description,
             format='date-time'
         )
 
     if field.style.get('base_template') == 'textarea.html':
-        return coreschema.String(
+        return typesys.String(
             title=title,
             description=description,
             format='textarea'
         )
-    return coreschema.String(title=title, description=description)
+    return typesys.String(title=title, description=description)
 
 
 def get_pk_description(model, model_field):
@@ -266,7 +266,7 @@ class AutoSchema(ViewInspector):
         for variable in uritemplate.variables(path):
             title = ''
             description = ''
-            schema_cls = coreschema.String
+            schema_cls = typesys.String
             kwargs = {}
             if model is not None:
                 # Attempt to infer a field description if possible.
@@ -286,7 +286,7 @@ class AutoSchema(ViewInspector):
                 if hasattr(view, 'lookup_value_regex') and view.lookup_field == variable:
                     kwargs['pattern'] = view.lookup_value_regex
                 elif isinstance(model_field, models.AutoField):
-                    schema_cls = coreschema.Integer
+                    schema_cls = typesys.Integer
 
             field = coreapi.Field(
                 name=variable,
@@ -326,7 +326,7 @@ class AutoSchema(ViewInspector):
                     name='data',
                     location='body',
                     required=True,
-                    schema=coreschema.Array()
+                    schema=typesys.Array()
                 )
             ]
 

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -49,11 +49,16 @@ def with_location(fields, location):
     ]
 
 
+# TOOD: Where to pull these helpers?
+def render_to_form(schema):
+    assert False, "Can't rely on coreschema encodings here."
+
+
 @register.simple_tag
 def form_for_link(link):
-    import coreschema
+    from coreapi import typesys
     properties = OrderedDict([
-        (field.name, field.schema or coreschema.String())
+        (field.name, field.schema or typesys.String())
         for field in link.fields
     ])
     required = [
@@ -61,8 +66,8 @@ def form_for_link(link):
         for field in link.fields
         if field.required
     ]
-    schema = coreschema.Object(properties=properties, required=required)
-    return mark_safe(coreschema.render_to_form(schema))
+    schema = typesys.Object(properties=properties, required=required)
+    return mark_safe(render_to_form(schema))
 
 
 @register.simple_tag

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -8,7 +8,7 @@ from django.conf.urls import url
 from django.http import HttpResponse
 from django.test import override_settings
 
-from rest_framework.compat import coreapi, coreschema
+from rest_framework.compat import coreapi, typesys
 from rest_framework.parsers import FileUploadParser
 from rest_framework.renderers import CoreJSONRenderer
 from rest_framework.response import Response
@@ -25,7 +25,7 @@ def get_schema():
             'headers': coreapi.Link('/headers/'),
             'location': {
                 'query': coreapi.Link('/example/', fields=[
-                    coreapi.Field(name='example', schema=coreschema.String(description='example field'))
+                    coreapi.Field(name='example', schema=typesys.String(description='example field'))
                 ]),
                 'form': coreapi.Link('/example/', action='post', fields=[
                     coreapi.Field(name='example')

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -9,7 +9,7 @@ from django.test import TestCase, override_settings
 from rest_framework import (
     filters, generics, pagination, permissions, serializers
 )
-from rest_framework.compat import coreapi, coreschema, get_regex_pattern, path
+from rest_framework.compat import coreapi, get_regex_pattern, path, typesys
 from rest_framework.decorators import action, api_view, schema
 from rest_framework.request import Request
 from rest_framework.routers import DefaultRouter, SimpleRouter
@@ -134,9 +134,9 @@ class TestRouterGeneratedSchema(TestCase):
                         url='/example/',
                         action='get',
                         fields=[
-                            coreapi.Field('page', required=False, location='query', schema=coreschema.Integer(title='Page', description='A page number within the paginated result set.')),
-                            coreapi.Field('page_size', required=False, location='query', schema=coreschema.Integer(title='Page size', description='Number of results to return per page.')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('page', required=False, location='query', schema=typesys.Integer(title='Page', description='A page number within the paginated result set.')),
+                            coreapi.Field('page_size', required=False, location='query', schema=typesys.Integer(title='Page size', description='Number of results to return per page.')),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'custom_list_action': coreapi.Link(
@@ -153,8 +153,8 @@ class TestRouterGeneratedSchema(TestCase):
                         url='/example/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     )
                 }
@@ -176,9 +176,9 @@ class TestRouterGeneratedSchema(TestCase):
                         url='/example/',
                         action='get',
                         fields=[
-                            coreapi.Field('page', required=False, location='query', schema=coreschema.Integer(title='Page', description='A page number within the paginated result set.')),
-                            coreapi.Field('page_size', required=False, location='query', schema=coreschema.Integer(title='Page size', description='Number of results to return per page.')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('page', required=False, location='query', schema=typesys.Integer(title='Page', description='A page number within the paginated result set.')),
+                            coreapi.Field('page_size', required=False, location='query', schema=typesys.Integer(title='Page size', description='Number of results to return per page.')),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'create': coreapi.Link(
@@ -186,16 +186,16 @@ class TestRouterGeneratedSchema(TestCase):
                         action='post',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description='A field description')),
-                            coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
+                            coreapi.Field('a', required=True, location='form', schema=typesys.String(title='A', description='A field description')),
+                            coreapi.Field('b', required=False, location='form', schema=typesys.String(title='B'))
                         ]
                     ),
                     'read': coreapi.Link(
                         url='/example/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'custom_action': coreapi.Link(
@@ -204,9 +204,9 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         description='A description of custom action.',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('c', required=True, location='form', schema=coreschema.String(title='C')),
-                            coreapi.Field('d', required=False, location='form', schema=coreschema.String(title='D')),
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('c', required=True, location='form', schema=typesys.String(title='C')),
+                            coreapi.Field('d', required=False, location='form', schema=typesys.String(title='D')),
                         ]
                     ),
                     'custom_action_with_dict_field': coreapi.Link(
@@ -215,8 +215,8 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         description='A custom action using a dict field in the serializer.',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('a', required=True, location='form', schema=coreschema.Object(title='A')),
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('a', required=True, location='form', schema=typesys.Object(title='A')),
                         ]
                     ),
                     'custom_action_with_list_fields': coreapi.Link(
@@ -225,9 +225,9 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         description='A custom action using both list field and list serializer in the serializer.',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('a', required=True, location='form', schema=coreschema.Array(title='A', items=coreschema.Integer())),
-                            coreapi.Field('b', required=True, location='form', schema=coreschema.Array(title='B', items=coreschema.String())),
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('a', required=True, location='form', schema=typesys.Array(title='A', items=typesys.Integer())),
+                            coreapi.Field('b', required=True, location='form', schema=typesys.Array(title='B', items=typesys.String())),
                         ]
                     ),
                     'custom_list_action': coreapi.Link(
@@ -249,10 +249,10 @@ class TestRouterGeneratedSchema(TestCase):
                         action='put',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description=('A field description'))),
-                            coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('a', required=True, location='form', schema=typesys.String(title='A', description=('A field description'))),
+                            coreapi.Field('b', required=False, location='form', schema=typesys.String(title='B')),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'partial_update': coreapi.Link(
@@ -260,18 +260,18 @@ class TestRouterGeneratedSchema(TestCase):
                         action='patch',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('a', required=False, location='form', schema=coreschema.String(title='A', description='A field description')),
-                            coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('a', required=False, location='form', schema=typesys.String(title='A', description='A field description')),
+                            coreapi.Field('b', required=False, location='form', schema=typesys.String(title='B')),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'delete': coreapi.Link(
                         url='/example/{id}/',
                         action='delete',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     )
                 }
@@ -362,7 +362,7 @@ class TestSchemaGenerator(TestCase):
                         url='/example/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'sub': {
@@ -370,7 +370,7 @@ class TestSchemaGenerator(TestCase):
                             url='/example/{id}/sub/',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         )
                     }
@@ -415,7 +415,7 @@ class TestSchemaGeneratorDjango2(TestCase):
                         url='/example/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'sub': {
@@ -423,7 +423,7 @@ class TestSchemaGeneratorDjango2(TestCase):
                             url='/example/{id}/sub/',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         )
                     }
@@ -468,7 +468,7 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
                         url='/api/v1/example/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'sub': {
@@ -476,7 +476,7 @@ class TestSchemaGeneratorNotAtRoot(TestCase):
                             url='/api/v1/example/{id}/sub/',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         )
                     }
@@ -513,9 +513,9 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
                         url='/example1/',
                         action='get',
                         fields=[
-                            coreapi.Field('page', required=False, location='query', schema=coreschema.Integer(title='Page', description='A page number within the paginated result set.')),
-                            coreapi.Field('page_size', required=False, location='query', schema=coreschema.Integer(title='Page size', description='Number of results to return per page.')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('page', required=False, location='query', schema=typesys.Integer(title='Page', description='A page number within the paginated result set.')),
+                            coreapi.Field('page_size', required=False, location='query', schema=typesys.Integer(title='Page size', description='Number of results to return per page.')),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'custom_list_action': coreapi.Link(
@@ -532,8 +532,8 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
                         url='/example1/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String()),
+                            coreapi.Field('ordering', required=False, location='query', schema=typesys.String(title='Ordering', description='Which field to use when ordering the results.'))
                         ]
                     )
                 }
@@ -612,8 +612,8 @@ class TestSchemaGeneratorWithForeignKey(TestCase):
                         action='post',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('name', required=True, location='form', schema=coreschema.String(title='Name')),
-                            coreapi.Field('target', required=True, location='form', schema=coreschema.Integer(description='Target', title='Target')),
+                            coreapi.Field('name', required=True, location='form', schema=typesys.String(title='Name')),
+                            coreapi.Field('target', required=True, location='form', schema=typesys.Integer(description='Target', title='Target')),
                         ]
                     )
                 }
@@ -677,7 +677,7 @@ class TestAutoSchema(TestCase):
                 "my_field",
                 required=True,
                 location="path",
-                schema=coreschema.String()
+                schema=typesys.String()
             ),
         ])
 
@@ -690,7 +690,7 @@ class TestAutoSchema(TestCase):
                 "my_field",
                 required=False,
                 location="path",
-                schema=coreschema.String()
+                schema=typesys.String()
             ),
         ])
 
@@ -706,7 +706,7 @@ class TestAutoSchema(TestCase):
                     "my_extra_field",
                     required=True,
                     location="path",
-                    schema=coreschema.String()
+                    schema=typesys.String()
                 ),
             ])
 
@@ -728,19 +728,19 @@ class TestAutoSchema(TestCase):
                 "first_field",
                 required=True,
                 location="path",
-                schema=coreschema.String()
+                schema=typesys.String()
             ),
             coreapi.Field(
                 "second_field",
                 required=True,
                 location="path",
-                schema=coreschema.String()
+                schema=typesys.String()
             ),
             coreapi.Field(
                 "third_field",
                 required=True,
                 location="path",
-                schema=coreschema.String()
+                schema=typesys.String()
             ),
         ]
         description = "A test endpoint"

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -5,7 +5,7 @@ import unittest
 
 from django.test import TestCase
 
-from rest_framework.compat import coreapi, coreschema
+from rest_framework.compat import coreapi, typesys
 from rest_framework.relations import Hyperlink
 from rest_framework.templatetags import rest_framework
 from rest_framework.templatetags.rest_framework import (
@@ -361,14 +361,14 @@ class SchemaLinksTests(TestCase):
                         url='/users/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'update': coreapi.Link(
                         url='/users/{id}/',
                         action='patch',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     )
                 }
@@ -402,21 +402,21 @@ class SchemaLinksTests(TestCase):
                         url='/users/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'update': coreapi.Link(
                         url='/users/{id}/',
                         action='patch',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'friends': coreapi.Link(
                         url='/users/{id}/friends',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     )
                 }
@@ -451,14 +451,14 @@ class SchemaLinksTests(TestCase):
                         url='/users/{id}/',
                         action='get',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'update': coreapi.Link(
                         url='/users/{id}/',
                         action='patch',
                         fields=[
-                            coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                            coreapi.Field('id', required=True, location='path', schema=typesys.String())
                         ]
                     ),
                     'friends': {
@@ -466,14 +466,14 @@ class SchemaLinksTests(TestCase):
                             url='/users/{id}/friends',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         ),
                         'create': coreapi.Link(
                             url='/users/{id}/friends',
                             action='post',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         )
                     }
@@ -502,7 +502,7 @@ class SchemaLinksTests(TestCase):
                                 url='/animals/dog/{id}/vet',
                                 action='get',
                                 fields=[
-                                    coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                    coreapi.Field('id', required=True, location='path', schema=typesys.String())
                                 ]
                             )
                         },
@@ -510,7 +510,7 @@ class SchemaLinksTests(TestCase):
                             url='/animals/dog/{id}',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         )
                     },
@@ -519,7 +519,7 @@ class SchemaLinksTests(TestCase):
                             url='/animals/cat/',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         ),
                         'create': coreapi.Link(
@@ -551,7 +551,7 @@ class SchemaLinksTests(TestCase):
                                 url='/animals/dog/{id}/vet',
                                 action='get',
                                 fields=[
-                                    coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                    coreapi.Field('id', required=True, location='path', schema=typesys.String())
                                 ]
                             )
                         },
@@ -559,7 +559,7 @@ class SchemaLinksTests(TestCase):
                             url='/animals/dog/{id}',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         )
                     },
@@ -568,7 +568,7 @@ class SchemaLinksTests(TestCase):
                             url='/animals/cat/',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         ),
                         'create': coreapi.Link(
@@ -585,7 +585,7 @@ class SchemaLinksTests(TestCase):
                                 url='/farmers/silo/{id}/soy',
                                 action='get',
                                 fields=[
-                                    coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                    coreapi.Field('id', required=True, location='path', schema=typesys.String())
                                 ]
                             )
                         },
@@ -593,7 +593,7 @@ class SchemaLinksTests(TestCase):
                             url='/farmers/silo',
                             action='get',
                             fields=[
-                                coreapi.Field('id', required=True, location='path', schema=coreschema.String())
+                                coreapi.Field('id', required=True, location='path', schema=typesys.String())
                             ]
                         )
                     }


### PR DESCRIPTION
This PR integrates the work from https://github.com/core-api/python-client/pull/156 into DRF. 

* drop coreschema.
* Swap `coreschema` for `coreapi.typesys`.
* Use `encode` rather than `dump` in the renderer.

Apart from the missing `render_to_form` helper (c.f. https://github.com/core-api/python-client/issues/160) That's about it, for a first pass. 

Now, lets see if I got the CI config right for this... 