### PR TITLE
Remove unnecessary use compat shim of six.binary_type

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -96,7 +96,7 @@ def unicode_to_repr(value):
 
 def unicode_http_header(value):
     # Coerce HTTP header value to unicode.
-    if isinstance(value, six.binary_type):
+    if isinstance(value, bytes):
         return value.decode('iso-8859-1')
     return value
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1780,7 +1780,7 @@ class JSONField(Field):
     def to_internal_value(self, data):
         try:
             if self.binary or getattr(data, 'is_json_string', False):
-                if isinstance(data, six.binary_type):
+                if isinstance(data, bytes):
                     data = data.decode('utf-8')
                 return json.loads(data)
             else:

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -47,7 +47,7 @@ class JSONEncoder(json.JSONEncoder):
             return six.text_type(obj)
         elif isinstance(obj, QuerySet):
             return tuple(obj)
-        elif isinstance(obj, six.binary_type):
+        elif isinstance(obj, bytes):
             # Best-effort for binary blobs. See #4187.
             return obj.decode('utf-8')
         elif hasattr(obj, 'tolist'):


### PR DESCRIPTION
The type `bytes` is available on all supported Pythons. On Python 2.7, it is an alias for `str`, same as `six.binary_type`. Makes the code more forward compatible with Python 3.