### PR TITLE
Fix url for group_names action example

### DIFF
--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -293,7 +293,7 @@ The following mappings would be generated...
     <tr><th>URL</th><th>HTTP Method</th><th>Action</th><th>URL Name</th></tr>
     <tr><td>/users</td><td>GET</td><td>list</td><td>user-list</td></tr>
     <tr><td>/users/{username}</td><td>GET</td><td>retrieve</td><td>user-detail</td></tr>
-    <tr><td>/users/{username}/group-names</td><td>GET</td><td>group_names</td><td>user-group-names</td></tr>
+    <tr><td>/users/{username}/group_names</td><td>GET</td><td>group_names</td><td>user-group-names</td></tr>
 </table>
 
 For another example of setting the `.routes` attribute, see the source code for the `SimpleRouter` class.


### PR DESCRIPTION
Since no extra `url_path` is given, `url_path` should be same with the action name

See details from http://www.django-rest-framework.org/api-guide/routers/#example (in the mapping table)

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
