### PR TITLE
Fix dist build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
         env: TOXENV=dist
         script:
           - python setup.py bdist_wheel
+          - rm -r djangorestframework.egg-info  # see #6139
           - tox --installpkg ./dist/djangorestframework-*.whl
           - tox  # test sdist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       - env: DJANGO=2.1
 
 install:
-    - pip install tox tox-travis
+    - pip install tox tox-venv tox-travis
 
 script:
     - tox


### PR DESCRIPTION
~There is some incompatibility with tox/pytest/virtualenv that causes the 'dist' build to fail. By using the builtin venvs, the issue is bypassed.~

~I'm also too lazy to figure out why exactly this is happening.~
