### PR TITLE
return 404 in DestroyModelMixin

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -90,6 +90,8 @@ class DestroyModelMixin(object):
     """
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+        if not instance:
+            return Response(status=status.HTTP_404_NOT_FOUND)
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
In case self.get_object() returns None we should return a 404.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
