### PR TITLE
Add use_prefix to FileField

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -417,6 +417,7 @@ Corresponds to `django.forms.fields.FileField`.
  - `max_length` - Designates the maximum length for the file name.
  - `allow_empty_file` - Designates if empty files are allowed.
 - `use_url` - If set to `True` then URL string values will be used for the output representation. If set to `False` then filename string values will be used for the output representation. Defaults to the value of the `UPLOADED_FILES_USE_URL` settings key, which is `True` unless set otherwise.
+- `use_prefix` - It will replace the original schema and host and be effective only when `use_url` is `True`. If set to a non-empty string and should include url schema and location, such as `http://192.168.1.1`. Defaults to the value of the `UPLOADED_FILES_USE_PREFIX` settings key, which is an empty string and means doing nothing.
 
 ## ImageField
 
@@ -429,6 +430,7 @@ Corresponds to `django.forms.fields.ImageField`.
  - `max_length` - Designates the maximum length for the file name.
  - `allow_empty_file` - Designates if empty files are allowed.
 - `use_url` - If set to `True` then URL string values will be used for the output representation. If set to `False` then filename string values will be used for the output representation. Defaults to the value of the `UPLOADED_FILES_USE_URL` settings key, which is `True` unless set otherwise.
+- `use_prefix` - It will replace the original schema and host and be effective only when `use_url` is `True`. If set to a non-empty string and should include url schema and location, such as `http://192.168.1.1`. Defaults to the value of the `UPLOADED_FILES_USE_PREFIX` settings key, which is an empty string and means doing nothing.
 
 Requires either the `Pillow` package or `PIL` package.  The `Pillow` package is recommended, as `PIL` is no longer actively maintained.
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1531,6 +1531,8 @@ class FileField(Field):
         self.allow_empty_file = kwargs.pop('allow_empty_file', False)
         if 'use_url' in kwargs:
             self.use_url = kwargs.pop('use_url')
+        if 'use_prefix' in kwargs:
+            self.use_prefix = kwargs.pop('use_prefix')
         super(FileField, self).__init__(*args, **kwargs)
 
     def to_internal_value(self, data):
@@ -1555,6 +1557,7 @@ class FileField(Field):
             return None
 
         use_url = getattr(self, 'use_url', api_settings.UPLOADED_FILES_USE_URL)
+        prefix = getattr(self, 'use_prefix', api_settings.UPLOADED_FILES_USE_PREFIX)
 
         if use_url:
             if not getattr(value, 'url', None):
@@ -1563,6 +1566,8 @@ class FileField(Field):
             url = value.url
             request = self.context.get('request', None)
             if request is not None:
+                if prefix:
+                    url = prefix + url
                 return request.build_absolute_uri(url)
             return url
         return value.name

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -117,6 +117,7 @@ DEFAULTS = {
     'STRICT_JSON': True,
     'COERCE_DECIMAL_TO_STRING': True,
     'UPLOADED_FILES_USE_URL': True,
+    'UPLOADED_FILES_USE_PREFIX': '',
 
     # Browseable API
     'HTML_SELECT_CUTOFF': 1000,


### PR DESCRIPTION
## Description

Generally, some Django sites use a seperate Web server for serving static files or media files in production. But the representation of FileField is unsuitable for this situation when `use_url` is `True`. Especially when front-end and back-end are seperate.

For example, a Django app is running at `http://192.168.1.2:8000` by `Gunicorn` or other WSGI server. Meanwhile, a web server is listening `http://192.168.1.1:80` and forward request to WSGI server. In production environments, we'd better set `DEBUG` to `False`, so we must use the web server to forward request of `/media` or `/static` to a location where the server can serve them, such as `http://192.168.1.1/media/`.Under the circumstances, the representation of FileFiled is `http://192.168.1.2:8000/media/...` and it is not suitable. 

`use_prefix` is an optional argument and it can replace schema and location for the output represention. If it is not provided, `UPLOADED_FILES_USE_PREFIX` of `api_settings` would be adopted which is an empty string and means doing nothing. If `use_prefix` is set to `http://192.168.1.1` and the output represention will be `http://192.168.1.1/<MEDIA_URL>/...`. If not provided, it will be `http://host:port/<MEDIA_URL>/...`.