### PR TITLE
There are some cases in which users may not want to have an error rep…

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -630,7 +630,7 @@ class ListSerializer(BaseSerializer):
 
         return value
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data, error_function=any):
         """
         List of dicts of native values <- List of dicts of primitive datatypes.
         """
@@ -666,7 +666,7 @@ class ListSerializer(BaseSerializer):
                 ret.append(validated)
                 errors.append({})
 
-        if any(errors):
+        if error_function(errors):
             raise ValidationError(errors)
 
         return ret


### PR DESCRIPTION
Currently, ListSerializer fails when `any` of its child elements fail. Sometimes we don't want this behaviour and would prefer to explicit it, for example fail on `all`.

In the `all` case, the framework would be able to keep on with the valid inputs, and do a best-effort work.