### PR TITLE
Test using model objects for dotted source default

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -69,6 +69,17 @@ class NullableUUIDForeignKeySource(RESTFrameworkModel):
                                on_delete=models.CASCADE)
 
 
+class NestedForeignKeySource(RESTFrameworkModel):
+    """
+    Used for testing FK chain. A -> B -> C.
+    """
+    name = models.CharField(max_length=100)
+    target = models.ForeignKey(NullableForeignKeySource, null=True, blank=True,
+                               related_name='nested_sources',
+                               verbose_name='Intermediate target object',
+                               on_delete=models.CASCADE)
+
+
 # OneToOne
 class OneToOneTarget(RESTFrameworkModel):
     name = models.CharField(max_length=100)


### PR DESCRIPTION
Test using model objects for dotted source default when path components may be null.

Ref #5375, #5727

There are two branches in `rest_framework.fields.get_attribute`: 

https://github.com/encode/django-rest-framework/blob/0da461710ad552c401a47b29b93e829ce879a696/rest_framework/fields.py#L97-L100

Previous tests were only exercising the `if` branch. This PR adds similar tests covering the `else`. 