### PR TITLE
Add Django 2.1 to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Tests are already running against Django 2.1 (see encode/django-rest-framework#6001) and the classifier is now available (see pypa/warehouse#4090).