### PR TITLE
Move guardian imports out of compat

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -139,14 +139,11 @@ except ImportError:
     requests = None
 
 
-# Django-guardian is optional. Import only if guardian is in INSTALLED_APPS
-# Fixes (#1712). We keep the try/except for the test suite.
-guardian = None
-try:
-    if 'guardian' in settings.INSTALLED_APPS:
-        import guardian  # noqa
-except ImportError:
-    pass
+def is_guardian_installed():
+    """
+    django-guardian is optional and only imported if in INSTALLED_APPS.
+    """
+    return 'guardian' in settings.INSTALLED_APPS
 
 
 # PATCH method is not implemented by Django

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -16,7 +16,9 @@ from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import coreapi, coreschema, distinct, guardian
+from rest_framework.compat import (
+    coreapi, coreschema, distinct, is_guardian_installed
+)
 from rest_framework.settings import api_settings
 
 
@@ -282,7 +284,7 @@ class DjangoObjectPermissionsFilter(BaseFilterBackend):
     has read object level permissions.
     """
     def __init__(self):
-        assert guardian, 'Using DjangoObjectPermissionsFilter, but django-guardian is not installed'
+        assert is_guardian_installed(), 'Using DjangoObjectPermissionsFilter, but django-guardian is not installed'
 
     perm_format = '%(app_label)s.view_%(model_name)s'
 
@@ -290,6 +292,7 @@ class DjangoObjectPermissionsFilter(BaseFilterBackend):
         # We want to defer this import until run-time, rather than import-time.
         # See https://github.com/encode/django-rest-framework/issues/4608
         # (Also see #1624 for why we need to make this import explicitly)
+        from guardian import VERSION as guardian_version
         from guardian.shortcuts import get_objects_for_user
 
         extra = {}
@@ -300,7 +303,7 @@ class DjangoObjectPermissionsFilter(BaseFilterBackend):
             'model_name': model_cls._meta.model_name
         }
         permission = self.perm_format % kwargs
-        if tuple(guardian.VERSION) >= (1, 3):
+        if tuple(guardian_version) >= (1, 3):
             # Maintain behavior compatibility with versions prior to 1.3
             extra = {'accept_global_perms': False}
         else:

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -12,7 +12,7 @@ from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
     status, views
 )
-from rest_framework.compat import guardian
+from rest_framework.compat import is_guardian_installed
 from rest_framework.filters import DjangoObjectPermissionsFilter
 from rest_framework.routers import DefaultRouter
 from rest_framework.test import APIRequestFactory
@@ -305,7 +305,7 @@ class GetQuerysetObjectPermissionInstanceView(generics.RetrieveUpdateDestroyAPIV
 get_queryset_object_permissions_view = GetQuerysetObjectPermissionInstanceView.as_view()
 
 
-@unittest.skipUnless(guardian, 'django-guardian not installed')
+@unittest.skipUnless(is_guardian_installed(), 'django-guardian not installed')
 class ObjectPermissionsIntegrationTests(TestCase):
     """
     Integration tests for the object level permissions API.


### PR DESCRIPTION
Supersedes #6038. The check now just ensures `guardian` is present in the `INSTALLED_APPS`, without attempting an import. Since this check is called during runtime by the framework, we won't trigger a "Django is not configured" error.