### PR TITLE
Correct allow_null behaviour when required=False

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -41,14 +41,6 @@ Setting this to `False` also allows the object attribute or dictionary key to be
 
 Defaults to `True`.
 
-### `allow_null`
-
-Normally an error will be raised if `None` is passed to a serializer field. Set this keyword argument to `True` if `None` should be considered a valid value.
-
-Note that setting this argument to `True` will imply a default value of `null` for serialization output, but does not imply a default for input deserialization.
-
-Defaults to `False`
-
 ### `default`
 
 If set, this gives the default value that will be used for the field if no input value is supplied. If not set the default behaviour is to not populate the attribute at all.
@@ -60,6 +52,14 @@ May be set to a function or other callable, in which case the value will be eval
 When serializing the instance, default will be used if the the object attribute or dictionary key is not present in the instance.
 
 Note that setting a `default` value implies that the field is not required. Including both the `default` and `required` keyword arguments is invalid and will raise an error.
+
+### `allow_null`
+
+Normally an error will be raised if `None` is passed to a serializer field. Set this keyword argument to `True` if `None` should be considered a valid value.
+
+Note that setting this argument to `True` will imply a default value of `null` for serialization output, but does not imply a default for input deserialization.
+
+Defaults to `False`
 
 ### `source`
 

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -57,7 +57,7 @@ Note that setting a `default` value implies that the field is not required. Incl
 
 Normally an error will be raised if `None` is passed to a serializer field. Set this keyword argument to `True` if `None` should be considered a valid value.
 
-Note that setting this argument to `True` will imply a default value of `null` for serialization output, but does not imply a default for input deserialization.
+Note that, without an explicit `default`, setting this argument to `True` will imply a `default` value of `null` for serialization output, but does not imply a default for input deserialization.
 
 Defaults to `False`
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -442,10 +442,10 @@ class Field(object):
         except (KeyError, AttributeError) as exc:
             if self.default is not empty:
                 return self.get_default()
-            if not self.required:
-                raise SkipField()
             if self.allow_null:
                 return None
+            if not self.required:
+                raise SkipField()
             msg = (
                 'Got {exc_type} when attempting to get a value for field '
                 '`{field}` on serializer `{serializer}`.\nThe serializer '

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -486,12 +486,16 @@ class TestDefaultOutput:
         assert Serializer({'nested': {'a': '3', 'b': {'c': '4'}}}).data == {'nested': {'a': '3', 'c': '4'}}
 
     def test_default_for_allow_null(self):
-        # allow_null=True should imply default=None
+        """
+        Without an explicit default, allow_null implies default=None when serializing. #5518 #5708
+        """
         class Serializer(serializers.Serializer):
             foo = serializers.CharField()
             bar = serializers.CharField(source='foo.bar', allow_null=True)
+            optional = serializers.CharField(required=False, allow_null=True)
 
-        assert Serializer({'foo': None}).data == {'foo': None, 'bar': None}
+        # allow_null=True should imply default=None when serialising:
+        assert Serializer({'foo': None}).data == {'foo': None, 'bar': None, 'optional': None, }
 
 
 class TestCacheSerializerData:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -384,14 +384,6 @@ class TestNotRequiredOutput:
         serializer.save()
         assert serializer.data == {'included': 'abc'}
 
-    def test_not_required_output_for_allow_null_field(self):
-        class ExampleSerializer(serializers.Serializer):
-            omitted = serializers.CharField(required=False, allow_null=True)
-            included = serializers.CharField()
-
-        serializer = ExampleSerializer({'included': 'abc'})
-        assert 'omitted' not in serializer.data
-
 
 class TestDefaultOutput:
     def setup(self):


### PR DESCRIPTION
This PR reverts #5639. There `required=False` would override the implicit default coming from `allow_null`, omitting the field from inclusion. This was incorrect, as reported in #5708. 

* Adds a test for #5708. (Thanks @ticosax for the original report and test) 
* Reverts #5639 
* Adjusts Field docs slightly. 

Closes #5708. 

There's a slight BC issue here — although we're restoring an older behaviour. Overriding `data` to remove the offending field if `None` would serve as a fallback. 

TODO: 

* [x] Release notes for behaviour change here. 
