### PR TITLE
Reduce the number of circular references

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -100,7 +100,16 @@ class ViewSetMixin(object):
             self.kwargs = kwargs
 
             # And continue as usual
-            return self.dispatch(request, *args, **kwargs)
+            result = self.dispatch(request, *args, **kwargs)
+
+            # break our circular reference before finishing
+            for method in actions:
+                delattr(self, method)
+
+            if hasattr(self, 'head'):
+                delattr(self, 'head')
+
+            return result
 
         # take name and docstring from class
         update_wrapper(view, cls, updated=())

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -167,7 +167,7 @@ class TestRootView(TestCase):
         request = factory.post('/', data, HTTP_ACCEPT='text/html')
         response = self.view(request).render()
         expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
-        assert expected_error in response.rendered_content.decode('utf-8')
+        assert expected_error in response.content.decode('utf-8')
 
 
 EXPECTED_QUERIES_FOR_PUT = 2
@@ -314,7 +314,7 @@ class TestInstanceView(TestCase):
         request = factory.put('/', data, HTTP_ACCEPT='text/html')
         response = self.view(request, pk=1).render()
         expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
-        assert expected_error in response.rendered_content.decode('utf-8')
+        assert expected_error in response.content.decode('utf-8')
 
 
 class TestFKInstanceView(TestCase):


### PR DESCRIPTION
This should avoid high memory usage due to largish object not being deleted immediately by the reference counter.

This should help #5826. It's not perfect (for instance, the exact example from #5826 is not fixed) but it fix our use case and the following sample:


```
# app.py
#!/usr/bin/env python
import sys

import os; os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'  # noqa

from django.conf.urls import url

from rest_framework.views import APIView
from rest_framework.response import Response


class AnonymousUser(object):
    pass

class MemoryLeakView(APIView):
    def get(self, request, **kwargs):
        _20_megabyte = "0123456789abcdef" * 64 * 1024 * 20
        with open('/proc/%d/stat' % os.getpid()) as fobj:
            print(int(fobj.read().split()[23])*4)
        return Response({'a': _20_megabyte})

urlpatterns = [
    url(r'^$', MemoryLeakView.as_view()),
]

if __name__ == "__main__":
    from django.core.management import execute_from_command_line
    execute_from_command_line([sys.argv[0], 'runserver'] + sys.argv[1:])
```

As the discussion on #5826 concluded, this PR does not fix a memory *leak* but a high memory usage due to object not being freed by the reference counter. This is a issue for us because our uWSGI process may consume up to 1 GB of memory and never return it to the OS (probably because of memory fragmentation after GC pass). Right after startup our uWSGI consumer ~100mb which means the overhead if around 900 mb.

What is probably the biggest reason why this impact us more than other site, it's because some of your view process rather largish (300 kb) JSON to dict to JSON. And this JSON is made of numerous objects which probably increase the memory fragmentation.
