### PR TITLE
Prefer io.BytesIO over six; available on all supported Pythons

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -57,10 +57,10 @@ At this point we've translated the model instance into Python native datatypes. 
 
 Deserialization is similar. First we parse a stream into Python native datatypes...
 
-    from django.utils.six import BytesIO
+    import io
     from rest_framework.parsers import JSONParser
 
-    stream = BytesIO(json)
+    stream = io.BytesIO(json)
     data = JSONParser().parse(stream)
 
 ...then we restore those native datatypes into a dictionary of validated data.

--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -154,9 +154,9 @@ At this point we've translated the model instance into Python native datatypes. 
 
 Deserialization is similar.  First we parse a stream into Python native datatypes...
 
-    from django.utils.six import BytesIO
+    import io
 
-    stream = BytesIO(content)
+    stream = io.BytesIO(content)
     data = JSONParser().parse(stream)
 
 ...then we restore those native datatypes into a fully populated object instance.

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -10,6 +10,7 @@ The wrapped request then offers a richer API, in particular :
 """
 from __future__ import unicode_literals
 
+import io
 import sys
 from contextlib import contextmanager
 
@@ -301,7 +302,7 @@ class Request(object):
         elif not self._request._read_started:
             self._stream = self._request
         else:
-            self._stream = six.BytesIO(self.body)
+            self._stream = io.BytesIO(self.body)
 
     def _supports_form_parsing(self):
         """

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import io
 import math
 
 import pytest
@@ -10,7 +11,7 @@ from django.core.files.uploadhandler import (
 )
 from django.http.request import RawPostDataException
 from django.test import TestCase
-from django.utils.six import BytesIO, StringIO
+from django.utils.six import StringIO
 
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import (
@@ -43,7 +44,7 @@ class TestFileUploadParser(TestCase):
     def setUp(self):
         class MockRequest(object):
             pass
-        self.stream = BytesIO(
+        self.stream = io.BytesIO(
             "Test text file".encode('utf-8')
         )
         request = MockRequest()
@@ -131,7 +132,7 @@ class TestFileUploadParser(TestCase):
 
 class TestJSONParser(TestCase):
     def bytes(self, value):
-        return BytesIO(value.encode('utf-8'))
+        return io.BytesIO(value.encode('utf-8'))
 
     def test_float_strictness(self):
         parser = JSONParser()


### PR DESCRIPTION
On all supported Pythons, the io.BytesIO is always a stream implementation using an in-memory bytes buffer.

Makes code slightly more forward compatible by reducing use of the six module and promotes more forward compatible practices in the docs.