### PR TITLE
Allow nullable BooleanField in Django 2.1

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,6 +5,7 @@ import unittest
 import uuid
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
 
+import django
 import pytest
 import pytz
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -657,7 +658,7 @@ class TestBooleanField(FieldValues):
 
 class TestNullBooleanField(TestBooleanField):
     """
-    Valid and invalid values for `BooleanField`.
+    Valid and invalid values for `NullBooleanField`.
     """
     valid_inputs = {
         'true': True,
@@ -680,6 +681,17 @@ class TestNullBooleanField(TestBooleanField):
         'other': True
     }
     field = serializers.NullBooleanField()
+
+
+@pytest.mark.skipif(django.VERSION < (2, 1), reason='Django version < 2.1')
+class TestNullableBooleanField(TestNullBooleanField):
+    """
+    Valid and invalid values for `BooleanField` when `allow_null=True`.
+    """
+
+    @property
+    def field(self):
+        return serializers.BooleanField(allow_null=True)
 
 
 # String types...

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -12,6 +12,7 @@ import decimal
 import sys
 from collections import OrderedDict
 
+import django
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import (
@@ -219,6 +220,25 @@ class TestRegularFieldMappings(TestCase):
                 "(u'red', u'Red'), (u'blue', u'Blue'), (u'green', u'Green')"
             )
         self.assertEqual(unicode_repr(TestSerializer()), expected)
+
+    # merge this into test_regular_fields / RegularFieldsModel when
+    # Django 2.1 is the minimum supported version
+    @pytest.mark.skipif(django.VERSION < (2, 1), reason='Django version < 2.1')
+    def test_nullable_boolean_field(self):
+        class NullableBooleanModel(models.Model):
+            field = models.BooleanField(null=True, default=False)
+
+        class NullableBooleanSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = NullableBooleanModel
+                fields = ['field']
+
+        expected = dedent("""
+            NullableBooleanSerializer():
+                field = BooleanField(allow_null=True, required=False)
+        """)
+
+        self.assertEqual(unicode_repr(NullableBooleanSerializer()), expected)
 
     def test_method_field(self):
         """


### PR DESCRIPTION
Fix #6103.