### PR TITLE
Allow ModelSerializers as children in ListField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -16,10 +16,10 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import (
     EmailValidator, RegexValidator, URLValidator, ip_address_validators
 )
+from django.db import models
 from django.forms import FilePathField as DjangoFilePathField
 from django.forms import ImageField as DjangoImageField
 from django.utils import six, timezone
-from django.db import models
 from django.utils.dateparse import (
     parse_date, parse_datetime, parse_duration, parse_time
 )

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -19,6 +19,7 @@ from django.core.validators import (
 from django.forms import FilePathField as DjangoFilePathField
 from django.forms import ImageField as DjangoImageField
 from django.utils import six, timezone
+from django.db import models
 from django.utils.dateparse import (
     parse_date, parse_datetime, parse_duration, parse_time
 )
@@ -1653,7 +1654,8 @@ class ListField(Field):
         """
         List of object instances -> List of dicts of primitive datatypes.
         """
-        return [self.child.to_representation(item) if item is not None else None for item in data]
+        items = data.all() if isinstance(data, models.Manager) else data
+        return [self.child.to_representation(item) if item is not None else None for item in items]
 
     def run_child_validation(self, data):
         result = []


### PR DESCRIPTION
# Allow ModelSerializers as children in ListField

## Description

When using the `ListField`, if we give a `ModelSerializer` to the `child` argument, we get a `TypeError: 'RelatedManager' object is not iterable` error when `to_representation` is called. It is because the `ListField` will iterate over all elements of the list but doesn't handle the case where it is a `Manager`.

To resolve it, we can use the same technique being used in `ListSerializer` :
``` python
def to_representation(self, data):
        """
        List of object instances -> List of dicts of primitive datatypes.
        """
        # Dealing with nested relationships, data can be a Manager,
        # so, first get a queryset from the Manager if needed
        iterable = data.all() if isinstance(data, models.Manager) else data

        return [
            self.child.to_representation(item) for item in iterable
        ]
```
