### PR TITLE
Add `OpenAPIRenderer` and `generate_schema` management command.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -11,11 +11,18 @@ from django.utils import six
 from django.views.generic import View
 
 try:
-    # Python 3 (required for 3.8+)
+    # Python 3
     from collections.abc import Mapping   # noqa
 except ImportError:
     # Python 2.7
     from collections import Mapping   # noqa
+
+try:
+    # Python 3
+    import urllib.parse as urlparse   # noqa
+except ImportError:
+    # Python 2.7
+    from urlparse import urlparse   # noqa
 
 try:
     from django.urls import (  # noqa

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -143,6 +143,13 @@ except ImportError:
     coreschema = None
 
 
+# pyyaml is optional
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
 # django-crispy-forms is optional
 try:
     import crispy_forms

--- a/rest_framework/management/commands/generate_schema.py
+++ b/rest_framework/management/commands/generate_schema.py
@@ -9,30 +9,24 @@ class Command(BaseCommand):
     help = "Generates configured API schema for project."
 
     def add_arguments(self, parser):
-        # TODO
-        # SchemaGenerator allows passing:
-        #
-        # - title
-        # - url
-        # - description
-        #
-        # Don't particularly want to pass these on the command-line.
-        # conf file?
-        #
-        # Other options to consider:
-        # - indent
-        # - ...
-        pass
+        parser.add_argument('--title', dest="title", default=None, type=str)
+        parser.add_argument('--url', dest="url", default=None, type=str)
+        parser.add_argument('--description', dest="description", default=None, type=str)
+        parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json', 'corejson'], default='openapi', type=str)
 
     def handle(self, *args, **options):
         assert coreapi is not None, 'coreapi must be installed.'
 
-        generator_class = api_settings.DEFAULT_SCHEMA_GENERATOR_CLASS()
+        generator_class = api_settings.DEFAULT_SCHEMA_GENERATOR_CLASS(
+            url=options['url']
+            title=options['title']
+            description=options['description']
+        )
         generator = generator_class()
 
         schema = generator.get_schema(request=None, public=True)
 
-        renderer = self.get_renderer('openapi')
+        renderer = self.get_renderer(options['format'])
         output = renderer.render(schema)
 
         self.stdout.write(output)

--- a/rest_framework/management/commands/generate_schema.py
+++ b/rest_framework/management/commands/generate_schema.py
@@ -18,8 +18,8 @@ class Command(BaseCommand):
         assert coreapi is not None, 'coreapi must be installed.'
 
         generator_class = api_settings.DEFAULT_SCHEMA_GENERATOR_CLASS(
-            url=options['url']
-            title=options['title']
+            url=options['url'],
+            title=options['title'],
             description=options['description']
         )
         generator = generator_class()

--- a/rest_framework/management/commands/generate_schema.py
+++ b/rest_framework/management/commands/generate_schema.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from rest_framework.compat import coreapi
-from rest_framework.renderers import CoreJSONRenderer, OpenAPIRenderer
+from rest_framework.renderers import CoreJSONRenderer, OpenAPIRenderer, JSONOpenAPIRenderer
 from rest_framework.settings import api_settings
 
 
@@ -15,8 +15,6 @@ class Command(BaseCommand):
         # - title
         # - url
         # - description
-        # - urlconf
-        # - patterns
         #
         # Don't particularly want to pass these on the command-line.
         # conf file?
@@ -42,5 +40,6 @@ class Command(BaseCommand):
     def get_renderer(self, format):
         return {
             'corejson': CoreJSONRenderer(),
-            'openapi': OpenAPIRenderer()
+            'openapi': OpenAPIRenderer(),
+            'openapi-json': JSONOpenAPIRenderer()
         }

--- a/rest_framework/management/commands/generate_schema.py
+++ b/rest_framework/management/commands/generate_schema.py
@@ -1,0 +1,46 @@
+from django.core.management.base import BaseCommand
+
+from rest_framework.compat import coreapi
+from rest_framework.renderers import CoreJSONRenderer, OpenAPIRenderer
+from rest_framework.settings import api_settings
+
+
+class Command(BaseCommand):
+    help = "Generates configured API schema for project."
+
+    def add_arguments(self, parser):
+        # TODO
+        # SchemaGenerator allows passing:
+        #
+        # - title
+        # - url
+        # - description
+        # - urlconf
+        # - patterns
+        #
+        # Don't particularly want to pass these on the command-line.
+        # conf file?
+        #
+        # Other options to consider:
+        # - indent
+        # - ...
+        pass
+
+    def handle(self, *args, **options):
+        assert coreapi is not None, 'coreapi must be installed.'
+
+        generator_class = api_settings.DEFAULT_SCHEMA_GENERATOR_CLASS()
+        generator = generator_class()
+
+        schema = generator.get_schema(request=None, public=True)
+
+        renderer = self.get_renderer('openapi')
+        output = renderer.render(schema)
+
+        self.stdout.write(output)
+
+    def get_renderer(self, format):
+        return {
+            'corejson': CoreJSONRenderer(),
+            'openapi': OpenAPIRenderer()
+        }

--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -29,9 +29,8 @@ class Command(BaseCommand):
         schema = generator.get_schema(request=None, public=True)
 
         renderer = self.get_renderer(options['format'])
-        output = renderer.render(schema)
-
-        self.stdout.write(output)
+        output = renderer.render(schema, renderer_context={})
+        self.stdout.write(output.decode('utf-8'))
 
     def get_renderer(self, format):
         return {

--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -5,7 +5,6 @@ from rest_framework.renderers import (
     CoreJSONRenderer, JSONOpenAPIRenderer, OpenAPIRenderer
 )
 from rest_framework.schemas.generators import SchemaGenerator
-from rest_framework.settings import api_settings
 
 
 class Command(BaseCommand):

--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -1,7 +1,10 @@
 from django.core.management.base import BaseCommand
 
 from rest_framework.compat import coreapi
-from rest_framework.renderers import CoreJSONRenderer, OpenAPIRenderer, JSONOpenAPIRenderer
+from rest_framework.renderers import (
+    CoreJSONRenderer, JSONOpenAPIRenderer, OpenAPIRenderer
+)
+from rest_framework.schemas.generators import SchemaGenerator
 from rest_framework.settings import api_settings
 
 
@@ -17,12 +20,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         assert coreapi is not None, 'coreapi must be installed.'
 
-        generator_class = api_settings.DEFAULT_SCHEMA_GENERATOR_CLASS(
+        generator = SchemaGenerator(
             url=options['url'],
             title=options['title'],
             description=options['description']
         )
-        generator = generator_class()
 
         schema = generator.get_schema(request=None, public=True)
 
@@ -36,4 +38,4 @@ class Command(BaseCommand):
             'corejson': CoreJSONRenderer(),
             'openapi': OpenAPIRenderer(),
             'openapi-json': JSONOpenAPIRenderer()
-        }
+        }[format]

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -935,19 +935,19 @@ class CoreJSONRenderer(BaseRenderer):
 
 
 class _BaseOpenAPIRenderer:
-    CLASS_TO_TYPENAME = {
-        coreschema.Object: 'object',
-        coreschema.Array: 'array',
-        coreschema.Number: 'number',
-        coreschema.Integer: 'integer',
-        coreschema.String: 'string',
-        coreschema.Boolean: 'boolean',
-    }
-
     def get_schema(self, instance):
+        CLASS_TO_TYPENAME = {
+            coreschema.Object: 'object',
+            coreschema.Array: 'array',
+            coreschema.Number: 'number',
+            coreschema.Integer: 'integer',
+            coreschema.String: 'string',
+            coreschema.Boolean: 'boolean',
+        }
+
         schema = {}
-        if instance.__class__ in self.CLASS_TO_TYPENAME:
-            schema['type'] = self.CLASS_TO_TYPENAME[instance.__class__]
+        if instance.__class__ in CLASS_TO_TYPENAME:
+            schema['type'] = CLASS_TO_TYPENAME[instance.__class__]
         schema['title'] = instance.title,
         schema['description'] = instance.description
         if hasattr(instance, 'enum'):

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -24,8 +24,8 @@ from django.utils.html import mark_safe
 
 from rest_framework import VERSION, exceptions, serializers, status
 from rest_framework.compat import (
-    INDENT_SEPARATORS, LONG_SEPARATORS, SHORT_SEPARATORS, coreapi,
-    pygments_css
+    INDENT_SEPARATORS, LONG_SEPARATORS, SHORT_SEPARATORS, coreapi, coreschema,
+    pygments_css, urlparse
 )
 from rest_framework.exceptions import ParseError
 from rest_framework.request import is_form_media_type, override_method
@@ -932,3 +932,95 @@ class CoreJSONRenderer(BaseRenderer):
         indent = bool(renderer_context.get('indent', 0))
         codec = coreapi.codecs.CoreJSONCodec()
         return codec.dump(data, indent=indent)
+
+
+class OpenAPIRenderer:
+    CLASS_TO_TYPENAME = {
+        coreschema.Object: 'object',
+        coreschema.Array: 'array',
+        coreschema.Number: 'number',
+        coreschema.Integer: 'integer',
+        coreschema.String: 'string',
+        coreschema.Boolean: 'boolean',
+    }
+
+    def __init__(self):
+        assert coreapi, 'Using OpenAPIRenderer, but `coreapi` is not installed.'
+
+    def get_schema(self, instance):
+        schema = {}
+        if instance.__class__ in self.CLASS_TO_TYPENAME:
+            schema['type'] = self.CLASS_TO_TYPENAME[instance.__class__]
+        schema['title'] = instance.title,
+        schema['description'] = instance.description
+        if hasattr(instance, 'enum'):
+            schema['enum'] = instance.enum
+        return schema
+
+    def get_parameters(self, link):
+        parameters = []
+        for field in link.fields:
+            if field.location not in ['path', 'query']:
+                continue
+            parameter = {
+                'name': field.name,
+                'in': field.location,
+            }
+            if field.required:
+                parameter['required'] = True
+            if field.description:
+                parameter['description'] = field.description
+            if field.schema:
+                parameter['schema'] = self.get_schema(field.schema)
+            parameters.append(parameter)
+        return parameters
+
+    def get_operation(self, link, name, tag):
+        operation_id = "%s_%s" % (tag, name) if tag else name
+        parameters = self.get_parameters(link)
+
+        operation = {
+            'operationId': operation_id,
+        }
+        if link.title:
+            operation['summary'] = link.title
+        if link.description:
+            operation['description'] = link.description
+        if parameters:
+            operation['parameters'] = parameters
+        if tag:
+            operation['tags'] = [tag]
+        return operation
+
+    def get_paths(self, document):
+        paths = {}
+
+        tag = None
+        for name, link in document.links.items():
+            path = urlparse.urlparse(link.url).path
+            method = link.action.lower()
+            paths.setdefault(path, {})
+            paths[path][method] = self.get_operation(link, name, tag=tag)
+
+        for tag, section in document.data.items():
+            for name, link in section.links.items():
+                path = urlparse.urlparse(link.url).path
+                method = link.action.lower()
+                paths.setdefault(path, {})
+                paths[path][method] = self.get_operation(link, name, tag=tag)
+
+        return paths
+
+    def render(self, data, media_type=None, renderer_context=None):
+        return json.dumps({
+            'openapi': '3.0.0',
+            'info': {
+                'version': '',
+                'title': data.title,
+                'description': data.description
+            },
+            'servers': [{
+                'url': data.url
+            }],
+            'paths': self.get_paths(data)
+        }, indent=4)

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -1034,7 +1034,7 @@ class OpenAPIRenderer(_BaseOpenAPIRenderer):
 
     def render(self, data, media_type=None, renderer_context=None):
         structure = self.get_structure(data)
-        return yaml.dumps(structure, default_flow_style=False)
+        return yaml.dump(structure, default_flow_style=False)
 
 
 class JSONOpenAPIRenderer(_BaseOpenAPIRenderer):

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -1034,7 +1034,7 @@ class OpenAPIRenderer(_BaseOpenAPIRenderer):
 
     def render(self, data, media_type=None, renderer_context=None):
         structure = self.get_structure(data)
-        return yaml.dump(structure, default_flow_style=False)
+        return yaml.dump(structure, default_flow_style=False).encode('utf-8')
 
 
 class JSONOpenAPIRenderer(_BaseOpenAPIRenderer):
@@ -1047,4 +1047,4 @@ class JSONOpenAPIRenderer(_BaseOpenAPIRenderer):
 
     def render(self, data, media_type=None, renderer_context=None):
         structure = self.get_structure(data)
-        return json.dumps(structure, indent=4)
+        return json.dumps(structure, indent=4).encode('utf-8')


### PR DESCRIPTION
This is a low footprint refinement of #6119.

Closes #5839.

Adds `OpenAPIRenderer` and `JSONOpenAPIRenderer`.
Add the `generate_schema` management command.

TODO:

- [x] Add flag options to the management command.
- [ ] Document the management command.
- [ ] Document the renderer classes, and switching to OpenAPI.
