### PR TITLE
Add linkage to Caching API Guide.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ pages:
     - 'Validators': 'api-guide/validators.md'
     - 'Authentication': 'api-guide/authentication.md'
     - 'Permissions': 'api-guide/permissions.md'
+    - 'Caching': 'api-guide/caching.md'
     - 'Throttling': 'api-guide/throttling.md'
     - 'Filtering': 'api-guide/filtering.md'
     - 'Pagination': 'api-guide/pagination.md'


### PR DESCRIPTION
## Description

This branch adds the link to `mkdocs.yml` to expose the Caching API Guide that was created with PR #5514.

Fixes #6011