### PR TITLE
tests: fix usage of transaction.non_atomic_requests

### DIFF
--- a/tests/test_atomic_requests.py
+++ b/tests/test_atomic_requests.py
@@ -6,7 +6,6 @@ from django.conf.urls import url
 from django.db import connection, connections, transaction
 from django.http import Http404
 from django.test import TestCase, TransactionTestCase, override_settings
-from django.utils.decorators import method_decorator
 
 from rest_framework import status
 from rest_framework.exceptions import APIException
@@ -37,7 +36,7 @@ class APIExceptionView(APIView):
 
 
 class NonAtomicAPIExceptionView(APIView):
-    @method_decorator(transaction.non_atomic_requests)
+    @transaction.non_atomic_requests
     def dispatch(self, *args, **kwargs):
         return super(NonAtomicAPIExceptionView, self).dispatch(*args, **kwargs)
 


### PR DESCRIPTION
This currently fails with Django 2.1 (beta), and it looks like the
decorator should be used just as is in general?!

    NonAtomicDBTransactionAPIExceptionTests.test_api_exception_rollback_transaction_non_atomic_view:

    ../django/django/db/transaction.py:277: in _non_atomic_requests
        view._non_atomic_requests.add(using)
    E   AttributeError: 'function' object has no attribute '_non_atomic_requests'

    During handling of the above exception, another exception occurred:
    tests/test_atomic_requests.py:149: in test_api_exception_rollback_transaction_non_atomic_view
        response = self.client.get('/')
    ../django/django/test/client.py:527: in get
        response = super().get(path, data=data, secure=secure, **extra)
    ../django/django/test/client.py:339: in get
        **extra,
    ../django/django/test/client.py:414: in generic
        return self.request(**r)
    ../django/django/test/client.py:477: in request
        response = self.handler(environ)
    ../django/django/test/client.py:140: in __call__
        response = self.get_response(request)
    ../django/django/core/handlers/base.py:81: in get_response
        response = self._middleware_chain(request)
    ../django/django/core/handlers/exception.py:37: in inner
        response = response_for_exception(request, exc)
    ../django/django/core/handlers/exception.py:87: in response_for_exception
        response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
    ../django/django/core/handlers/exception.py:35: in inner
        response = get_response(request)
    ../django/django/utils/deprecation.py:91: in __call__
        response = response or self.get_response(request)
    ../django/django/core/handlers/exception.py:37: in inner
        response = response_for_exception(request, exc)
    ../django/django/core/handlers/exception.py:87: in response_for_exception
        response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
    ../django/django/core/handlers/exception.py:35: in inner
        response = get_response(request)
    ../django/django/utils/deprecation.py:91: in __call__
        response = response or self.get_response(request)
    ../django/django/core/handlers/exception.py:37: in inner
        response = response_for_exception(request, exc)
    ../django/django/core/handlers/exception.py:87: in response_for_exception
        response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
    ../django/django/core/handlers/exception.py:35: in inner
        response = get_response(request)
    ../django/django/utils/deprecation.py:91: in __call__
        response = response or self.get_response(request)
    ../django/django/core/handlers/exception.py:37: in inner
        response = response_for_exception(request, exc)
    ../django/django/core/handlers/exception.py:87: in response_for_exception
        response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
    ../django/django/core/handlers/exception.py:35: in inner
        response = get_response(request)
    ../django/django/utils/deprecation.py:91: in __call__
        response = response or self.get_response(request)
    ../django/django/core/handlers/exception.py:37: in inner
        response = response_for_exception(request, exc)
    ../django/django/core/handlers/exception.py:87: in response_for_exception
        response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
    ../django/django/core/handlers/exception.py:35: in inner
        response = get_response(request)
    ../django/django/core/handlers/base.py:128: in _get_response
        response = self.process_exception_by_middleware(e, request)
    ../django/django/core/handlers/base.py:126: in _get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
    ../django/django/views/decorators/csrf.py:54: in wrapped_view
        return view_func(*args, **kwargs)
    ../django/django/views/generic/base.py:68: in view
        return self.dispatch(request, *args, **kwargs)
    ../django/django/utils/decorators.py:42: in _wrapper
        bound_method = dec(bound_method)
    ../django/django/db/transaction.py:285: in non_atomic_requests
        return _non_atomic_requests(using, DEFAULT_DB_ALIAS)
    ../django/django/db/transaction.py:279: in _non_atomic_requests
        view._non_atomic_requests = {using}
    E   AttributeError: 'method' object has no attribute '_non_atomic_requests'

Initially added in c292b3d1 by @hellysmile.