### PR TITLE
Always pass a valid rounding value

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1135,6 +1135,7 @@ class DecimalField(Field):
             return value
 
         context = decimal.getcontext().copy()
+        # For Python 2.7 compatibility when using cdecimal
         rounding = context.rounding if self.rounding is None else self.rounding
         if self.max_digits is not None:
             context.prec = self.max_digits

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1135,11 +1135,12 @@ class DecimalField(Field):
             return value
 
         context = decimal.getcontext().copy()
+        rounding = context.rounding if self.rounding is None else self.rounding
         if self.max_digits is not None:
             context.prec = self.max_digits
         return value.quantize(
             decimal.Decimal('.1') ** self.decimal_places,
-            rounding=self.rounding,
+            rounding=rounding,
             context=context
         )
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -7,6 +7,7 @@ from decimal import ROUND_DOWN, ROUND_UP, Decimal
 
 import pytest
 import pytz
+from _pytest.monkeypatch import MonkeyPatch
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import QueryDict
 from django.test import TestCase, override_settings
@@ -16,6 +17,11 @@ from django.utils.timezone import activate, deactivate, override, utc
 import rest_framework
 from rest_framework import exceptions, serializers
 from rest_framework.fields import DjangoImageField, is_simple_callable
+
+try:
+    import cdecimal
+except ImportError:
+    cdecimal = False
 
 try:
     import typings
@@ -1127,6 +1133,16 @@ class TestQuantizedValueForDecimal(TestCase):
         value = field.to_internal_value('12.0').as_tuple()
         expected_digit_tuple = (0, (1, 2, 0, 0), -2)
         assert value == expected_digit_tuple
+
+    @unittest.skipUnless(cdecimal, 'requires python 2.7')
+    def test_quantize_on_monkey_patched_cdecimal(self):
+        # Monkey-patch cdecimal to replace decimal in for DecimalField
+        monkeypatch = MonkeyPatch()
+
+        with monkeypatch.context() as m:
+            m.setattr('rest_framework.fields.decimal', cdecimal)
+            f = rest_framework.fields.DecimalField(max_digits=4, decimal_places=2)
+            f.quantize(cdecimal.Decimal('1.234'))
 
 
 class TestNoDecimalPlaces(FieldValues):

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
         django20: Django>=2.0,<2.1
         django21: Django>=2.1b1,<2.2
         djangomaster: https://github.com/django/django/archive/master.tar.gz
+        py27: m3-cdecimal
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt
 


### PR DESCRIPTION
## Description

Fixes #6105

Prevent an exception in `quantize()` when monkey-patching the decimal
library as cdecimal in Python 2 environments by always passing a valid
(not None) `rounding` value to `quantize()`.
