### PR TITLE
remove references to DOAC in docs

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -395,10 +395,6 @@ For details on configuration and usage see the Django REST framework OAuth docum
 
 HTTP digest authentication is a widely implemented scheme that was intended to replace HTTP basic authentication, and which provides a simple encrypted authentication mechanism. [Juan Riaza][juanriaza] maintains the [djangorestframework-digestauth][djangorestframework-digestauth] package which provides HTTP digest authentication support for REST framework.
 
-## Django OAuth2 Consumer
-
-The [Django OAuth2 Consumer][doac] library from [Rediker Software][rediker] is another package that provides [OAuth 2.0 support for REST framework][doac-rest-framework].  The package includes token scoping permissions on tokens, which allows finer-grained access to your API.
-
 ## JSON Web Token Authentication
 
 JSON Web Token is a fairly new standard which can be used for token-based authentication. Unlike the built-in TokenAuthentication scheme, JWT Authentication doesn't need to use a database to validate a token. [Blimp][blimp] maintains the [djangorestframework-jwt][djangorestframework-jwt] package which provides a JWT Authentication class as well as a mechanism for clients to obtain a JWT given the username and password. An alternative package for JWT authentication is [djangorestframework-simplejwt][djangorestframework-simplejwt] which provides different features as well as a pluggable token blacklist app.
@@ -449,9 +445,6 @@ HTTP Signature (currently a [IETF draft][http-signature-ietf-draft]) provides a 
 [django-oauth-toolkit]: https://github.com/evonove/django-oauth-toolkit
 [evonove]: https://github.com/evonove/
 [oauthlib]: https://github.com/idan/oauthlib
-[doac]: https://github.com/Rediker-Software/doac
-[rediker]: https://github.com/Rediker-Software
-[doac-rest-framework]: https://github.com/Rediker-Software/doac/blob/master/docs/integrations.md#
 [blimp]: https://github.com/GetBlimp
 [djangorestframework-jwt]: https://github.com/GetBlimp/django-rest-framework-jwt
 [djangorestframework-simplejwt]: https://github.com/davesque/django-rest-framework-simplejwt

--- a/docs/topics/third-party-packages.md
+++ b/docs/topics/third-party-packages.md
@@ -183,7 +183,6 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 
 * [djangorestframework-digestauth][djangorestframework-digestauth] - Provides Digest Access Authentication support.
 * [django-oauth-toolkit][django-oauth-toolkit] - Provides OAuth 2.0 support.
-* [doac][doac] - Provides OAuth 2.0 support.
 * [djangorestframework-jwt][djangorestframework-jwt] - Provides JSON Web Token Authentication support.
 * [djangorestframework-simplejwt][djangorestframework-simplejwt] - An alternative package that provides JSON Web Token Authentication support.
 * [hawkrest][hawkrest] - Provides Hawk HTTP Authorization.
@@ -285,7 +284,6 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [discussion-group]: https://groups.google.com/forum/#!forum/django-rest-framework
 [djangorestframework-digestauth]: https://github.com/juanriaza/django-rest-framework-digestauth
 [django-oauth-toolkit]: https://github.com/evonove/django-oauth-toolkit
-[doac]: https://github.com/Rediker-Software/doac
 [djangorestframework-jwt]: https://github.com/GetBlimp/django-rest-framework-jwt
 [djangorestframework-simplejwt]: https://github.com/davesque/django-rest-framework-simplejwt
 [hawkrest]: https://github.com/kumar303/hawkrest


### PR DESCRIPTION
project has been archived on github and hasn't had any activity since 2014, and I'm not aware of an active fork.
