### PR TITLE
setup.cfg: use [tool:pytest]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [metadata]
 license_file = LICENSE.md
 
-[pytest]
+[tool:pytest]
 addopts=--tb=short --strict
 testspath = tests
 


### PR DESCRIPTION
Fixes:

> [pytest] section in setup.cfg files is deprecated, use [tool:pytest]
> instead.