### PR TITLE
Fix Django 2.1 permissions tests

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import base64
 import unittest
 
+import django
 from django.contrib.auth.models import Group, Permission, User
 from django.db import models
 from django.test import TestCase
@@ -248,10 +249,12 @@ class BasicPermModel(models.Model):
 
     class Meta:
         app_label = 'tests'
-        permissions = (
-            ('view_basicpermmodel', 'Can view basic perm model'),
-            # add, change, delete built in to django
-        )
+
+        if django.VERSION < (2, 1):
+            permissions = (
+                ('view_basicpermmodel', 'Can view basic perm model'),
+                # add, change, delete built in to django
+            )
 
 
 class BasicPermSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
I've pulled out the permissions fix separately from #6044 while we wait for the UTC timezone issue to be fixed. Currently, the permissions error massively slows down the test suite, causing the Django 2.1+ builds to take ~12 minutes.