### PR TITLE
runtests.py: clean up PYTEST_ARGS

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -7,8 +7,8 @@ import sys
 import pytest
 
 PYTEST_ARGS = {
-    'default': ['tests', '--tb=short', '-s', '-rw'],
-    'fast': ['tests', '--tb=short', '-q', '-s', '-rw'],
+    'default': [],
+    'fast': ['-q'],
 }
 
 FLAKE8_ARGS = ['rest_framework', 'tests']


### PR DESCRIPTION
1. `tests` and `--tb=short` is not necessary, since it is in
`pytest.addopts` already.
2. removes `-s` (shortcut for --capture=no): it is typically a good idea
   to not display output from successful tests.

If you really want to keep `-s` it should be moved to addopts then.

Regarding `-q` for `--fast`: `--fast` is used by default, i.e. it could also be moved to `addopts`, but then I also do not like using it by default at all (default verbosity should be good).

(I still think that the indirection via `runtests.py` is not necessary and adds confusion - it would be better to run pytest and the other tools via tox directly)