### PR TITLE
compat: (py2) urlparse = urllib.parse (py3)

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -22,7 +22,7 @@ try:
     import urllib.parse as urlparse   # noqa
 except ImportError:
     # Python 2.7
-    from urlparse import urlparse   # noqa
+    import urlparse   # noqa
 
 try:
     from django.urls import (  # noqa

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -18,13 +18,6 @@ except ImportError:
     from collections import Mapping   # noqa
 
 try:
-    # Python 3
-    import urllib.parse as urlparse   # noqa
-except ImportError:
-    # Python 2.7
-    import urlparse   # noqa
-
-try:
     from django.urls import (  # noqa
         URLPattern,
         URLResolver,

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -21,11 +21,12 @@ from django.test.client import encode_multipart
 from django.urls import NoReverseMatch
 from django.utils import six
 from django.utils.html import mark_safe
+from django.utils.six.moves.urllib import parse as urlparse
 
 from rest_framework import VERSION, exceptions, serializers, status
 from rest_framework.compat import (
     INDENT_SEPARATORS, LONG_SEPARATORS, SHORT_SEPARATORS, coreapi, coreschema,
-    pygments_css, urlparse, yaml
+    pygments_css, yaml
 )
 from rest_framework.exceptions import ParseError
 from rest_framework.request import is_form_media_type, override_method


### PR DESCRIPTION
We were mistakenly importing the 'urlparse' function from the Python 2
'urlparse' module, as opposed to the module itself. Correct this.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Closes: #6261