### PR TITLE
Message field of Permission class is not going to be ignored when the user is anonymous

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -173,7 +173,7 @@ class APIView(View):
         If request is not permitted, determine what kind of exception to raise.
         """
         if request.authenticators and not request.successful_authenticator:
-            raise exceptions.NotAuthenticated()
+            raise exceptions.NotAuthenticated(detail=message)
         raise exceptions.PermissionDenied(detail=message)
 
     def throttled(self, request, wait):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -527,6 +527,5 @@ class CustomPermissionsTests(TestCase):
             anonymous_request = factory.get('/1', format='json')
             response = denied_object_view_with_detail(anonymous_request, pk=1)
             detail = response.data.get('detail')
-            print(response.status_code, detail)
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(detail, self.custom_message)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -522,3 +522,11 @@ class CustomPermissionsTests(TestCase):
             detail = response.data.get('detail')
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(detail, self.custom_message)
+
+    def test_permission_denied_for_object_with_custom_detail_by_anonymous_user(self):
+            anonymous_request = factory.get('/1', format='json')
+            response = denied_object_view_with_detail(anonymous_request, pk=1)
+            detail = response.data.get('detail')
+            print(response.status_code, detail)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+            self.assertEqual(detail, self.custom_message)


### PR DESCRIPTION
message field of Permission class is not going to be ignored when the user is not anonymous.

refs #6117