### PR TITLE
Fix AttributeError in base.html when called without `response_headers`

### DIFF
--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -240,6 +240,10 @@ def items(value):
     lookup.  See issue #4931
     Also see: https://stackoverflow.com/questions/15416662/django-template-loop-over-dictionary-items-with-items-as-key
     """
+    if value is None:
+        # `{% for k, v in value.items %}` doesn't raise when value is None or
+        # not in the context, so neither should `{% for k, v in value|items %}`
+        return []
     return value.items()
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,7 @@
+from django.shortcuts import render
+
+
+def test_base_template_with_no_context():
+    # base.html should be renderable with no context,
+    # so it can be easily extended.
+    render({}, 'rest_framework/base.html')


### PR DESCRIPTION

## Description

We use a `404.html` which extends `rest_framework/base.html`. With the default `handler404` implementation, this template is rendered when you encounter a `Resolver404`. With DRF <3.6 this worked fine. Since then it throws an `AttributeError`. I traced the problem to 0173e9bd21e70c7fa973b2daf1480d2fff0089ae.

Since `Resolver404` goes via django's `handler404` and not via DRF's exception handling,
it doesn't get any extra context.

Since the `|items` filter doesn't check for `response_headers` being null (missing) it attempts
to call `<None>.items()`, thus raising an AttributeError.

This fixes the problem by checking for the presence of `response_headers` before calling `|items` with it.

## Possible alternative solutions

 * This could alternatively be solved in the `items` filter, making it just check for null before continuing. That might mask other problems elsewhere though.
 * If there was an easy way to delegate `handler404` etc to a DRF-based implementation which added the correct context, that might be more ideal. I couldn't find an easy way to do this.
