### PR TITLE
Feature/form render

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -105,7 +105,11 @@ def field_to_schema(field):
             format='textarea'
         )
 
-    return coreschema.String(title=title, description=description)
+    return coreschema.String(
+        title=title,
+        description=description,
+        format=getattr(field, 'style', {}).get('input_type'),
+    )
 
 
 def get_pk_description(model, model_field):

--- a/rest_framework/static/rest_framework/docs/js/api.js
+++ b/rest_framework/static/rest_framework/docs/js/api.js
@@ -132,10 +132,17 @@ $(function () {
           params[paramKey] = value
         }
       } else if (dataType === 'array' && paramValue) {
-        try {
-          params[paramKey] = JSON.parse(paramValue)
-        } catch (err) {
-          // Ignore malformed JSON
+        if($elem.is('select')){
+          if(!(paramKey in params)) {
+            params[paramKey] = []
+          }
+          params[paramKey].push(paramValue)
+        } else {
+          try {
+              params[paramKey] = JSON.parse(paramValue)
+          } catch (err) {
+              // Ignore malformed JSON
+          }
         }
       } else if (dataType === 'object' && paramValue) {
         try {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -48,6 +48,7 @@ class ExampleSerializer(serializers.Serializer):
     b = serializers.CharField(required=False)
     read_only = serializers.CharField(read_only=True)
     hidden = serializers.HiddenField(default='hello')
+    password = serializers.CharField(write_only=True, style={'input_type': 'password'})
 
 
 class AnotherSerializerWithDictField(serializers.Serializer):
@@ -188,7 +189,8 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         fields=[
                             coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description='A field description')),
-                            coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
+                            coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B')),
+                            coreapi.Field('password', required=True, location='form', schema=coreschema.String(title='Password', format='password'))
                         ]
                     ),
                     'read': coreapi.Link(
@@ -253,7 +255,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
                             coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description=('A field description'))),
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.')),
+                            coreapi.Field('password', required=True, location='form', schema=coreschema.String(title='Password', format='password')),
                         ]
                     ),
                     'partial_update': coreapi.Link(
@@ -264,7 +267,8 @@ class TestRouterGeneratedSchema(TestCase):
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
                             coreapi.Field('a', required=False, location='form', schema=coreschema.String(title='A', description='A field description')),
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.')),
+                            coreapi.Field('password', required=False, location='form', schema=coreschema.String(title='Password', format='password')),
                         ]
                     ),
                     'delete': coreapi.Link(


### PR DESCRIPTION
## Description

I noticed a couple of issues with rendering of schema forms in the documentation. 
* Firstly password fields weren't treated as passwords in the form (ie they were plain text)
* Secondly multi select fields weren't being handled correctly as array data types (an error was raised at `JSON.parse`.

I've had a go at fixing them here.

Cheers
