### PR TITLE
FIX: openapi schema title should be a string not a tuple

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -948,7 +948,7 @@ class _BaseOpenAPIRenderer:
         schema = {}
         if instance.__class__ in CLASS_TO_TYPENAME:
             schema['type'] = CLASS_TO_TYPENAME[instance.__class__]
-        schema['title'] = instance.title,
+        schema['title'] = instance.title
         schema['description'] = instance.description
         if hasattr(instance, 'enum'):
             schema['enum'] = instance.enum


### PR DESCRIPTION
## Description

Introduced OpenAPI Schema renderer in 8908934928f448c1ec5f00bae754aacd6dbc0cfc has a bug that converts `schema['title']` from string to tuple.

The resulting OpenAPI Schema YAML then contains `!!python/tuple`, which causes `apistar` to fail.
```
       schema:
          description: A unique integer value identifying this thing.
          title: !!python/tuple
          - ID
          type: integer
```