### PR TITLE
authtoken/admin: Use raw_id_fields for user field

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -7,6 +7,7 @@ class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
     ordering = ('-created',)
+    raw_id_fields = ('user',)
 
 
 admin.site.register(Token, TokenAdmin)


### PR DESCRIPTION
## Description

When attempting to create an authtoken from the admin Django will generate a select box with
all the users in the DB as options. In enviroments with a lot of users this will make the page
unreponsive.

Starting Django 2.0, there is a new option that addresses this issue - [raw_id_field](https://docs.djangoproject.com/en/2.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields).

This option will render the user selection as a special widget that does not require rendering
a list of all the users in the DB.
