### PR TITLE
Removed input value from deault_error_message

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -642,7 +642,7 @@ class Field(object):
 
 class BooleanField(Field):
     default_error_messages = {
-        'invalid': _('"{input}" is not a valid boolean.')
+        'invalid': _('Is not a valid boolean.')
     }
     default_empty_html = False
     initial = False
@@ -687,7 +687,7 @@ class BooleanField(Field):
 
 class NullBooleanField(Field):
     default_error_messages = {
-        'invalid': _('"{input}" is not a valid boolean.')
+        'invalid': _('Is not a valid boolean.')
     }
     initial = None
     TRUE_VALUES = {
@@ -841,7 +841,7 @@ class UUIDField(Field):
     valid_formats = ('hex_verbose', 'hex', 'int', 'urn')
 
     default_error_messages = {
-        'invalid': _('"{value}" is not a valid UUID.'),
+        'invalid': _('Is not a valid UUID.'),
     }
 
     def __init__(self, **kwargs):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -642,7 +642,7 @@ class Field(object):
 
 class BooleanField(Field):
     default_error_messages = {
-        'invalid': _('Is not a valid boolean.')
+        'invalid': _('Must be a valid boolean.')
     }
     default_empty_html = False
     initial = False
@@ -687,7 +687,7 @@ class BooleanField(Field):
 
 class NullBooleanField(Field):
     default_error_messages = {
-        'invalid': _('Is not a valid boolean.')
+        'invalid': _('Must be a valid boolean.')
     }
     initial = None
     TRUE_VALUES = {
@@ -841,7 +841,7 @@ class UUIDField(Field):
     valid_formats = ('hex_verbose', 'hex', 'int', 'urn')
 
     default_error_messages = {
-        'invalid': _('Is not a valid UUID.'),
+        'invalid': _('Must be a valid UUID.'),
     }
 
     def __init__(self, **kwargs):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -573,7 +573,7 @@ class TestBooleanField(FieldValues):
         False: False,
     }
     invalid_inputs = {
-        'foo': ['Is not a valid boolean.'],
+        'foo': ['Must be a valid boolean.'],
         None: ['This field may not be null.']
     }
     outputs = {
@@ -598,7 +598,7 @@ class TestBooleanField(FieldValues):
         for input_value in inputs:
             with pytest.raises(serializers.ValidationError) as exc_info:
                 field.run_validation(input_value)
-            expected = ['Is not a valid boolean.'.format(input_value)]
+            expected = ['Must be a valid boolean.'.format(input_value)]
             assert exc_info.value.detail == expected
 
 
@@ -615,7 +615,7 @@ class TestNullBooleanField(TestBooleanField):
         None: None
     }
     invalid_inputs = {
-        'foo': ['Is not a valid boolean.'],
+        'foo': ['Must be a valid boolean.'],
     }
     outputs = {
         'true': True,
@@ -759,8 +759,8 @@ class TestUUIDField(FieldValues):
         284758210125106368185219588917561929842: uuid.UUID('d63a6fb6-88d5-40c7-a91c-9edf73283072')
     }
     invalid_inputs = {
-        '825d7aeb-05a9-45b5-a5b7': ['Is not a valid UUID.'],
-        (1, 2, 3): ['Is not a valid UUID.']
+        '825d7aeb-05a9-45b5-a5b7': ['Must be a valid UUID.'],
+        (1, 2, 3): ['Must be a valid UUID.']
     }
     outputs = {
         uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda'): '825d7aeb-05a9-45b5-a5b7-05df87923cda'

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -760,7 +760,7 @@ class TestUUIDField(FieldValues):
     }
     invalid_inputs = {
         '825d7aeb-05a9-45b5-a5b7': ['Is not a valid UUID.'],
-        (1, 2, 3): ['"(1, 2, 3)" is not a valid UUID.']
+        (1, 2, 3): ['Is not a valid UUID.']
     }
     outputs = {
         uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda'): '825d7aeb-05a9-45b5-a5b7-05df87923cda'

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -573,7 +573,7 @@ class TestBooleanField(FieldValues):
         False: False,
     }
     invalid_inputs = {
-        'foo': ['"foo" is not a valid boolean.'],
+        'foo': ['Is not a valid boolean.'],
         None: ['This field may not be null.']
     }
     outputs = {
@@ -598,7 +598,7 @@ class TestBooleanField(FieldValues):
         for input_value in inputs:
             with pytest.raises(serializers.ValidationError) as exc_info:
                 field.run_validation(input_value)
-            expected = ['"{0}" is not a valid boolean.'.format(input_value)]
+            expected = ['Is not a valid boolean.'.format(input_value)]
             assert exc_info.value.detail == expected
 
 
@@ -615,7 +615,7 @@ class TestNullBooleanField(TestBooleanField):
         None: None
     }
     invalid_inputs = {
-        'foo': ['"foo" is not a valid boolean.'],
+        'foo': ['Is not a valid boolean.'],
     }
     outputs = {
         'true': True,
@@ -759,7 +759,7 @@ class TestUUIDField(FieldValues):
         284758210125106368185219588917561929842: uuid.UUID('d63a6fb6-88d5-40c7-a91c-9edf73283072')
     }
     invalid_inputs = {
-        '825d7aeb-05a9-45b5-a5b7': ['"825d7aeb-05a9-45b5-a5b7" is not a valid UUID.'],
+        '825d7aeb-05a9-45b5-a5b7': ['Is not a valid UUID.'],
         (1, 2, 3): ['"(1, 2, 3)" is not a valid UUID.']
     }
     outputs = {


### PR DESCRIPTION
Its never a good idea to return the provided input in an error message, as it can easily result in an reflected XSS. Imagine someone sends a form with a field like "<script>something evil</script>", you return the value in the error message  as it does not pass your serializer and the frontend may not sanitize it proper, as it trusts its own backend. :)
