### PR TITLE
Docs: Add necessary imports to usage example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,8 @@ Add `'rest_framework'` to your `INSTALLED_APPS` setting.
 
 If you're intending to use the browsable API you'll probably also want to add REST framework's login and logout views.  Add the following to your root `urls.py` file.
 
+    from django.conf.urls import url, include
+    ...
     urlpatterns = [
         ...
         url(r'^api-auth/', include('rest_framework.urls'))


### PR DESCRIPTION
Beginners (like myself) will get errors when using the examples without specifiying these imports. Seems they are needed since Django 1.6, so applies to all supported versions of django-rest-framework.