### PR TITLE
runtests.py: include coverage for tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -91,10 +91,9 @@ if __name__ == "__main__":
             pass
         else:
             pytest_args = [
-                '--cov-report',
-                'xml',
-                '--cov',
-                'rest_framework'] + pytest_args
+                '--cov', '.',
+                '--cov-report', 'xml',
+            ] + pytest_args
 
         if first_arg.startswith('-'):
             # `runtests.py [flags]`

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,11 @@ multi_line_output=5
 known_standard_library=types
 known_third_party=pytest,_pytest,django
 known_first_party=rest_framework
+
+[coverage:run]
+# NOTE: source is ignored with pytest-cov (but uses the same).
+source = .
+include = rest_framework/*,tests/*
+branch = 1
+[coverage:report]
+include = rest_framework/*,tests/*


### PR DESCRIPTION
It is useful to see if tests itself are covered after all - missing
coverage there typically indicates dead/missed code paths.