### PR TITLE
Change ISO 8601 date format to exclude year/month-only options

### DIFF
--- a/rest_framework/utils/humanize_datetime.py
+++ b/rest_framework/utils/humanize_datetime.py
@@ -13,7 +13,7 @@ def datetime_formats(formats):
 
 
 def date_formats(formats):
-    format = ', '.join(formats).replace(ISO_8601, 'YYYY[-MM[-DD]]')
+    format = ', '.join(formats).replace(ISO_8601, 'YYYY-MM-DD')
     return humanize_strptime(format)
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1122,8 +1122,10 @@ class TestDateField(FieldValues):
         datetime.date(2001, 1, 1): datetime.date(2001, 1, 1),
     }
     invalid_inputs = {
-        'abc': ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
-        '2001-99-99': ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
+        'abc': ['Date has wrong format. Use one of these formats instead: YYYY-MM-DD.'],
+        '2001-99-99': ['Date has wrong format. Use one of these formats instead: YYYY-MM-DD.'],
+        '2001-01': ['Date has wrong format. Use one of these formats instead: YYYY-MM-DD.'],
+        '2001': ['Date has wrong format. Use one of these formats instead: YYYY-MM-DD.'],
         datetime.datetime(2001, 1, 1, 12, 00): ['Expected a date but got a datetime.'],
     }
     outputs = {


### PR DESCRIPTION
Fixes #5933