### PR TITLE
Alter read_only+default behaviour

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -189,7 +189,6 @@ A default class that can be used to *only set a default argument during create o
 It takes a single argument, which is the default value or callable that should be used during create operations.
 
     created_at = serializers.DateTimeField(
-        read_only=True,
         default=serializers.CreateOnlyDefault(timezone.now)
     )
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -367,8 +367,7 @@ class Serializer(BaseSerializer):
     @cached_property
     def _writable_fields(self):
         return [
-            field for field in self.fields.values()
-            if (not field.read_only) or (field.default is not empty)
+            field for field in self.fields.values() if not field.read_only
         ]
 
     @cached_property

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -219,9 +219,16 @@ class TestSource:
 class TestReadOnly:
     def setup(self):
         class TestSerializer(serializers.Serializer):
-            read_only = serializers.ReadOnlyField()
+            read_only = serializers.ReadOnlyField(default="789")
             writable = serializers.IntegerField()
         self.Serializer = TestSerializer
+
+    def test_writable_fields(self):
+        """
+        Read-only fields should not be writable, even with default ()
+        """
+        serializer = self.Serializer()
+        assert len(serializer._writable_fields) == 1
 
     def test_validate_read_only(self):
         """

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -513,7 +513,7 @@ class TestCacheSerializerData:
 class TestDefaultInclusions:
     def setup(self):
         class ExampleSerializer(serializers.Serializer):
-            char = serializers.CharField(read_only=True, default='abc')
+            char = serializers.CharField(default='abc')
             integer = serializers.IntegerField()
         self.Serializer = ExampleSerializer
 


### PR DESCRIPTION
Since ≈forever `read_only` fields with a `default` have set that default in `validated_data` on create and update operations. 

This has led to issues as we have tried to _Fix default value handling for dotted sources_ #5375: uses such as `source=a.b.c, default='x'` where e.g. `b` may be null were returning `None`, rather than the default `x`. 

#5375 resolved the _serialisation_ issues with dotted `source` — `default` will be used if any step in the chain is `None` —  but revealed a latent issue for _deserialisation_ when using `read_only` plus a `default`. This comes up in a couple of ways: 

* The check for nested writes errors on a read_only field with dotted source and default. #4666. (Exact reproduce pending on this one.)
* Skipping that, `validated_data` ends up including a nested dict, which cannot be assigned in e.g. places where a model object is expected. https://github.com/encode/django-rest-framework/pull/5708#issuecomment-355569737

Both of these cases come up because the `default` means `read_only` fields end up in `_writable_fields`. 

Whilst we've been doing it ≈forever, it's still a _Que?_ here. How on earth is a `read_only` field writable?

This PR adjusts the `_writable_fields` check to **always exclude** `read_only` fields. 

---

This is a backwards incompatible change.

The previous use-case was for e.g. setting the current user as the owner of a object on create. 

This change will require an extra workaround — to explicitly add the `read_only` fields with a _writable default_ to `validated_data`, probably by overriding `save`. 

```python
class MySerializer(serializers.ModelSerializer):
    user = serializers.PrimaryKeyRelatedField(read_only=True, default=CreateOnlyDefault(CurrentUserDefault()))
    ...
    
    def save(self, **kwargs):
        """Include default for read_only `user` field"""
        kwargs["user"] = self.fields["user"].get_default()
        return super().save(**kwargs)
```

Possibly we could add some convenience to this? (I'm a bit loathe to add API here.) 

Note that [in the tutorial](http://www.django-rest-framework.org/tutorial/4-authentication-and-permissions/#associating-snippets-with-users) we demonstrate this kind of this at the view level: 

```
def perform_create(self, serializer):
    serializer.save(owner=self.request.user)
```

---

My overall take here is that the previous use-case saves a line or two, and is a convenience, but it inhibits correctness with the dotted source issue, so I think we need to swallow the pill on this one and make the change. 

---

TODO: 

* [x] Release notes for BC change and workaround. 
* [x] Docs changes