### PR TITLE
Small example code fixes

### DIFF
--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -274,7 +274,7 @@ For example, using the "Django REST framework JWT" package
     result = client.action(schema, action, params)
 
     auth = coreapi.auth.TokenAuthentication(
-        scheme='Token',
+        scheme='JWT',
         token=result['token']
     )
     client = coreapi.Client(auth=auth)

--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -269,12 +269,12 @@ For example, using the "Django REST framework JWT" package
     client = coreapi.Client()
     schema = client.get('https://api.example.org/')
 
-    action = ['api-token-auth', 'obtain-token']
-    params = {username: "example", email: "example@example.com"}
+    action = ['api-token-auth', 'create']
+    params = {"username": "example", "password": "secret"}
     result = client.action(schema, action, params)
 
     auth = coreapi.auth.TokenAuthentication(
-        scheme='JWT',
+        scheme='Token',
         token=result['token']
     )
     client = coreapi.Client(auth=auth)


### PR DESCRIPTION
## Description
Tried token authentication today and found those small errors. If it really should have ben JWT and you are using djangorestframework-simplejwt then the action should look more like this:

```action = ['auth', 'token', 'obtain', 'create']```