### PR TITLE
quickstart: fix too much output from `find .` cmd

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -28,8 +28,7 @@ The project layout should look like:
 
     $ pwd
     <some path>/tutorial
-    $ find .
-    .
+    $ find . -type d -name "env" -prune -o -type f -print
     ./manage.py
     ./tutorial
     ./tutorial/__init__.py


### PR DESCRIPTION
## Description

at 'Project Setup' in quickstart
http://www.django-rest-framework.org/tutorial/quickstart/#project-setup

`find .` outputs too much bc goes through virtual environment

<img width="1280" alt="screen shot 2018-05-12 at 2 09 31 pm" src="https://user-images.githubusercontent.com/11388735/39960306-8a36fe8a-55ee-11e8-9abf-56b255fdfc91.png">

`find . -type d -name "env" -prune -o -type f -print` output matches quickstart content

`tree` would be more concise but adds dependency

<img width="1280" alt="screen shot 2018-05-12 at 2 09 48 pm" src="https://user-images.githubusercontent.com/11388735/39960313-ab117fcc-55ee-11e8-803f-25cb2fc09749.png">
