### PR TITLE
Update serializers.md

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -312,8 +312,8 @@ The following example demonstrates how you might handle creating a user with a n
 
         def create(self, validated_data):
             profile_data = validated_data.pop('profile')
-            user = User.objects.create(**validated_data)
-            Profile.objects.create(user=user, **profile_data)
+            profile = Profile.objects.create(**profile_data)
+	    user = User.objects.create(profile=profile, **validated_data)
             return user
 
 #### Writing `.update()` methods for nested representations


### PR DESCRIPTION
refs #bugfix: The class UserSerializer shows that the User model has a foreign key of a profile. Whereas when creating an object of a profile in the code it was written as Profile.objects.create(user=user, **profile_data) which means profile has a foreign key of users.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
