### PR TITLE
tutorial #1: fix imports

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -84,7 +84,7 @@ We'll also need to create an initial migration for our snippet model, and sync t
 The first thing we need to get started on our Web API is to provide a way of serializing and deserializing the snippet instances into representations such as `json`.  We can do this by declaring serializers that work very similar to Django's forms.  Create a file in the `snippets` directory named `serializers.py` and add the following.
 
     from rest_framework import serializers
-    from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
+    from .models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
 
 
     class SnippetSerializer(serializers.Serializer):

--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -220,8 +220,8 @@ Edit the `snippets/views.py` file, and add the following.
     from django.views.decorators.csrf import csrf_exempt
     from rest_framework.renderers import JSONRenderer
     from rest_framework.parsers import JSONParser
-    from snippets.models import Snippet
-    from snippets.serializers import SnippetSerializer
+    from .models import Snippet
+    from .serializers import SnippetSerializer
 
 The root of our API is going to be a view that supports listing all the existing snippets, or creating a new snippet.
 


### PR DESCRIPTION
## Description

for reference, this is my directory structure from following tutorial

<img width="365" alt="screen shot 2018-05-12 at 2 52 21 pm" src="https://user-images.githubusercontent.com/11388735/39960632-32830282-55f4-11e8-81e6-c5ee0bd00167.png">

there is error in [http://www.django-rest-framework.org/tutorial/1-serialization/#creating-a-serializer-class](url)

`from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES` is incorrect reference

<img width="1280" alt="screen shot 2018-05-12 at 2 36 18 pm" src="https://user-images.githubusercontent.com/11388735/39960481-e0b7609e-55f1-11e8-960d-c38b754058e1.png">

`from .models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES` is fix

<img width="1280" alt="screen shot 2018-05-12 at 2 37 41 pm" src="https://user-images.githubusercontent.com/11388735/39960499-1f2e91c6-55f2-11e8-90f5-aeceb0b3ba5d.png">

this error also appears in [http://www.django-rest-framework.org/tutorial/1-serialization/#writing-regular-django-views-using-our-serializer](url); have fixed as well