### PR TITLE
Feature/remove unused code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Changes should broadly follow the [PEP 8][pep-8] style conventions, and we recom
 To run the tests, clone the repository, and then:
 
     # Setup the virtual environment
-    virtualenv env
+    python -m venv env
     source env/bin/activate
     pip install django
     pip install -r requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Changes should broadly follow the [PEP 8][pep-8] style conventions, and we recom
 To run the tests, clone the repository, and then:
 
     # Setup the virtual environment
-    python -m venv env
+    virtualenv env
     source env/bin/activate
     pip install django
     pip install -r requirements.txt

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -16,19 +16,17 @@ class AuthTokenSerializer(serializers.Serializer):
         username = attrs.get('username')
         password = attrs.get('password')
 
-        if username and password:
-            user = authenticate(request=self.context.get('request'),
-                                username=username, password=password)
 
-            # The authenticate call simply returns None for is_active=False
-            # users. (Assuming the default ModelBackend authentication
-            # backend.)
-            if not user:
-                msg = _('Unable to log in with provided credentials.')
-                raise serializers.ValidationError(msg, code='authorization')
-        else:
-            msg = _('Must include "username" and "password".')
+        user = authenticate(request=self.context.get('request'),
+                            username=username, password=password)
+
+        # The authenticate call simply returns None for is_active=False
+        # users. (Assuming the default ModelBackend authentication
+        # backend.)
+        if not user:
+            msg = _('Unable to log in with provided credentials.')
             raise serializers.ValidationError(msg, code='authorization')
+
 
         attrs['user'] = user
         return attrs

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -16,7 +16,6 @@ class AuthTokenSerializer(serializers.Serializer):
         username = attrs.get('username')
         password = attrs.get('password')
 
-
         user = authenticate(request=self.context.get('request'),
                             username=username, password=password)
 
@@ -26,7 +25,6 @@ class AuthTokenSerializer(serializers.Serializer):
         if not user:
             msg = _('Unable to log in with provided credentials.')
             raise serializers.ValidationError(msg, code='authorization')
-
 
         attrs['user'] = user
         return attrs

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -13,8 +13,8 @@ class AuthTokenSerializer(serializers.Serializer):
     )
 
     def validate(self, attrs):
-        username = attrs.get('username')
-        password = attrs.get('password')
+        username = attrs['username']
+        password = attrs['password']
 
         user = authenticate(request=self.context.get('request'),
                             username=username, password=password)

--- a/tests/test_authtoken.py
+++ b/tests/test_authtoken.py
@@ -10,7 +10,6 @@ from rest_framework.authtoken.management.commands.drf_create_token import \
     Command as AuthTokenCommand
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.serializers import AuthTokenSerializer
-from rest_framework.exceptions import ValidationError
 
 
 class AuthTokenTests(TestCase):
@@ -27,10 +26,6 @@ class AuthTokenTests(TestCase):
 
     def test_token_string_representation(self):
         assert str(self.token) == 'test token'
-
-    def test_validate_raise_error_if_no_credentials_provided(self):
-        with pytest.raises(ValidationError):
-            AuthTokenSerializer().validate({})
 
     def test_whitespace_in_password(self):
         data = {'username': self.user.username, 'password': 'test pass '}


### PR DESCRIPTION
Hey DRF Team,

I noticed that the `AuthTokenSerializer` had some unreachable code in the `validate` method. 

Because `CharField` set `required` to [true by default](https://www.django-rest-framework.org/api-guide/fields/#required), there is no case where `username` or `password` would not be set.

This is my first PR for this project, apologies in advance if I misunderstood something.

Cheers,
Mark