### PR TITLE
Proper output is not return

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1783,7 +1783,7 @@ class JSONField(Field):
                     data = data.decode('utf-8')
                 return json.loads(data)
             else:
-                json.dumps(data)
+                data = json.dumps(data)
         except (TypeError, ValueError):
             self.fail('invalid')
         return data


### PR DESCRIPTION
def to_internal_value is not return data if binary=False and is_json_string=False

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
