### PR TITLE
Fix a badly formatted title in docs

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -209,7 +209,7 @@ directly.
 
 Note that the requests client requires you to pass fully qualified URLs.
 
-## `RequestsClient` and working with the database
+## RequestsClient and working with the database
 
 The `RequestsClient` class is useful if you want to write tests that solely interact with the service interface. This is a little stricter than using the standard Django test client, as it means that all interactions should be via the API.
 


### PR DESCRIPTION
While having code blocks in a title is valid Markdown, MkDocs does not
render it as expected. This removes a code block placed in a title.

------

Before:

![](https://i.imgur.com/BS4TwBy.png)

------

After:

![](https://i.imgur.com/RYjdlgr.png)