### PR TITLE
Fix web UI when using session-based CSRF

### DIFF
--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -428,9 +428,6 @@ the user to login, and then instantiate a client using session authentication:
 The authentication scheme will handle including a CSRF header in any outgoing
 requests for unsafe HTTP methods.
 
-** Note: ** This mechanism does not work when used in conjunction with
-`CSRF_USE_SESSIONS = True` in your Django settings.
-
 #### Token authentication
 
 The `TokenAuthentication` class can be used to support REST framework's built-in

--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -428,6 +428,9 @@ the user to login, and then instantiate a client using session authentication:
 The authentication scheme will handle including a CSRF header in any outgoing
 requests for unsafe HTTP methods.
 
+** Note: ** This mechanism does not work when used in conjunction with
+`CSRF_USE_SESSIONS = True` in your Django settings.
+
 #### Token authentication
 
 The `TokenAuthentication` class can be used to support REST framework's built-in

--- a/rest_framework/static/rest_framework/js/csrf.js
+++ b/rest_framework/static/rest_framework/js/csrf.js
@@ -38,7 +38,7 @@ function sameOrigin(url) {
     !(/^(\/\/|http:|https:).*/.test(url));
 }
 
-var csrftoken = getCookie(window.drf.csrfCookieName);
+var csrftoken = window.drf.csrfToken;
 
 $.ajaxSetup({
   beforeSend: function(xhr, settings) {

--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -247,7 +247,7 @@
         <script>
           window.drf = {
             csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",
-            csrfCookieName: "{{ csrf_cookie_name|default:'csrftoken' }}"
+            csrfToken: "{{ csrf_token }}"
           };
         </script>
         <script src="{% static "rest_framework/js/jquery-3.3.1.min.js" %}"></script>

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -286,7 +286,7 @@
       <script>
         window.drf = {
           csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",
-          csrfToken: "{{ csrf_token }}"
+          csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
         };
       </script>
       <script src="{% static "rest_framework/js/jquery-3.3.1.min.js" %}"></script>

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -286,7 +286,7 @@
       <script>
         window.drf = {
           csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",
-          csrfCookieName: "{{ csrf_cookie_name|default:'csrftoken' }}"
+          csrfToken: "{{ csrf_token }}"
         };
       </script>
       <script src="{% static "rest_framework/js/jquery-3.3.1.min.js" %}"></script>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,6 +3,12 @@ import re
 from django.shortcuts import render
 
 
+def test_base_template_with_context():
+    context = {'request': True, 'csrf_token': 'TOKEN'}
+    result = render({}, 'rest_framework/base.html', context=context)
+    assert re.search(r'\bcsrfToken: "TOKEN"', result.content.decode('utf-8'))
+
+
 def test_base_template_with_no_context():
     # base.html should be renderable with no context,
     # so it can be easily extended.

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,7 +1,11 @@
+import re
+
 from django.shortcuts import render
 
 
 def test_base_template_with_no_context():
     # base.html should be renderable with no context,
     # so it can be easily extended.
-    render({}, 'rest_framework/base.html')
+    result = render({}, 'rest_framework/base.html')
+    # note that this response will not include a valid CSRF token
+    assert re.search(r'\bcsrfToken: ""', result.content)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -8,4 +8,4 @@ def test_base_template_with_no_context():
     # so it can be easily extended.
     result = render({}, 'rest_framework/base.html')
     # note that this response will not include a valid CSRF token
-    assert re.search(r'\bcsrfToken: ""', result.content)
+    assert re.search(r'\bcsrfToken: ""', result.content.decode('utf-8'))


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Closes #6206 

Pass the actual CSRF token value instead of the name of the cookie in which to find the value, and use this actual value in the `X-CSRFToken` header.