### PR TITLE
Update tutorial to Django 2.0 routing syntax (#5963)

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -275,20 +275,22 @@ We'll also need a view which corresponds to an individual snippet, and can be us
 
 Finally we need to wire these views up.  Create the `snippets/urls.py` file:
 
-    from django.conf.urls import url
+    from django.urls import path
+    # note that the path function was added in Django 2.0
+    # use django.conf.urls.url if on an older version of Django
     from snippets import views
 
     urlpatterns = [
-        url(r'^snippets/$', views.snippet_list),
-        url(r'^snippets/(?P<pk>[0-9]+)/$', views.snippet_detail),
+        path('snippets/', views.snippet_list),
+        path('snippets/<int:pk>/', views.snippet_detail),
     ]
 
 We also need to wire up the root urlconf, in the `tutorial/urls.py` file, to include our snippet app's URLs.
 
-    from django.conf.urls import url, include
+    from django.urls import path, include
 
     urlpatterns = [
-        url(r'^', include('snippets.urls')),
+        path('', include('snippets.urls')),
     ]
 
 It's worth noting that there are a couple of edge cases we're not dealing with properly at the moment.  If we send malformed `json`, or if a request is made with a method that the view doesn't handle, then we'll end up with a 500 "server error" response.  Still, this'll do for now.

--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -276,8 +276,6 @@ We'll also need a view which corresponds to an individual snippet, and can be us
 Finally we need to wire these views up.  Create the `snippets/urls.py` file:
 
     from django.urls import path
-    # note that the path function was added in Django 2.0
-    # use django.conf.urls.url if on an older version of Django
     from snippets import views
 
     urlpatterns = [

--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -108,13 +108,13 @@ and
 
 Now update the `snippets/urls.py` file slightly, to append a set of `format_suffix_patterns` in addition to the existing URLs.
 
-    from django.conf.urls import url
+    from django.urls import path
     from rest_framework.urlpatterns import format_suffix_patterns
     from snippets import views
 
     urlpatterns = [
-        url(r'^snippets/$', views.snippet_list),
-        url(r'^snippets/(?P<pk>[0-9]+)$', views.snippet_detail),
+        path('snippets/', views.snippet_list),
+        path('snippets/<int:pk>', views.snippet_detail),
     ]
 
     urlpatterns = format_suffix_patterns(urlpatterns)

--- a/docs/tutorial/3-class-based-views.md
+++ b/docs/tutorial/3-class-based-views.md
@@ -64,13 +64,13 @@ That's looking good.  Again, it's still pretty similar to the function based vie
 
 We'll also need to refactor our `snippets/urls.py` slightly now that we're using class-based views.
 
-    from django.conf.urls import url
+    from django.urls import path
     from rest_framework.urlpatterns import format_suffix_patterns
     from snippets import views
 
     urlpatterns = [
-        url(r'^snippets/$', views.SnippetList.as_view()),
-        url(r'^snippets/(?P<pk>[0-9]+)/$', views.SnippetDetail.as_view()),
+        path('snippets/', views.SnippetList.as_view()),
+        path('snippets/<int:pk>/', views.SnippetDetail.as_view()),
     ]
 
     urlpatterns = format_suffix_patterns(urlpatterns)

--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -85,10 +85,10 @@ Make sure to also import the `UserSerializer` class
 
 	from snippets.serializers import UserSerializer
 
-Finally we need to add those views into the API, by referencing them from the URL conf. Add the following to the patterns in `urls.py`.
+Finally we need to add those views into the API, by referencing them from the URL conf. Add the following to the patterns in `snippets/urls.py`.
 
-    url(r'^users/$', views.UserList.as_view()),
-    url(r'^users/(?P<pk>[0-9]+)/$', views.UserDetail.as_view()),
+    path('users/', views.UserList.as_view()),
+    path('users/<int:pk>/', views.UserDetail.as_view()),
 
 ## Associating Snippets with Users
 
@@ -142,10 +142,10 @@ Add the following import at the top of the file:
 And, at the end of the file, add a pattern to include the login and logout views for the browsable API.
 
     urlpatterns += [
-        url(r'^api-auth/', include('rest_framework.urls')),
+        path('api-auth/', include('rest_framework.urls')),
     ]
 
-The `r'^api-auth/'` part of pattern can actually be whatever URL you want to use.
+The `'api-auth/'` part of pattern can actually be whatever URL you want to use.
 
 Now if you open up the browser again and refresh the page you'll see a 'Login' link in the top right of the page.  If you log in as one of the users you created earlier, you'll be able to create code snippets again.
 

--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -44,11 +44,11 @@ Instead of using a concrete generic view, we'll use the base class for represent
 As usual we need to add the new views that we've created in to our URLconf.
 We'll add a url pattern for our new API root in `snippets/urls.py`:
 
-    url(r'^$', views.api_root),
+    path('', views.api_root),
 
 And then add a url pattern for the snippet highlights:
 
-    url(r'^snippets/(?P<pk>[0-9]+)/highlight/$', views.SnippetHighlight.as_view()),
+    path('snippets/<int:pk>/highlight/', views.SnippetHighlight.as_view()),
 
 ## Hyperlinking our API
 
@@ -112,20 +112,20 @@ After adding all those names into our URLconf, our final `snippets/urls.py` file
 
     # API endpoints
     urlpatterns = format_suffix_patterns([
-        url(r'^$', views.api_root),
-        url(r'^snippets/$',
+        path('', views.api_root),
+        path('snippets/',
             views.SnippetList.as_view(),
             name='snippet-list'),
-        url(r'^snippets/(?P<pk>[0-9]+)/$',
+        path('snippets/<int:pk>/',
             views.SnippetDetail.as_view(),
             name='snippet-detail'),
-        url(r'^snippets/(?P<pk>[0-9]+)/highlight/$',
+        path('snippets/<int:pk>/highlight/',
             views.SnippetHighlight.as_view(),
             name='snippet-highlight'),
-        url(r'^users/$',
+        path('users/',
             views.UserList.as_view(),
             name='user-list'),
-        url(r'^users/(?P<pk>[0-9]+)/$',
+        path('users/<int:pk>/',
             views.UserDetail.as_view(),
             name='user-detail')
     ])

--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -93,7 +93,7 @@ Now that we've bound our resources into concrete views, we can register the view
     urlpatterns = format_suffix_patterns([
         path('', api_root),
         path('snippets/', snippet_list, name='snippet-list'),
-        path('snippets/<int:pk>/$', snippet_detail, name='snippet-detail'),
+        path('snippets/<int:pk>/', snippet_detail, name='snippet-detail'),
         path('snippets/<int:pk>/highlight/', snippet_highlight, name='snippet-highlight'),
         path('users/', user_list, name='user-list'),
         path('users/<int:pk>/', user_detail, name='user-detail')

--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -91,12 +91,12 @@ Notice how we're creating multiple views from each `ViewSet` class, by binding t
 Now that we've bound our resources into concrete views, we can register the views with the URL conf as usual.
 
     urlpatterns = format_suffix_patterns([
-        url(r'^$', api_root),
-        url(r'^snippets/$', snippet_list, name='snippet-list'),
-        url(r'^snippets/(?P<pk>[0-9]+)/$', snippet_detail, name='snippet-detail'),
-        url(r'^snippets/(?P<pk>[0-9]+)/highlight/$', snippet_highlight, name='snippet-highlight'),
-        url(r'^users/$', user_list, name='user-list'),
-        url(r'^users/(?P<pk>[0-9]+)/$', user_detail, name='user-detail')
+        path('', api_root),
+        path('snippets/', snippet_list, name='snippet-list'),
+        path('snippets/<int:pk>/$', snippet_detail, name='snippet-detail'),
+        path('snippets/<int:pk>/highlight/', snippet_highlight, name='snippet-highlight'),
+        path('users/', user_list, name='user-list'),
+        path('users/<int:pk>/', user_detail, name='user-detail')
     ])
 
 ## Using Routers

--- a/docs/tutorial/7-schemas-and-client-libraries.md
+++ b/docs/tutorial/7-schemas-and-client-libraries.md
@@ -42,7 +42,7 @@ from rest_framework.schemas import get_schema_view
 schema_view = get_schema_view(title='Pastebin API')
 
 urlpatterns = [
-    url(r'^schema/$', schema_view),
+    path('schema/', schema_view),
     ...
 ]
 ```


### PR DESCRIPTION
Updated part 1 of the DRF tutorial to use django.urls.path instead of
django.conf.urls.url

## Description

refs #5963 , updated tutorial part 1 to use Django 2.0 routing syntax.
