### PR TITLE
Update throttling docs to reflect correct throttle rate keys

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -33,12 +33,12 @@ The default throttling policy may be set globally, using the `DEFAULT_THROTTLE_C
             'rest_framework.throttling.UserRateThrottle'
         ),
         'DEFAULT_THROTTLE_RATES': {
-            'anon': '100/day',
-            'user': '1000/day'
+            'anon': '100/d',
+            'user': '1000/d'
         }
     }
 
-The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `second`, `minute`, `hour` or `day` as the throttle period.
+The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `s`, `m`, `h` or `d` as the throttle period.
 
 You can also set the throttling policy on a per-view or per-viewset basis,
 using the `APIView` class-based views.


### PR DESCRIPTION
## Description

The docs for Throttling show an incorrect throttle definition format. Per the source code (https://github.com/encode/django-rest-framework/blob/master/rest_framework/throttling.py#L60), the correct keys are 'm', 's', 'd, 'h'.
