### PR TITLE
tests: fix skipping with TestPosgresFieldsMapping

### DIFF
--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -402,7 +402,7 @@ class TestGenericIPAddressFieldValidation(TestCase):
                          '{0}'.format(s.errors))
 
 
-@pytest.mark.skipUnless(postgres_fields, 'postgres is required')
+@pytest.mark.skipif('not postgres_fields')
 class TestPosgresFieldsMapping(TestCase):
     def test_hstore_field(self):
         class HStoreFieldModel(models.Model):


### PR DESCRIPTION
`pytest.mark.skipUnless` does not exist, it was confused with
`unittest.skipUnless` probably.