### PR TITLE
Enable OrderingFilter to handle an empty tuple (or list) for the 'ord…

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -242,7 +242,7 @@ class OrderingFilter(BaseFilterBackend):
 
     def get_template_context(self, request, queryset, view):
         current = self.get_ordering(request, queryset, view)
-        current = None if current is None else current[0]
+        current = None if not current else current[0]
         options = []
         context = {
             'request': request,


### PR DESCRIPTION
## Description

Closes [#5861](https://github.com/encode/django-rest-framework/issues/5861).

The `OrderingFilter` can now handle an empty tuple (or list) value for the `ordering` field.
