### PR TITLE
tests: fix test_write_only_fields not being executed

### DIFF
--- a/tests/test_write_only_fields.py
+++ b/tests/test_write_only_fields.py
@@ -14,7 +14,7 @@ class WriteOnlyFieldTests(TestCase):
 
         self.Serializer = ExampleSerializer
 
-    def write_only_fields_are_present_on_input(self):
+    def test_write_only_fields_are_present_on_input(self):
         data = {
             'email': 'foo@example.com',
             'password': '123'
@@ -23,7 +23,7 @@ class WriteOnlyFieldTests(TestCase):
         assert serializer.is_valid()
         assert serializer.validated_data == data
 
-    def write_only_fields_are_not_present_on_output(self):
+    def test_write_only_fields_are_not_present_on_output(self):
         instance = {
             'email': 'foo@example.com',
             'password': '123'


### PR DESCRIPTION
This adds the required `test_` prefix.

Found via https://github.com/encode/django-rest-framework/pull/5970.