### PR TITLE
Documentation fix for django-admin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Startup up a new project like so...
 
     pip install django
     pip install djangorestframework
-    django-admin.py startproject example .
+    django-admin startproject example .
     ./manage.py migrate
     ./manage.py createsuperuser
 

--- a/docs/community/project-management.md
+++ b/docs/community/project-management.md
@@ -152,7 +152,7 @@ When any user visible strings are changed, they should be uploaded to Transifex 
 
     # 1. Update the source django.po file, which is the US English version.
     cd rest_framework
-    django-admin.py makemessages -l en_US
+    django-admin makemessages -l en_US
     # 2. Push the source django.po file to Transifex.
     cd ..
     tx push -s
@@ -173,7 +173,7 @@ When a translator has finished translating their work needs to be downloaded fro
     tx pull -a --minimum-perc 10
     cd rest_framework
     # 4. Compile the binary .mo files for all supported languages.
-    django-admin.py compilemessages
+    django-admin compilemessages
 
 ---
 

--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -33,7 +33,7 @@ Okay, we're ready to get coding.
 To get started, let's create a new project to work with.
 
     cd ~
-    django-admin.py startproject tutorial
+    django-admin startproject tutorial
     cd tutorial
 
 Once that's done we can create an app that we'll use to create a simple Web API.

--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -19,9 +19,9 @@ Create a new Django project named `tutorial`, then start a new app called `quick
     pip install djangorestframework
 
     # Set up a new project with a single application
-    django-admin.py startproject tutorial .  # Note the trailing '.' character
+    django-admin startproject tutorial .  # Note the trailing '.' character
     cd tutorial
-    django-admin.py startapp quickstart
+    django-admin startapp quickstart
     cd ..
 
 The project layout should look like:


### PR DESCRIPTION


## Description

`refs #6231`
Fixes instances in docs where user is told to enter commands like:

`django-admin.py startproject tutorial`

to the correct:

`django-admin startproject tutorial`
