### PR TITLE
Do not do `SELECT count(*) FROM ...` if pagination is not requested

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -322,10 +322,11 @@ class LimitOffsetPagination(BasePagination):
     template = 'rest_framework/pagination/numbers.html'
 
     def paginate_queryset(self, queryset, request, view=None):
-        self.count = self.get_count(queryset)
         self.limit = self.get_limit(request)
         if self.limit is None:
             return None
+
+        self.count = self.get_count(queryset)
 
         self.offset = self.get_offset(request)
         self.request = request

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -327,7 +327,6 @@ class LimitOffsetPagination(BasePagination):
             return None
 
         self.count = self.get_count(queryset)
-
         self.offset = self.get_offset(request)
         self.request = request
         if self.count > self.limit and self.template is not None:


### PR DESCRIPTION
Even if  I do not request pagination in HTTP-query `LimitOffsetPagination` still calls self.get_count(queryset) which results in an extra `SELECT count(*) FROM ...`. This becomes important if the query itself is comparatively heavy. Let's fix it by checking if pagination is requested first.

The pull request was not tested. Please, consider it as an issue report with proposed solution.

P.S.:

Here is my log before
```
2018-07-27 10:53:09,741 DEBUG django.db.backends (0.350) SELECT COUNT(*) FROM (SELECT "core_agent"."id" AS Col1, (COALESCE(EXTRACT(EPOCH FROM now() - last_online_dt) < 30, False)) AS "is_online_db" FROM "core_agent" WHERE ("core_agent"."user_id" = 14 AND "core_agent"."is_hidden" = false AND "core_agent"."id" IN (SELECT DISTINCT U0."source_id" AS Col1 FROM "core_ping" U0 INNER JOIN "core_target" U1 ON (U0."target_id" = U1."id") WHERE (U0."ts" >= 1468962000 AND U0."ts" <= 1532638799 AND U1."name" = 'mikrotik.com'))) GROUP BY "core_agent"."id", (COALESCE(EXTRACT(EPOCH FROM now() - last_online_dt) < 30, False))) subquery; args=(30, 14, False, 1468962000, 1532638799, u'mikrotik.com', 30)
2018-07-27 10:53:10,063 DEBUG django.db.backends (0.320) SELECT "core_agent"."id", "core_agent"."user_id", "core_agent"."name", "core_agent"."key", "core_agent"."location", "core_agent"."model", "core_agent"."ip_address", "core_agent"."public_ip_address", "core_agent"."version", "core_agent"."last_heard_from", "core_agent"."last_online_dt", "core_agent"."notified_online_dt", "core_agent"."notified_offline_dt", "core_agent"."gps_longitude", "core_agent"."gps_latitude", "core_agent"."module_settings", "core_agent"."tags", "core_agent"."is_active", "core_agent"."is_hidden", "core_agent"."bytes_sent", "core_agent"."bytes_received", (COALESCE(EXTRACT(EPOCH FROM now() - last_online_dt) < 30, False)) AS "is_online_db" FROM "core_agent" WHERE ("core_agent"."user_id" = 14 AND "core_agent"."is_hidden" = false AND "core_agent"."id" IN (SELECT DISTINCT U0."source_id" AS Col1 FROM "core_ping" U0 INNER JOIN "core_target" U1 ON (U0."target_id" = U1."id") WHERE (U0."ts" >= 1468962000 AND U0."ts" <= 1532638799 AND U1."name" = 'mikrotik.com'))) ORDER BY "core_agent"."id" ASC; args=(30, 14, False, 1468962000, 1532638799, u'mikrotik.com')
```

And after the change:
```
2018-07-27 11:08:45,964 DEBUG django.db.backends (0.477) SELECT "core_agent"."id", "core_agent"."user_id", "core_agent"."name", "core_agent"."key", "core_agent"."location", "core_agent"."model", "core_agent"."ip_address", "core_agent"."public_ip_address", "core_agent"."version", "core_agent"."last_heard_from", "core_agent"."last_online_dt", "core_agent"."notified_online_dt", "core_agent"."notified_offline_dt", "core_agent"."gps_longitude", "core_agent"."gps_latitude", "core_agent"."module_settings", "core_agent"."tags", "core_agent"."is_active", "core_agent"."is_hidden", "core_agent"."bytes_sent", "core_agent"."bytes_received", (COALESCE(EXTRACT(EPOCH FROM now() - last_online_dt) < 30, False)) AS "is_online_db" FROM "core_agent" WHERE ("core_agent"."user_id" = 14 AND "core_agent"."is_hidden" = false AND "core_agent"."id" IN (SELECT DISTINCT U0."source_id" AS Col1 FROM "core_ping" U0 INNER JOIN "core_target" U1 ON (U0."target_id" = U1."id") WHERE (U0."ts" >= 1468962000 AND U0."ts" <= 1532638799 AND U1."name" = 'mikrotik.com'))) ORDER BY "core_agent"."id" ASC; args=(30, 14, False, 1468962000, 1532638799, u'mikrotik.com')
```