### PR TITLE
Small docs fix & a verbose message about renderer not found

### DIFF
--- a/docs/topics/html-and-forms.md
+++ b/docs/topics/html-and-forms.md
@@ -92,7 +92,7 @@ The following view demonstrates an example of using a serializer in a template f
 
 The `render_form` tag takes an optional `template_pack` argument, that specifies which template directory should be used for rendering the form and form fields.
 
-REST framework includes three built-in template packs, all based on Bootstrap 3. The built-in styles are `horizontal`, `vertical`, and `inline`. The default style is `horizontal`. To use any of these template packs you'll want to also include the Bootstrap 3 CSS.
+REST framework includes three built-in template packs, all based on Bootstrap 3. The built-in styles are `horizontal`, `vertical`, and `inline`. The default style is `vertical`. To use any of these template packs you'll want to also include the Bootstrap 3 CSS.
 
 The following HTML will link to a CDN hosted version of the Bootstrap 3 CSS:
 
@@ -144,13 +144,15 @@ Presents labels and controls alongside each other, using a 2/10 column split.
 
 *This is the form style used in the browsable API and admin renderers.*
 
+Note: make sure you add "form-horizontal" class to `form` tag as per Bootstrap 3 guidelines.
+
     {% load rest_framework %}
 
     ...
 
     <form class="form-horizontal" action="{% url 'login' %}" method="post" novalidate>
         {% csrf_token %}
-        {% render_form serializer %}
+        {% render_form serializer template_pack='rest_framework/horizontal' %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <button type="submit" class="btn btn-default">Sign in</button>

--- a/rest_framework/negotiation.py
+++ b/rest_framework/negotiation.py
@@ -85,7 +85,9 @@ class DefaultContentNegotiation(BaseContentNegotiation):
         renderers = [renderer for renderer in renderers
                      if renderer.format == format]
         if not renderers:
-            raise Http404
+            raise Http404('Renderer for (%s) not found. Did you enable it with'
+                          ' DEFAULT_RENDERER_CLASSES or within the APIView'
+                          ' / ViewSet?' % format)
         return renderers
 
     def get_accept_list(self, request):

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -81,7 +81,7 @@ def exception_handler(exc, context):
     to be raised.
     """
     if isinstance(exc, Http404):
-        exc = exceptions.NotFound()
+        exc = exceptions.NotFound(*exc.args)
     elif isinstance(exc, PermissionDenied):
         exc = exceptions.PermissionDenied()
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -522,7 +522,8 @@ class TestFilterBackendAppliedToViews(TestCase):
         request = factory.get('/1')
         response = instance_view(request, pk=1).render()
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.data == {'detail': 'Not found.'}
+        assert (response.data == {'detail': 'Not found.'} or
+                response.data == {'detail': 'No BasicModel matches the given query.'})
 
     def test_get_instance_view_will_return_single_object_when_filter_does_not_exclude_it(self):
         """


### PR DESCRIPTION
Update documentation on HTMLFormRenderer
Add verbose message about renderer not found

## Description

This is in reference to issue #6101, points 1 and 4.

1. The documentation says default template pack is `horizontal` while in fact it is `vertical`

http://www.django-rest-framework.org/topics/html-and-forms/#using-template-packs

https://github.com/encode/django-rest-framework/blob/8493990a66e36d5dd4a62742d861b5b6b15cae80/rest_framework/renderers.py#L263

4. If you specify format in the query to a `ViewSet`, such as http://yourserver/rest/viewset/pk/?format=xyz, you will get the same *"404 Not found"* if **the renderer** is not found as you would if **the record** was not found. Makes it a bit awkward diagnosing the issue as there's no additional info.

The PR changes error detail to say: Renderer for (asked for format) not found. Did you enable it with DEFAULT_RENDERER_CLASSES or within the APIView / ViewSet?