### PR TITLE
Fix CSRF cookie check failure when using session auth

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -135,7 +135,10 @@ class SessionAuthentication(BaseAuthentication):
         """
         Enforce CSRF validation for session based authentication.
         """
-        reason = CSRFCheck().process_view(request, None, (), {})
+        check = CSRFCheck()
+        # populates request.META['CSRF_COOKIE'], which is used in process_view()
+        check.process_request(request)
+        reason = check.process_view(request, None, (), {})
         if reason:
             # CSRF failed, bail with explicit error message
             raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)


### PR DESCRIPTION
Fixes CSRF failures when using cookie-based csrf with session auth and django 1.11.6+.

Test included (fails with old DRF and passes with this fix). Fixes #6088
