### PR TITLE
Add NotImplementedError to coverage exclusion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,9 @@ known_first_party=rest_framework
 source = .
 include = rest_framework/*,tests/*
 branch = 1
+
 [coverage:report]
 include = rest_framework/*,tests/*
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -35,26 +35,26 @@ class ActionViewSet(GenericViewSet):
     queryset = Action.objects.all()
 
     def list(self, request, *args, **kwargs):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError
 
     def retrieve(self, request, *args, **kwargs):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError
 
     @action(detail=False)
     def list_action(self, request, *args, **kwargs):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError
 
     @action(detail=False, url_name='list-custom')
     def custom_list_action(self, request, *args, **kwargs):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError
 
     @action(detail=True)
     def detail_action(self, request, *args, **kwargs):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError
 
     @action(detail=True, url_name='detail-custom')
     def custom_detail_action(self, request, *args, **kwargs):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError
 
 
 router = SimpleRouter()


### PR DESCRIPTION
In tests, uncalled stub methods should raise `NotImplementedError` instead of simply passing. This helps ensure that methods are not called unexpectedly by various code paths. As a trivial example, getting a view method's description should not unintentionally invoke that method.