### PR TITLE
Do not persist the context in validators

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -47,7 +47,7 @@ If set, this gives the default value that will be used for the field if no input
 
 The `default` is not applied during partial update operations. In the partial update case only fields that are provided in the incoming data will have a validated value returned.
 
-May be set to a function or other callable, in which case the value will be evaluated each time it is used. When called, it will receive no arguments. If the callable has a `set_context` method, that will be called each time before getting the value with the field instance as only argument. This works the same way as for [validators](validators.md#using-set_context).
+May be set to a function or other callable, in which case the value will be evaluated each time it is used. When called, it will receive no arguments. If the callable has a `set_context` method, that will be called each time before getting the value with the field instance as only argument.
 
 When serializing the instance, default will be used if the the object attribute or dictionary key is not present in the instance.
 

--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -290,13 +290,18 @@ To write a class-based validator, use the `__call__` method. Class-based validat
                 message = 'This field must be a multiple of %d.' % self.base
                 raise serializers.ValidationError(message)
 
-#### Using `set_context()`
+#### Accessing the context
 
-In some advanced cases you might want a validator to be passed the serializer field it is being used with as additional context. You can do so by declaring a `set_context` method on a class-based validator.
+In some advanced cases you might want a validator to be passed the serializer
+field it is being used with as additional context. You can do so by using
+`rest_framework.validators.ContextBasedValidator` as a base class for the
+validator. The `__call__` method will then be called with the `serializer_field`
+or `serializer` as an additional argument.
 
-    def set_context(self, serializer_field):
+    def __call__(self, value, serializer_field):
         # Determine if this is an update or a create operation.
-        # In `__call__` we can then use that information to modify the validation behavior.
-        self.is_update = serializer_field.parent.instance is not None
+        is_update = serializer_field.parent.instance is not None
+
+        pass  # implementation of the validator that uses `is_update`
 
 [cite]: https://docs.djangoproject.com/en/stable/ref/validators/

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -30,7 +30,17 @@ def qs_filter(queryset, **kwargs):
         return queryset.none()
 
 
-class UniqueValidator:
+class ContextBasedValidator:
+    """Base class for validators that need a context during evaluation.
+
+    In extension to regular validators their `__call__` method must not only
+    accept a value, but also an instance of a serializer.
+    """
+    def __call__(self, value, serializer):
+        raise NotImplementedError('`__call__()` must be implemented.')
+
+
+class UniqueValidator(ContextBasedValidator):
     """
     Validator that corresponds to `unique=True` on a model field.
 
@@ -44,37 +54,32 @@ class UniqueValidator:
         self.message = message or self.message
         self.lookup = lookup
 
-    def set_context(self, serializer_field):
-        """
-        This hook is called by the serializer instance,
-        prior to the validation call being made.
-        """
-        # Determine the underlying model field name. This may not be the
-        # same as the serializer field name if `source=<>` is set.
-        self.field_name = serializer_field.source_attrs[-1]
-        # Determine the existing instance, if this is an update operation.
-        self.instance = getattr(serializer_field.parent, 'instance', None)
-
-    def filter_queryset(self, value, queryset):
+    def filter_queryset(self, value, queryset, field_name):
         """
         Filter the queryset to all instances matching the given attribute.
         """
-        filter_kwargs = {'%s__%s' % (self.field_name, self.lookup): value}
+        filter_kwargs = {'%s__%s' % (field_name, self.lookup): value}
         return qs_filter(queryset, **filter_kwargs)
 
-    def exclude_current_instance(self, queryset):
+    def exclude_current_instance(self, queryset, instance):
         """
         If an instance is being updated, then do not include
         that instance itself as a uniqueness conflict.
         """
-        if self.instance is not None:
-            return queryset.exclude(pk=self.instance.pk)
+        if instance is not None:
+            return queryset.exclude(pk=instance.pk)
         return queryset
 
-    def __call__(self, value):
+    def __call__(self, value, serializer_field):
+        # Determine the underlying model field name. This may not be the
+        # same as the serializer field name if `source=<>` is set.
+        field_name = serializer_field.source_attrs[-1]
+        # Determine the existing instance, if this is an update operation.
+        instance = getattr(serializer_field.parent, 'instance', None)
+
         queryset = self.queryset
-        queryset = self.filter_queryset(value, queryset)
-        queryset = self.exclude_current_instance(queryset)
+        queryset = self.filter_queryset(value, queryset, field_name)
+        queryset = self.exclude_current_instance(queryset, instance)
         if qs_exists(queryset):
             raise ValidationError(self.message, code='unique')
 
@@ -85,7 +90,7 @@ class UniqueValidator:
         )
 
 
-class UniqueTogetherValidator:
+class UniqueTogetherValidator(ContextBasedValidator):
     """
     Validator that corresponds to `unique_together = (...)` on a model class.
 
@@ -100,20 +105,12 @@ class UniqueTogetherValidator:
         self.serializer_field = None
         self.message = message or self.message
 
-    def set_context(self, serializer):
-        """
-        This hook is called by the serializer instance,
-        prior to the validation call being made.
-        """
-        # Determine the existing instance, if this is an update operation.
-        self.instance = getattr(serializer, 'instance', None)
-
-    def enforce_required_fields(self, attrs):
+    def enforce_required_fields(self, attrs, instance):
         """
         The `UniqueTogetherValidator` always forces an implied 'required'
         state on the fields it applies to.
         """
-        if self.instance is not None:
+        if instance is not None:
             return
 
         missing_items = {
@@ -124,16 +121,16 @@ class UniqueTogetherValidator:
         if missing_items:
             raise ValidationError(missing_items, code='required')
 
-    def filter_queryset(self, attrs, queryset):
+    def filter_queryset(self, attrs, queryset, instance):
         """
         Filter the queryset to all instances matching the given attributes.
         """
         # If this is an update, then any unprovided field should
         # have it's value set based on the existing instance attribute.
-        if self.instance is not None:
+        if instance is not None:
             for field_name in self.fields:
                 if field_name not in attrs:
-                    attrs[field_name] = getattr(self.instance, field_name)
+                    attrs[field_name] = getattr(instance, field_name)
 
         # Determine the filter keyword arguments and filter the queryset.
         filter_kwargs = {
@@ -142,20 +139,23 @@ class UniqueTogetherValidator:
         }
         return qs_filter(queryset, **filter_kwargs)
 
-    def exclude_current_instance(self, attrs, queryset):
+    def exclude_current_instance(self, attrs, queryset, instance):
         """
         If an instance is being updated, then do not include
         that instance itself as a uniqueness conflict.
         """
-        if self.instance is not None:
-            return queryset.exclude(pk=self.instance.pk)
+        if instance is not None:
+            return queryset.exclude(pk=instance.pk)
         return queryset
 
-    def __call__(self, attrs):
-        self.enforce_required_fields(attrs)
+    def __call__(self, attrs, serializer):
+        # Determine the existing instance, if this is an update operation.
+        instance = getattr(serializer, 'instance', None)
+
+        self.enforce_required_fields(attrs, instance)
         queryset = self.queryset
-        queryset = self.filter_queryset(attrs, queryset)
-        queryset = self.exclude_current_instance(attrs, queryset)
+        queryset = self.filter_queryset(attrs, queryset, instance)
+        queryset = self.exclude_current_instance(attrs, queryset, instance)
 
         # Ignore validation if any field is None
         checked_values = [
@@ -174,7 +174,7 @@ class UniqueTogetherValidator:
         )
 
 
-class BaseUniqueForValidator:
+class BaseUniqueForValidator(ContextBasedValidator):
     message = None
     missing_message = _('This field is required.')
 
@@ -183,18 +183,6 @@ class BaseUniqueForValidator:
         self.field = field
         self.date_field = date_field
         self.message = message or self.message
-
-    def set_context(self, serializer):
-        """
-        This hook is called by the serializer instance,
-        prior to the validation call being made.
-        """
-        # Determine the underlying model field names. These may not be the
-        # same as the serializer field names if `source=<>` is set.
-        self.field_name = serializer.fields[self.field].source_attrs[-1]
-        self.date_field_name = serializer.fields[self.date_field].source_attrs[-1]
-        # Determine the existing instance, if this is an update operation.
-        self.instance = getattr(serializer, 'instance', None)
 
     def enforce_required_fields(self, attrs):
         """
@@ -209,23 +197,30 @@ class BaseUniqueForValidator:
         if missing_items:
             raise ValidationError(missing_items, code='required')
 
-    def filter_queryset(self, attrs, queryset):
+    def filter_queryset(self, attrs, queryset, field_name, date_field_name):
         raise NotImplementedError('`filter_queryset` must be implemented.')
 
-    def exclude_current_instance(self, attrs, queryset):
+    def exclude_current_instance(self, attrs, queryset, instance):
         """
         If an instance is being updated, then do not include
         that instance itself as a uniqueness conflict.
         """
-        if self.instance is not None:
-            return queryset.exclude(pk=self.instance.pk)
+        if instance is not None:
+            return queryset.exclude(pk=instance.pk)
         return queryset
 
-    def __call__(self, attrs):
+    def __call__(self, attrs, serializer):
+        # Determine the underlying model field names. These may not be the
+        # same as the serializer field names if `source=<>` is set.
+        field_name = serializer.fields[self.field].source_attrs[-1]
+        date_field_name = serializer.fields[self.date_field].source_attrs[-1]
+        # Determine the existing instance, if this is an update operation.
+        instance = getattr(serializer, 'instance', None)
+
         self.enforce_required_fields(attrs)
         queryset = self.queryset
-        queryset = self.filter_queryset(attrs, queryset)
-        queryset = self.exclude_current_instance(attrs, queryset)
+        queryset = self.filter_queryset(attrs, queryset, field_name, date_field_name)
+        queryset = self.exclude_current_instance(attrs, queryset, instance)
         if qs_exists(queryset):
             message = self.message.format(date_field=self.date_field)
             raise ValidationError({
@@ -244,39 +239,39 @@ class BaseUniqueForValidator:
 class UniqueForDateValidator(BaseUniqueForValidator):
     message = _('This field must be unique for the "{date_field}" date.')
 
-    def filter_queryset(self, attrs, queryset):
+    def filter_queryset(self, attrs, queryset, field_name, date_field_name):
         value = attrs[self.field]
         date = attrs[self.date_field]
 
         filter_kwargs = {}
-        filter_kwargs[self.field_name] = value
-        filter_kwargs['%s__day' % self.date_field_name] = date.day
-        filter_kwargs['%s__month' % self.date_field_name] = date.month
-        filter_kwargs['%s__year' % self.date_field_name] = date.year
+        filter_kwargs[field_name] = value
+        filter_kwargs['%s__day' % date_field_name] = date.day
+        filter_kwargs['%s__month' % date_field_name] = date.month
+        filter_kwargs['%s__year' % date_field_name] = date.year
         return qs_filter(queryset, **filter_kwargs)
 
 
 class UniqueForMonthValidator(BaseUniqueForValidator):
     message = _('This field must be unique for the "{date_field}" month.')
 
-    def filter_queryset(self, attrs, queryset):
+    def filter_queryset(self, attrs, queryset, field_name, date_field_name):
         value = attrs[self.field]
         date = attrs[self.date_field]
 
         filter_kwargs = {}
-        filter_kwargs[self.field_name] = value
-        filter_kwargs['%s__month' % self.date_field_name] = date.month
+        filter_kwargs[field_name] = value
+        filter_kwargs['%s__month' % date_field_name] = date.month
         return qs_filter(queryset, **filter_kwargs)
 
 
 class UniqueForYearValidator(BaseUniqueForValidator):
     message = _('This field must be unique for the "{date_field}" year.')
 
-    def filter_queryset(self, attrs, queryset):
+    def filter_queryset(self, attrs, queryset, field_name, date_field_name):
         value = attrs[self.field]
         date = attrs[self.date_field]
 
         filter_kwargs = {}
-        filter_kwargs[self.field_name] = value
-        filter_kwargs['%s__year' % self.date_field_name] = date.year
+        filter_kwargs[field_name] = value
+        filter_kwargs['%s__year' % date_field_name] = date.year
         return qs_filter(queryset, **filter_kwargs)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -361,8 +361,7 @@ class TestUniquenessTogetherValidation(TestCase):
         queryset = MockQueryset()
         validator = UniqueTogetherValidator(queryset, fields=('race_name',
                                                               'position'))
-        validator.instance = self.instance
-        validator.filter_queryset(attrs=data, queryset=queryset)
+        validator.filter_queryset(attrs=data, queryset=queryset, instance=self.instance)
         assert queryset.called_with == {'race_name': 'bar', 'position': 1}
 
 
@@ -586,4 +585,6 @@ class ValidatorsTests(TestCase):
         validator = BaseUniqueForValidator(queryset=object(), field='foo',
                                            date_field='bar')
         with pytest.raises(NotImplementedError):
-            validator.filter_queryset(attrs=None, queryset=None)
+            validator.filter_queryset(
+                attrs=None, queryset=None, field_name='', date_field_name=''
+            )


### PR DESCRIPTION
This fixes encode/django-rest-framework#5760 and supersedes encode/django-rest-framework#5762.  It does however not include the failing test from encode/django-rest-framework#5761 as this makes no longer sense.

## Description

Please see encode/django-rest-framework#5760 for a detailed description of the race condition.  In short: When two serializers of the same type run their validators in parallel, the context might leak from one validator to the other (because the validator instances are identical).

Before validators could have a `set_context` method that persisted things like the instance of a django model on the validator.  This PR deprecates this feature.

Instead it adds a new base class `ContextBasedValidator` for class based validators.  Instances of this class will get the context (serializer or serialzer_field) as an additional argument.  This context can be used during validation without the need to persist it on the instance.

## Background of the implementation

This was basically proposed by @rpkilby in https://github.com/encode/django-rest-framework/pull/5762#discussion_r197617906 in a similar form:

- Refactor unique validators to inherit a base InstanceValidator
  - I decided to do this for all validators for consistency.  And it should make it easier to prevent similar issues for custom validators.
- Change the InstanceValidator call signature to expect an instance in addition to the value.
  - I've implemented this with the modification that `__call__` accepts the serializer[_field] instead.  This ensures that the full context is still available if needed.
- Delete the set_context method handling.
  - Deprecated for now.
- Handle regular validators first, then instance validators second.
  - I've skipped this since I'm not convinced that this provides any advantages.

This approach also prevents `deepcopy` as preferred by @tomchristie:

> If set_context means that we need a separate instance, perhaps we should be reconsidering the interface (e.g. set_context returns a new instance).
> 
> deepcopy is black magic, we should avoid it if we can.

Source: https://github.com/encode/django-rest-framework/pull/5762#discussion_r169986659


## Backwards compatibility

- `set_context` is still called by fields/serializers to give authors of custom validators time to adjust to the new behavior.  (The concrete release for the removal might need adjustment.)
- Existing validators in rest_framework no longer provide some fields on their instances (`self.instance`, `self.field_name`, …).  Custom validators based on those classes need to be adjusted immediately without any deprecation warning.
