### PR TITLE
If choices is set on a models.TextField default to a select box rather than a text area

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -88,7 +88,7 @@ def get_field_kwargs(field_name, model_field):
     if decimal_places is not None:
         kwargs['decimal_places'] = decimal_places
 
-    if isinstance(model_field, models.TextField) or (postgres_fields and isinstance(model_field, postgres_fields.JSONField)):
+    if isinstance(model_field, models.TextField) and not model_field.choices or (postgres_fields and isinstance(model_field, postgres_fields.JSONField)):
         kwargs['style'] = {'base_template': 'textarea.html'}
 
     if isinstance(model_field, models.AutoField) or not model_field.editable:


### PR DESCRIPTION
## Description

Do not set the base_template style to textarea.html if choices is set; when it is converted to a ChoiceField it will use the default select.html instead.

refs #6181
