### PR TITLE
Fix html undefined dict parsing (refs #6234)

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1711,7 +1711,7 @@ class DictField(Field):
         # We override the default field access in order to support
         # dictionaries in HTML forms.
         if html.is_html_input(dictionary):
-            return html.parse_html_dict(dictionary, prefix=self.field_name)
+            return html.parse_html_dict(dictionary, prefix=self.field_name, default=empty)
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):

--- a/rest_framework/utils/html.py
+++ b/rest_framework/utils/html.py
@@ -66,7 +66,7 @@ def parse_html_list(dictionary, prefix='', default=None):
     return [ret[item] for item in sorted(ret)] if ret else default
 
 
-def parse_html_dict(dictionary, prefix=''):
+def parse_html_dict(dictionary, prefix='', default=None):
     """
     Used to support dictionary values in HTML forms.
 
@@ -92,4 +92,4 @@ def parse_html_dict(dictionary, prefix=''):
         value = dictionary.getlist(field)
         ret.setlist(key, value)
 
-    return ret
+    return ret if ret else default


### PR DESCRIPTION
## Description

This pull request fixes the issue identified in #6234 where, when handling a `multipart/form-data` request, DictField incorrectly returns an empty dictionary when no data for that dictionary was specified in the request.  In this case, it allows those implementing custom partial update logic to correctly distinguish between an omitted field and an empty dictionary.