### PR TITLE
release_notes: fix call to super().data

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -74,7 +74,7 @@ You can determine your currently installed version using `pip show`:
             """
             Drop `maybe_none` field if None.
             """
-            data = super().data()
+            data = super().data
             if 'maybe_none' in data and data['maybe_none'] is None:
                 del data['maybe_none']
             return data


### PR DESCRIPTION
`super().data()` leads to a `TypeError` saying that 'ReturnDict' object
is not callable.