### PR TITLE
fix e.indexOf is not a function error

### DIFF
--- a/rest_framework/static/rest_framework/js/default.js
+++ b/rest_framework/static/rest_framework/js/default.js
@@ -41,7 +41,7 @@ $(document).ready(function() {
     $('.form-switcher a:first').tab('show');
   }
 
-  $(window).load(function() {
+  $(window).on('load', function() {
     $('#errorModal').modal('show');
   });
 });


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description
The jQuery upgrade throws the following exception when browsing endpoints:
e.indexOf is not a function error
.load, .unload or .error are deprecated since jQuery 1.8

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
