### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Send a description of the issue via email to [rest-framework-security@googlegrou
 [coverage-status-image]: https://img.shields.io/codecov/c/github/encode/django-rest-framework/master.svg
 [codecov]: https://codecov.io/github/encode/django-rest-framework?branch=master
 [pypi-version]: https://img.shields.io/pypi/v/djangorestframework.svg
-[pypi]: https://pypi.python.org/pypi/djangorestframework
+[pypi]: https://pypi.org/project/djangorestframework/
 [twitter]: https://twitter.com/_tomchristie
 [group]: https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework
 [sandbox]: https://restframework.herokuapp.com/

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@
         <img src="https://secure.travis-ci.org/encode/django-rest-framework.svg?branch=master" class="status-badge">
     </a>
 
-    <a href="https://pypi.python.org/pypi/djangorestframework">
+    <a href="https://pypi.org/project/djangorestframework/">
         <img src="https://img.shields.io/pypi/v/djangorestframework.svg" class="status-badge">
     </a>
 </p>
@@ -308,9 +308,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 [redhat]: https://www.redhat.com/
 [heroku]: https://www.heroku.com/
 [eventbrite]: https://www.eventbrite.co.uk/about/
-[coreapi]: https://pypi.python.org/pypi/coreapi/
-[markdown]: https://pypi.python.org/pypi/Markdown/
-[django-filter]: https://pypi.python.org/pypi/django-filter
+[coreapi]: https://pypi.org/project/coreapi/
+[markdown]: https://pypi.org/project/Markdown/
+[django-filter]: https://pypi.org/project/django-filter/
 [django-crispy-forms]: https://github.com/maraujop/django-crispy-forms
 [django-guardian]: https://github.com/django-guardian/django-guardian
 [index]: .

--- a/docs/topics/project-management.md
+++ b/docs/topics/project-management.md
@@ -204,7 +204,7 @@ The following issues still need to be addressed:
 [bus-factor]: https://en.wikipedia.org/wiki/Bus_factor
 [un-triaged]: https://github.com/encode/django-rest-framework/issues?q=is%3Aopen+no%3Alabel
 [transifex-project]: https://www.transifex.com/projects/p/django-rest-framework/
-[transifex-client]: https://pypi.python.org/pypi/transifex-client
+[transifex-client]: https://pypi.org/project/transifex-client/
 [translation-memory]: http://docs.transifex.com/guides/tm#let-tm-automatically-populate-translations
 [github-org]: https://github.com/encode/django-rest-framework/issues/2162
 [sandbox]: https://restframework.herokuapp.com/


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html