### PR TITLE
Handle models without .objects manager in ModelSerializer.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -937,14 +937,15 @@ class ModelSerializer(Serializer):
                 many_to_many[field_name] = validated_data.pop(field_name)
 
         try:
-            instance = ModelClass.objects.create(**validated_data)
+            instance = ModelClass(**validated_data)
+            instance.save(force_insert=True)
         except TypeError:
             tb = traceback.format_exc()
             msg = (
-                'Got a `TypeError` when calling `%s.objects.create()`. '
+                'Got a `TypeError` when calling `%s()`. '
                 'This may be because you have a writable field on the '
                 'serializer class that is not a valid argument to '
-                '`%s.objects.create()`. You may need to make the field '
+                '`%s()`. You may need to make the field '
                 'read-only, or override the %s.create() method to handle '
                 'this correctly.\nOriginal exception was:\n %s' %
                 (

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -937,15 +937,14 @@ class ModelSerializer(Serializer):
                 many_to_many[field_name] = validated_data.pop(field_name)
 
         try:
-            instance = ModelClass(**validated_data)
-            instance.save(force_insert=True)
+            instance = ModelClass._default_manager.create(**validated_data)
         except TypeError:
             tb = traceback.format_exc()
             msg = (
-                'Got a `TypeError` when calling `%s()`. '
+                'Got a `TypeError` when calling `%s._default_manager.create()`. '
                 'This may be because you have a writable field on the '
                 'serializer class that is not a valid argument to '
-                '`%s()`. You may need to make the field '
+                '`%s._default_manager.create()`. You may need to make the field '
                 'read-only, or override the %s.create() method to handle '
                 'this correctly.\nOriginal exception was:\n %s' %
                 (

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -133,7 +133,7 @@ class TestModelSerializer(TestCase):
         })
         serializer.is_valid()
 
-        msginitial = 'Got a `TypeError` when calling `OneFieldModel()`.'
+        msginitial = 'Got a `TypeError` when calling `OneFieldModel._default_manager.create()`.'
         with self.assertRaisesMessage(TypeError, msginitial):
             serializer.save()
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -102,6 +102,13 @@ class Issue3674ChildModel(models.Model):
     value = models.CharField(primary_key=True, max_length=64)
 
 
+class Issue6110TestModel(models.Model):
+    """Model without .objects manager."""
+
+    name = models.CharField(max_length=64)
+    all_objects = models.Manager()
+
+
 class UniqueChoiceModel(models.Model):
     CHOICES = (
         ('choice1', 'choice 1'),
@@ -126,7 +133,7 @@ class TestModelSerializer(TestCase):
         })
         serializer.is_valid()
 
-        msginitial = 'Got a `TypeError` when calling `OneFieldModel.objects.create()`.'
+        msginitial = 'Got a `TypeError` when calling `OneFieldModel()`.'
         with self.assertRaisesMessage(TypeError, msginitial):
             serializer.save()
 
@@ -1224,3 +1231,15 @@ class TestFieldSource(TestCase):
         """)
         self.maxDiff = None
         self.assertEqual(unicode_repr(TestSerializer()), expected)
+
+
+class Issue6110Test(TestCase):
+    def test_model_serializer_custom_manager(self):
+
+        class TestModelSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = Issue6110TestModel
+                fields = ('name',)
+
+        instance = TestModelSerializer().create({'name': 'test_name'})
+        self.assertEqual(instance.name, 'test_name')


### PR DESCRIPTION
This pull request is a proposed fix for #6110 .
Regression test-case is added.
Alternative solution is to use `Model._default_manager`, but current solution seems more simple.