### PR TITLE
docs: Add missing argument 'detail' to Route

### DIFF
--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -241,12 +241,14 @@ The following example will only route to the `list` and `retrieve` actions, and 
                 url=r'^{prefix}$',
                 mapping={'get': 'list'},
                 name='{basename}-list',
+                detail=False,
                 initkwargs={'suffix': 'List'}
             ),
             Route(
                 url=r'^{prefix}/{lookup}$',
                 mapping={'get': 'retrieve'},
                 name='{basename}-detail',
+                detail=True,
                 initkwargs={'suffix': 'Detail'}
             ),
             DynamicRoute(


### PR DESCRIPTION
The [namedtuple Route](https://github.com/encode/django-rest-framework/pull/5705/files#diff-88b0cad65f9e1caad64e0c9bb44615f9R34) requires `detail` to be specified, otherwise it fails with: `TypeError: __new__() missing 1 required positional argument: 'detail'`.

## Description

Since PR #5705 `Route()` requires argument `detail`.  It was [added to the SimpleRouter](https://github.com/encode/django-rest-framework/pull/5705/files#diff-88b0cad65f9e1caad64e0c9bb44615f9R116), but forgotten in an example in the documentation.
