### PR TITLE
Update JSONRenderer to render a null response when `data=None`

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -88,9 +88,6 @@ class JSONRenderer(BaseRenderer):
         """
         Render `data` into JSON, returning a bytestring.
         """
-        if data is None:
-            return bytes()
-
         renderer_context = renderer_context or {}
         indent = self.get_indent(accepted_media_type, renderer_context)
 


### PR DESCRIPTION
## Description
Fixes https://github.com/encode/django-rest-framework/issues/6026
