### PR TITLE
Handle "suffix" used in action decorator kwargs

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -157,9 +157,7 @@ def action(methods=None, detail=None, name=None, url_path=None, url_name=None, *
             'description': func.__doc__ or None
         })
         if 'suffix' not in kwargs:
-            func.kwargs.update({
-                'name': func.name,
-            })
+            func.kwargs['name'] = func.name
 
         return func
     return decorator

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -154,9 +154,12 @@ def action(methods=None, detail=None, name=None, url_path=None, url_name=None, *
         func.url_name = url_name if url_name else func.__name__.replace('_', '-')
         func.kwargs = kwargs
         func.kwargs.update({
-            'name': func.name,
             'description': func.__doc__ or None
         })
+        if 'suffix' not in kwargs:
+            func.kwargs.update({
+                'name': func.name,
+            })
 
         return func
     return decorator

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -187,6 +187,16 @@ class ActionDecoratorTestCase(TestCase):
             'description': 'Description',
         }
 
+    def test_detail_suffix(self):
+        @action(detail=True, suffix='Suffix')
+        def test_action(request):
+            raise NotImplementedError
+
+        assert test_action.kwargs == {
+            'description': None,
+            'suffix': 'Suffix',
+        }
+
     def test_detail_required(self):
         with pytest.raises(AssertionError) as excinfo:
             @action()


### PR DESCRIPTION
With 0148a9f8d you would get a TypeError when using "suffix" in an
action decorator.

This might get improved to take suffix as a keyword argument already,
defaulting to `None`.

TODO:

- [x] test

/cc @rpkilby 