### PR TITLE
Fix DictField.get_value to return `empty`

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1708,10 +1708,17 @@ class DictField(Field):
         self.child.bind(field_name='', parent=self)
 
     def get_value(self, dictionary):
+        if self.field_name not in dictionary:
+            if getattr(self.root, 'partial', False):
+                return empty
         # We override the default field access in order to support
         # dictionaries in HTML forms.
         if html.is_html_input(dictionary):
-            return html.parse_html_dict(dictionary, prefix=self.field_name)
+            val = dictionary.getlist(self.field_name, {})
+            if len(val) > 0:
+                # Support QueryDict lists in HTML input.
+                return val
+            return html.parse_html_list(dictionary, prefix=self.field_name, default=empty)
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -16,7 +16,7 @@ from django.utils.timezone import activate, deactivate, override, utc
 import rest_framework
 from rest_framework import exceptions, serializers
 from rest_framework.compat import ProhibitNullCharactersValidator
-from rest_framework.fields import DjangoImageField, is_simple_callable
+from rest_framework.fields import DjangoImageField, empty, is_simple_callable
 
 try:
     import typings
@@ -167,6 +167,11 @@ class TestEmpty:
         field = serializers.IntegerField(default=123)
         output = field.run_validation()
         assert output is 123
+
+    def test_dictfield_empty(self):
+        field = serializers.DictField()
+        field.field_name = 'dict_field'
+        assert field.get_value(QueryDict()) is empty
 
 
 class TestSource:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -469,19 +469,6 @@ class TestHTMLInput:
         assert serializer.is_valid()
         assert serializer.validated_data == {'scores': [1]}
 
-    def test_querydict_list_input_no_values_uses_default(self):
-        """
-        When there are no values passed in, and default is set
-        The field should return the default value
-        """
-        class TestSerializer(serializers.Serializer):
-            a = serializers.IntegerField(required=True)
-            scores = serializers.ListField(default=lambda: [1, 3])
-
-        serializer = TestSerializer(data=QueryDict('a=1&'))
-        assert serializer.is_valid()
-        assert serializer.validated_data == {'a': 1, 'scores': [1, 3]}
-
     def test_querydict_list_input_supports_indexed_keys(self):
         """
         When data is passed in the format `scores[0]=1&scores[1]=3`
@@ -494,18 +481,6 @@ class TestHTMLInput:
         assert serializer.is_valid()
         assert serializer.validated_data == {'scores': ['5', '6']}
 
-    def test_querydict_list_input_no_values_no_default_and_not_required(self):
-        """
-        When there are no keys passed, there is no default, and required=False
-        The field should be skipped
-        """
-        class TestSerializer(serializers.Serializer):
-            scores = serializers.ListField(required=False)
-
-        serializer = TestSerializer(data=QueryDict(''))
-        assert serializer.is_valid()
-        assert serializer.validated_data == {}
-
     def test_querydict_list_input_posts_key_but_no_values(self):
         """
         When there are no keys passed, there is no default, and required=False
@@ -517,6 +492,37 @@ class TestHTMLInput:
         serializer = TestSerializer(data=QueryDict('scores=&'))
         assert serializer.is_valid()
         assert serializer.validated_data == {'scores': ['']}
+
+
+@pytest.mark.parametrize('field', (
+    serializers.ListField,
+    serializers.DictField,
+))
+class TestHTMLInputWithListAndDict:
+    def test_querydict_no_values_uses_default(self, field):
+        """
+        When there are no values passed in, and default is set
+        The field should return the default value
+        """
+        class TestSerializer(serializers.Serializer):
+            a = serializers.IntegerField(required=True)
+            scores = field(default=lambda: {'default': 'value'})
+
+        serializer = TestSerializer(data=QueryDict('a=1&'))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'a': 1, 'scores': {'default': 'value'}}
+
+    def test_querydict_no_values_no_default_and_not_required(self, field):
+        """
+        When there are no keys passed, there is no default, and required=False
+        The field should be skipped
+        """
+        class TestSerializer(serializers.Serializer):
+            scores = field(required=False)
+
+        serializer = TestSerializer(data=QueryDict(''))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {}
 
 
 class TestCreateOnlyDefault:

--- a/tests/test_serializer_lists.py
+++ b/tests/test_serializer_lists.py
@@ -294,7 +294,7 @@ class TestListSerializerClass:
 
 class TestSerializerPartialUsage:
     """
-    When not submitting key for list fields or multiple choice, partial
+    When not submitting keys for list, dict or multiple choice fields, partial
     serialization should result in an empty state (key not there), not
     an empty list.
 
@@ -316,6 +316,16 @@ class TestSerializerPartialUsage:
         serializer = MultipleChoiceSerializer(data=MultiValueDict(), partial=True)
         result = serializer.to_internal_value(data={})
         assert "multiplechoice" not in result
+        assert serializer.is_valid()
+        assert serializer.validated_data == {}
+        assert serializer.errors == {}
+
+    def test_partial_dictfield(self):
+        class DictFieldSerializer(serializers.Serializer):
+            data = serializers.DictField()
+        serializer = DictFieldSerializer(data=MultiValueDict(), partial=True)
+        result = serializer.to_internal_value(data={})
+        assert "data" not in result
         assert serializer.is_valid()
         assert serializer.validated_data == {}
         assert serializer.errors == {}


### PR DESCRIPTION
Without this, an empty field is not considered to be empty and then
validators might fail, e.g.
django.contrib.postgres.validators.RangeMinValueValidator with

> E   TypeError: '<' not supported between instances of 'NoneType' and 'int'

TODO:

- [ ] full test coverage?! https://codecov.io/gh/encode/django-rest-framework/pull/6009/diff