### PR TITLE
Preventing KeyError to be raised

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -328,7 +328,7 @@ For example, if you need to lookup objects based on multiple fields in the URL c
             queryset = self.filter_queryset(queryset)  # Apply any filter backends
             filter = {}
             for field in self.lookup_fields:
-                if self.kwargs[field]: # Ignore empty fields.
+                if field in self.kwargs: # Ignore empty fields.
                     filter[field] = self.kwargs[field]
             obj = get_object_or_404(queryset, **filter)  # Lookup the object
             self.check_object_permissions(self.request, obj)


### PR DESCRIPTION
## Description

When implementing the `MultipleFieldLookupMixin` as it was, a `KeyError` would be raised when either one of the `lookup_fields` was not present.