### PR TITLE
add feature: extra_validators

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1026,6 +1026,8 @@ class ModelSerializer(Serializer):
             field_names, declared_fields, extra_kwargs
         )
 
+        extra_validators = self.get_extra_validators()
+
         # Determine the fields that should be included on the serializer.
         fields = OrderedDict()
 
@@ -1048,6 +1050,13 @@ class ModelSerializer(Serializer):
             # Include any kwargs defined in `Meta.extra_kwargs`
             field_kwargs = self.include_extra_kwargs(
                 field_kwargs, extra_field_kwargs
+            )
+
+            extra_field_validators = extra_validators.get(field_name, [])
+
+            # Include extra validators defined in `Meta.validators`
+            field_kwargs = self.include_extra_validators(
+                field_kwargs, extra_field_validators
             )
 
             # Create the serializer field.
@@ -1430,6 +1439,25 @@ class ModelSerializer(Serializer):
             extra_kwargs[key] = value
 
         return extra_kwargs, hidden_fields
+
+    def include_extra_validators(self, kwargs, extra_validators):
+        """
+        Include any 'extra_validators' that have been included for this field,
+        """
+        print(kwargs.get('validators', []))
+        print(extra_validators)
+        validators = kwargs.get('validators', []) + extra_validators
+        if validators:
+            kwargs['validators'] = validators
+        return kwargs
+
+    def get_extra_validators(self):
+        """
+        Return a dictionary mapping field names to a list of
+        additional validators.
+        """
+        extra_validators = copy.deepcopy(getattr(self.Meta, 'extra_validators', {}))
+        return extra_validators
 
     def _get_model_fields(self, field_names, declared_fields, extra_kwargs):
         """

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -14,7 +14,8 @@ from collections import OrderedDict
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import (
-    MaxValueValidator, MinLengthValidator, MinValueValidator, EmailValidator, URLValidator
+    EmailValidator, MaxValueValidator, MinLengthValidator, MinValueValidator,
+    URLValidator
 )
 from django.db import models
 from django.test import TestCase
@@ -290,7 +291,7 @@ class TestRegularFieldMappings(TestCase):
         """
         Ensure `extra_validators` are included to generated fields.
         """
-        class TestModel(models.Model):
+        class ExtraValidatorsTestModel(models.Model):
             int = models.IntegerField()
             email = models.CharField(unique=True)
             url = models.CharField(validators=[URLValidator()])
@@ -298,7 +299,7 @@ class TestRegularFieldMappings(TestCase):
 
         class TestSerializer(serializers.ModelSerializer):
             class Meta:
-                model = TestModel
+                model = ExtraValidatorsTestModel
                 fields = ('int', 'email', 'url', 'avatar')
                 extra_validators = {
                     'email': [EmailValidator()],
@@ -308,7 +309,7 @@ class TestRegularFieldMappings(TestCase):
         expected = dedent("""
             TestSerializer():
                 int = IntegerField()
-                email = CharField(validators=[<django.core.validators.MaxLengthValidator object>, <UniqueValidator(queryset=TestModel.objects.all())>, <django.core.validators.EmailValidator object>])
+                email = CharField(validators=[<django.core.validators.MaxLengthValidator object>, <UniqueValidator(queryset=ExtraValidatorsTestModel.objects.all())>, <django.core.validators.EmailValidator object>])
                 url = CharField(validators=[<django.core.validators.URLValidator object>, <django.core.validators.MaxLengthValidator object>])
                 avatar = CharField(validators=[<django.core.validators.MaxLengthValidator object>, <django.core.validators.URLValidator object>])
         """)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import (
-    MaxValueValidator, MinLengthValidator, MinValueValidator
+    MaxValueValidator, MinLengthValidator, MinValueValidator, EmailValidator, URLValidator
 )
 from django.db import models
 from django.test import TestCase
@@ -283,6 +283,34 @@ class TestRegularFieldMappings(TestCase):
             TestSerializer():
                 auto_field = IntegerField(read_only=False, required=False)
                 char_field = CharField(max_length=100)
+        """)
+        self.assertEqual(repr(TestSerializer()), expected)
+
+    def test_extra_field_validators(self):
+        """
+        Ensure `extra_validators` are included to generated fields.
+        """
+        class TestModel(models.Model):
+            int = models.IntegerField()
+            email = models.CharField(unique=True)
+            url = models.CharField(validators=[URLValidator()])
+            avatar = models.CharField()
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = TestModel
+                fields = ('int', 'email', 'url', 'avatar')
+                extra_validators = {
+                    'email': [EmailValidator()],
+                    'avatar': [URLValidator()],
+                }
+
+        expected = dedent("""
+            TestSerializer():
+                int = IntegerField()
+                email = CharField(validators=[<django.core.validators.MaxLengthValidator object>, <UniqueValidator(queryset=TestModel.objects.all())>, <django.core.validators.EmailValidator object>])
+                url = CharField(validators=[<django.core.validators.URLValidator object>, <django.core.validators.MaxLengthValidator object>])
+                avatar = CharField(validators=[<django.core.validators.MaxLengthValidator object>, <django.core.validators.URLValidator object>])
         """)
         self.assertEqual(repr(TestSerializer()), expected)
 


### PR DESCRIPTION
I want to add validator to fields built by `ModelSerializer`, if I add
```
    class Meta:
        extra_kwargs = {
            'name': validators: [RegexValidator('example')],
        }
```
it will override validators bulit by `ModelSerializer`, such as `UniqueValidator`.

So I think I can add a `extra_validators` in Meta class, is it a good idea?