### PR TITLE
Add admin to installed apps to avoid test failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ def pytest_configure(config):
             'django.contrib.messages.middleware.MessageMiddleware',
         ),
         INSTALLED_APPS=(
+            'django.contrib.admin',
             'django.contrib.auth',
             'django.contrib.contenttypes',
             'django.contrib.sessions',


### PR DESCRIPTION
The tests look for the "admin" app in the list of apps. If not present, running `runtests.py` gives the following error:
```
LookupError: No installed app with label 'admin'.
```
Adding admin to `INSTALLED_APPS` fixes it.

OS : Windows 10
Python version: 3.6.4
Django version: 2.1