### PR TITLE
Add Django 2.1 to requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 # Requirements
 
 * Python (2.7, 3.4, 3.5, 3.6)
-* Django (1.11, 2.0)
+* Django (1.11, 2.0, 2.1)
 
 # Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ continued development by **[signing up for a paid plan][funding]**.
 REST framework requires the following:
 
 * Python (2.7, 3.4, 3.5, 3.6)
-* Django (1.11, 2.0)
+* Django (1.11, 2.0, 2.1)
 
 The following packages are optional:
 


### PR DESCRIPTION
If Django Rest Framework is compatible with Django 2.1, it should be mentioned in the requirements.

See also https://github.com/encode/django-rest-framework/pull/5510
