### PR TITLE
requirements-optionals.txt: bump psycopg2 to 2.7.4

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,6 +1,6 @@
 # Optional packages which may be used with REST framework.
 pytz==2017.2
-psycopg2==2.7.3
+psycopg2==2.7.4
 markdown==2.6.4
 django-guardian==1.4.9
 django-filter==1.1.0


### PR DESCRIPTION
With 2.7.3 I am seeing an ImportError on Arch Linux:

> ImportError: …/.venv/lib/python3.6/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so:
> symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference
