### PR TITLE
docs: Added djangorestframework-datatables to third-party packages

### DIFF
--- a/docs/topics/third-party-packages.md
+++ b/docs/topics/third-party-packages.md
@@ -264,6 +264,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [django-rest-framework-version-transforms][django-rest-framework-version-transforms] - Enables the use of delta transformations for versioning of DRF resource representations.
 * [django-rest-messaging][django-rest-messaging], [django-rest-messaging-centrifugo][django-rest-messaging-centrifugo] and [django-rest-messaging-js][django-rest-messaging-js] - A real-time pluggable messaging service using DRM.
 * [djangorest-alchemy][djangorest-alchemy] - SQLAlchemy support for REST framework.
+* [djangorestframework-datatables][djangorestframework-datatables] - Seamless integration between Django REST framework and [Datatables](https://datatables.net).
 
 [cite]: http://www.software-ecosystems.com/Software_Ecosystems/Ecosystems.html
 [cookiecutter]: https://github.com/jpadilla/cookiecutter-django-rest-framework
@@ -337,3 +338,4 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [djangorestframework-queryfields]: https://github.com/wimglenn/djangorestframework-queryfields
 [drfpasswordless]: https://github.com/aaronn/django-rest-framework-passwordless
 [djangorest-alchemy]: https://github.com/dealertrack/djangorest-alchemy
+[djangorestframework-datatables]: https://github.com/izimobil/django-rest-framework-datatables


### PR DESCRIPTION
## Description

Seamless integration between Django REST framework and Datatables (https://datatables.net).

When you call your API with ?format=datatables it will return a JSON structure that is fully compatible with what Datatables expects. It handles searching, filtering, ordering and most usecases you can imagine with Datatables.

The great benefit of django-rest-framework-datatables is that you don't have to create a different API, your API will be untouched unless you specify the datatables format on your request.