### PR TITLE
Fix Python 3.7 DeprecationWarning (Python 3.8 compatibility)

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -11,6 +11,13 @@ from django.utils import six
 from django.views.generic import View
 
 try:
+    # Python 3 (required for 3.8+)
+    from collections.abc import Mapping   # noqa
+except ImportError:
+    # Python 2.7
+    from collections import Mapping   # noqa
+
+try:
     from django.urls import (  # noqa
         URLPattern,
         URLResolver,

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 import copy
 import inspect
 import traceback
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -27,7 +27,7 @@ from django.utils import six, timezone
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import postgres_fields, unicode_to_repr
+from rest_framework.compat import Mapping, postgres_fields, unicode_to_repr
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.fields import get_error_detail, set_value
 from rest_framework.settings import api_settings


### PR DESCRIPTION
## Description

Fixes warning:

```
rest_framework/serializers.py:18: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping, OrderedDict
```