### PR TITLE
Allow hashing of ErrorDetail

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -91,6 +91,9 @@ class ErrorDetail(six.text_type):
             self.code,
         ))
 
+    def __hash__(self):
+        return hash(str(self))
+
 
 class APIException(Exception):
     """

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -81,6 +81,10 @@ class ErrorDetailTests(TestCase):
         assert str(ErrorDetail('msg1')) == 'msg1'
         assert str(ErrorDetail('msg1', 'code')) == 'msg1'
 
+    def test_hash(self):
+        assert hash(ErrorDetail('msg')) == hash('msg')
+        assert hash(ErrorDetail('msg', 'code')) == hash('msg')
+
 
 class TranslationTests(TestCase):
 


### PR DESCRIPTION
## Description

Allow hashing of ErrorDetail objects to address #5919.

I'm not entirely sure if `hash(ErrorDetail('msg')) == hash('msg')` should be true. I'd love some feedback on this.