### PR TITLE
Fix Spanish internationalization example

### DIFF
--- a/docs/topics/internationalization.md
+++ b/docs/topics/internationalization.md
@@ -43,7 +43,7 @@ REST framework includes these built-in translations both for standard exception 
 
 Note that the translations only apply to the error strings themselves. The format of error messages, and the keys of field names will remain the same. An example `400 Bad Request` response body might look like this:
 
-    {"detail": {"username": ["Esse campo deve ser unico."]}}
+    {"detail": {"username": ["Este campo debe ser único."]}}
 
 If you want to use different string for parts of the response such as `detail` and `non_field_errors` then you can modify this behavior by using a [custom exception handler][custom-exception-handler].
 


### PR DESCRIPTION
The translation 'Esse campo deve ser unico' is wrong. The right text should look like: 'Este campo debe ser único'. If you need help translating some parts of the project into Spanish let me know.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Spanish translation fix.
