### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ matrix:
       - { python: "3.6", env: DJANGO=1.11 }
       - { python: "3.6", env: DJANGO=2.0 }
       - { python: "3.6", env: DJANGO=2.1 }
+
+      - { python: "3.7", env: DJANGO=2.0, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=2.1, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=master, dist: xenial, sudo: true }
+
       - { python: "3.6", env: TOXENV=base }
       - { python: "2.7", env: TOXENV=lint }
       - { python: "2.7", env: TOXENV=docs }
@@ -42,7 +47,6 @@ matrix:
 
     allow_failures:
       - env: DJANGO=master
-      - env: DJANGO=2.1
 
 install:
     - pip install tox tox-venv tox-travis

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 
 # Requirements
 
-* Python (2.7, 3.4, 3.5, 3.6)
+* Python (2.7, 3.4, 3.5, 3.6, 3.7)
 * Django (1.11, 2.0, 2.1)
 
 # Installation
@@ -142,14 +142,14 @@ You can now open the API in your browser at `http://127.0.0.1:8000/`, and view y
 You can also interact with the API using command line tools such as [`curl`](https://curl.haxx.se/). For example, to list the users endpoint:
 
     $ curl -H 'Accept: application/json; indent=4' -u admin:password http://127.0.0.1:8000/users/
-	[
-	    {
-	        "url": "http://127.0.0.1:8000/users/1/",
-	        "username": "admin",
-	        "email": "admin@example.com",
-	        "is_staff": true,
-	    }
-	]
+    [
+        {
+            "url": "http://127.0.0.1:8000/users/1/",
+            "username": "admin",
+            "email": "admin@example.com",
+            "is_staff": true,
+        }
+    ]
 
 Or to create a new user:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ continued development by **[signing up for a paid plan][funding]**.
 
 REST framework requires the following:
 
-* Python (2.7, 3.4, 3.5, 3.6)
+* Python (2.7, 3.4, 3.5, 3.6, 3.7)
 * Django (1.11, 2.0, 2.1)
 
 The following packages are optional:

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 import datetime
 import decimal
+import sys
 from collections import OrderedDict
 
 import pytest
@@ -381,6 +382,10 @@ class TestDurationFieldMapping(TestCase):
             TestSerializer():
                 id = IntegerField(label='ID', read_only=True)
                 duration_field = DurationField(max_value=datetime.timedelta(3), min_value=datetime.timedelta(1))
+        """) if sys.version_info < (3, 7) else dedent("""
+            TestSerializer():
+                id = IntegerField(label='ID', read_only=True)
+                duration_field = DurationField(max_value=datetime.timedelta(days=3), min_value=datetime.timedelta(days=1))
         """)
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
        {py27,py34,py35,py36}-django111,
-       {py34,py35,py36}-django20,
-       {py35,py36}-django21
-       {py35,py36}-djangomaster,
+       {py34,py35,py36,py37}-django20,
+       {py35,py36,py37}-django21
+       {py35,py36,py37}-djangomaster,
        base,dist,lint,docs,
 
 [travis:env]


### PR DESCRIPTION
Attempt at adding Python 3.7, which requires switching to Xenial. I've also updated the Travix matrix to be an explicit include list, as opposed to a mix of both include and exclude.