### PR TITLE
Simplify job matrix on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: python
 cache: pip
 
-python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
-
 sudo: false
-
-env:
-    - DJANGO=1.11
-    - DJANGO=2.0
-    - DJANGO=2.1
-    - DJANGO=master
 
 matrix:
     fast_finish: true
     include:
+      - { python: "2.7", env: DJANGO=1.11 }
+
+      - { python: "3.4", env: DJANGO=1.11 }
+      - { python: "3.4", env: DJANGO=2.0 }
+
+      - { python: "3.5", env: DJANGO=1.11 }
+      - { python: "3.5", env: DJANGO=2.0 }
+      - { python: "3.5", env: DJANGO=2.1 }
+      - { python: "3.5", env: DJANGO=master }
+
       - { python: "3.6", env: DJANGO=master }
       - { python: "3.6", env: DJANGO=1.11 }
       - { python: "3.6", env: DJANGO=2.0 }
@@ -37,13 +36,6 @@ matrix:
           - rm -r djangorestframework.egg-info  # see #6139
           - tox --installpkg ./dist/djangorestframework-*.whl
           - tox  # test sdist
-
-    exclude:
-      - { python: "2.7", env: DJANGO=master }
-      - { python: "2.7", env: DJANGO=2.0 }
-      - { python: "2.7", env: DJANGO=2.1 }
-      - { python: "3.4", env: DJANGO=master }
-      - { python: "3.4", env: DJANGO=2.1 }
 
     allow_failures:
       - env: DJANGO=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ matrix:
       - { python: "3.5", env: DJANGO=2.1 }
       - { python: "3.5", env: DJANGO=master }
 
-      - { python: "3.6", env: DJANGO=master }
       - { python: "3.6", env: DJANGO=1.11 }
       - { python: "3.6", env: DJANGO=2.0 }
       - { python: "3.6", env: DJANGO=2.1 }
+      - { python: "3.6", env: DJANGO=master }
 
       - { python: "3.7", env: DJANGO=2.0, dist: xenial, sudo: true }
       - { python: "3.7", env: DJANGO=2.1, dist: xenial, sudo: true }


### PR DESCRIPTION
The current travis matrix is kind of a pain to parse, given that it's a combination of python/env expansion and both an include and exclude list. This simplifies the matrix by using only an include list.

Broken out of #6141.