### PR TITLE
pytest: use --strict

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts=--tb=short
+addopts=--tb=short --strict
 
 [tox]
 envlist =


### PR DESCRIPTION
This causes errors with invalid markers:

> AttributeError: 'skipUnless' not a registered marker

Fixed in https://github.com/encode/django-rest-framework/pull/5965.