### PR TITLE
Enable Codecov status API

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   status:
-    project: false
-    patch: false
-    changes: false
+    project: true
+    patch: true
+    changes: true
 
 comment: off


### PR DESCRIPTION
It was disabled in 68d20201, but likely accidentally - although there
was an issue for it already:
https://github.com/encode/django-rest-framework/issues/4594, but

I think it is really nice to have feedback on how much of a diff is
covered etc - you can still merge PRs, especially when it is not
configured to be a required check.

I've intentionally left "comment: off", since that triggers
notifications (although I like it personally since it means that CI is
finished and there is a coverage report).