### PR TITLE
tox/pytest: move posargs, use -ra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 license_file = LICENSE.md
 
 [tool:pytest]
-addopts=--tb=short --strict
+addopts=--tb=short --strict -ra
 testspath = tests
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ DJANGO =
     master: djangomaster
 
 [testenv]
-commands = ./runtests.py --fast {posargs} --coverage -rw
+commands = ./runtests.py --fast --coverage {posargs}
 envdir = {toxworkdir}/venvs/{envname}
 setenv =
        PYTHONDONTWRITEBYTECODE=1
@@ -37,7 +37,7 @@ deps =
         -rrequirements/requirements-testing.txt
 
 [testenv:dist]
-commands = ./runtests.py --fast {posargs} --no-pkgroot --staticfiles -rw
+commands = ./runtests.py --fast --no-pkgroot --staticfiles {posargs}
 deps =
         django
         -rrequirements/requirements-testing.txt


### PR DESCRIPTION
- tox: move {posargs} to the end, so that it can override previous
  entries, e.g. `-ra` when `-rw` was used.
- pytest: add `-ra` to addopts: it is good to see a summary of skipped
  and failed tests at the end.