### PR TITLE
Add warning to documentation regarding TokenAuthentication expiration and rotation

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -160,7 +160,7 @@ The `curl` command line tool may be useful for testing token authenticated APIs.
 
 ---
 
-**Note:** If you use `TokenAuthentication` in production you must ensure that your API is only available over `https`.
+**Note:** If you use `TokenAuthentication` in production you must ensure that your API is only available over `https`. Additionally, beware that `TokenAuthentication` tokens do not rotate or expire. A number of [Third party packages](#third-party-packages) provide more advanced token support.
 
 ---
 


### PR DESCRIPTION
A [quick search](https://github.com/search?q=%22from+rest_framework+%22*+import+*+%22TokenAuthentication%22&type=Code) shows that thousands of projects use TokenAuthentication. Since storing tokens client-side is common practice, the fact that the basic tokens don't expire is worth a warning.