### PR TITLE
Update documenting-your-api.md

### DIFF
--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -333,6 +333,6 @@ To implement a hypermedia API you'll need to decide on an appropriate media type
 [image-django-rest-swagger]: ../img/django-rest-swagger.png
 [image-apiary]: ../img/apiary.png
 [image-self-describing-api]: ../img/self-describing.png
-[schemas-examples]: ../api-guide/schemas/#example
+[schemas-examples]: ../api-guide/schemas/#examples
 [metadata-docs]: ../api-guide/metadata/
 [client-library-templates]: https://github.com/encode/django-rest-framework/tree/master/rest_framework/templates/rest_framework/docs/langs


### PR DESCRIPTION
Fix link to "Schemas as Documentation: Examples" anchor (`#example` -> `#examples`)

## Description

This PR fixes the link on the [Documenting your API](http://www.django-rest-framework.org/topics/documenting-your-api/) page to the "Schemas as documenation: Examples" anchor tag on the schemas API guide page.

The anchor was `#example` but should be `#examples`, as seen in this URL (line 457 of the raw Markdown file):

https://github.com/encode/django-rest-framework/blob/master/docs/api-guide/schemas.md#examples
