### PR TITLE
adding DEFAULT_SEARCH_LOOKUP setting and icontains lookup prefix

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -159,6 +159,12 @@ See the pagination documentation for further guidance on [setting the pagination
 
 ---
 
+### DEFAULT_SEARCH_LOOKUP
+
+The type of lookup to use for searching if a lookup prefix is not specified.  May be any of the Django search lookups (e.g. `icontains`, `istartswith`, `iexact`, `search`, `iregex`).
+
+Default: `icontains`
+
 ### SEARCH_PARAM
 
 The name of a query parameter, which can be used to specify the search term used by `SearchFilter`.

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -42,6 +42,7 @@ class SearchFilter(BaseFilterBackend):
     search_param = api_settings.SEARCH_PARAM
     template = 'rest_framework/filters/search.html'
     lookup_prefixes = {
+        '*': 'icontains',
         '^': 'istartswith',
         '=': 'iexact',
         '@': 'search',
@@ -63,7 +64,7 @@ class SearchFilter(BaseFilterBackend):
         if lookup:
             field_name = field_name[1:]
         else:
-            lookup = 'icontains'
+            lookup = api_settings.DEFAULT_SEARCH_LOOKUP
         return LOOKUP_SEP.join([field_name, lookup])
 
     def must_call_distinct(self, queryset, search_fields):

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -69,6 +69,7 @@ DEFAULTS = {
     'PAGE_SIZE': None,
 
     # Filtering
+    'DEFAULT_SEARCH_LOOKUP': 'icontains',
     'SEARCH_PARAM': 'search',
     'ORDERING_PARAM': 'ordering',
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -134,6 +134,25 @@ class SearchFilterTests(TestCase):
             {'id': 2, 'title': 'zz', 'text': 'bcd'}
         ]
 
+    def test_search_with_nonstandard_search_lookup(self):
+        with override_settings(REST_FRAMEWORK={'DEFAULT_SEARCH_LOOKUP': 'iregex'}):
+            reload_module(filters)
+
+            class SearchListView(generics.ListAPIView):
+                queryset = SearchFilterModel.objects.all()
+                serializer_class = SearchFilterSerializer
+                filter_backends = (filters.SearchFilter,)
+                search_fields = ('title', '*text')
+
+            view = SearchListView.as_view()
+            request = factory.get('/', {'search': 'z{2} b'})
+            response = view(request)
+            assert response.data == [
+                {'id': 2, 'title': 'zz', 'text': 'bcd'}
+            ]
+
+        reload_module(filters)
+
     def test_search_with_nonstandard_search_param(self):
         with override_settings(REST_FRAMEWORK={'SEARCH_PARAM': 'query'}):
             reload_module(filters)


### PR DESCRIPTION
## Description

This adds a `DEFAULT_SEARCH_LOOKUP` feature. The current (unchangeable) default is `icontains` and it's slow as heck. Rather than put an `@` in front of all of our search fields, I figured making it customizable would help me and others.