### PR TITLE
Update filtering.md

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -366,7 +366,7 @@ The following third party packages provide additional filter implementations.
 
 ## Django REST framework filters package
 
-The [django-rest-framework-filters package][django-rest-framework-filters] works together with the `DjangoFilterBackend` class, and allows you to easily create filters across relationships, or create multiple filter lookup types for a given field.
+The [django-rest-framework-filters package][django-rest-framework-filters] works together with the `DjangoFilterBackend` class (from the `django-filter` library), and allows you to easily create filters across relationships, or create multiple filter lookup types for a given field.
 
 ## Django REST framework full word search filter
 


### PR DESCRIPTION
this line --> "The django-rest-framework-filters package works together with the DjangoFilterBackend class"

doesn't work w/out ctrl+F to see where DjangoFilterBackend *itself* comes from

to me the clearest thing would be adding `django-filter` to the 'Third party packages' section, as it is package external to DRF, just the same as `django-rest-framework-filters`
