### PR TITLE
Disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,4 @@ coverage:
     patch: true
     changes: true
 
-comment:
-  layout: "diff"
+comment: off


### PR DESCRIPTION
Going to propose we switch these off. They're noisy and make it harder to see more relevant information.