### PR TITLE
perform_create mixin method should return newly created object

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -156,13 +156,14 @@ The following methods are provided by the mixin classes, and provide easy overri
 These hooks are particularly useful for setting attributes that are implicit in the request, but are not part of the request data.  For instance, you might set an attribute on the object based on the request user, or based on a URL keyword argument.
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        return serializer.save(user=self.request.user)
 
 These override points are also particularly useful for adding behavior that occurs before or after saving an object, such as emailing a confirmation, or logging the update.
 
     def perform_update(self, serializer):
         instance = serializer.save()
         send_email_confirmation(user=self.request.user, modified=instance)
+        return instance
 
 You can also use these hooks to provide additional validation, by raising a `ValidationError()`. This can be useful if you need some validation logic to apply at the point of database save. For example:
 
@@ -170,7 +171,7 @@ You can also use these hooks to provide additional validation, by raising a `Val
         queryset = SignupRequest.objects.filter(user=self.request.user)
         if queryset.exists():
             raise ValidationError('You have already signed up')
-        serializer.save(user=self.request.user)
+        return serializer.save(user=self.request.user)
 
 **Note**: These methods replace the old-style version 2.x `pre_save`, `post_save`, `pre_delete` and `post_delete` methods, which are no longer available.
 

--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -99,7 +99,7 @@ The way we deal with that is by overriding a `.perform_create()` method on our s
 On the `SnippetList` view class, add the following method:
 
     def perform_create(self, serializer):
-        serializer.save(owner=self.request.user)
+        return serializer.save(owner=self.request.user)
 
 The `create()` method of our serializer will now be passed an additional `'owner'` field, along with the validated data from the request.
 

--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -46,7 +46,7 @@ Next we're going to replace the `SnippetList`, `SnippetDetail` and `SnippetHighl
             return Response(snippet.highlighted)
 
         def perform_create(self, serializer):
-            serializer.save(owner=self.request.user)
+            return serializer.save(owner=self.request.user)
 
 This time we've used the `ModelViewSet` class in order to get the complete set of default read and write operations.
 

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -77,7 +77,7 @@ class UpdateModelMixin(object):
         return Response(serializer.data)
 
     def perform_update(self, serializer):
-        serializer.save()
+        return serializer.save()
 
     def partial_update(self, request, *args, **kwargs):
         kwargs['partial'] = True

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -23,7 +23,7 @@ class CreateModelMixin(object):
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     def perform_create(self, serializer):
-        serializer.save()
+        return serializer.save()
 
     def get_success_headers(self, data):
         try:


### PR DESCRIPTION
The rationale is that when overriding method perform_create usually there is some need to manage custom operations with the newly created object. The current implementation is very misleading as trying to use super() method (what would be expected) returns None rather than an object:

    def perform_create(self, serializer):
        obj = super().perform_create(serializer)   # Will return None
        ... do something with obj 





