### PR TITLE
Use stacklevel=2 with exclude_from_schema DeprecationWarning

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -81,7 +81,7 @@ def api_view(http_method_names=None, exclude_from_schema=False):
             warnings.warn(
                 "The `exclude_from_schema` argument to `api_view` is deprecated. "
                 "Use the `schema` decorator instead, passing `None`.",
-                DeprecationWarning
+                DeprecationWarning, stacklevel=2
             )
             WrappedAPIView.exclude_from_schema = exclude_from_schema
 


### PR DESCRIPTION
I've checked other warnings, and https://github.com/encode/django-rest-framework/blob/6522d4ae2058c6de39c9818d53cc5c45fec70762/rest_framework/schemas/generators.py#L214 might be a candidate also, but have not checked it really.