### PR TITLE
Allow writing of schemas to files

### DIFF
--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -14,13 +14,29 @@ class Command(BaseCommand):
     help = "Generates configured API schema for project."
 
     def add_arguments(self, parser):
-        parser.add_argument('--title')
-        parser.add_argument('--url')
-        parser.add_argument('--description')
-        parser.add_argument('--format', choices=['openapi', 'openapi-json', 'corejson'], default='openapi')
+        parser.add_argument(
+            '--title',
+            help='A short description of the application. CommonMark syntax '
+            'MAY be used for rich text representation.')
+        parser.add_argument(
+            '--url',
+            help='A URL to the target host. This URL supports Server '
+            'Variables and MAY be relative, to indicate that the host '
+            'location is relative to the location where the OpenAPI document '
+            'is being served. Variable substitutions will be made when a '
+            'variable is named in {brackets}.')
+        parser.add_argument(
+            '--description',
+            help='An optional string describing the host designated by the '
+            'URL. CommonMark syntax MAY be used for rich text representation.')
+        parser.add_argument(
+            '--format',
+            choices=['openapi', 'openapi-json', 'corejson'], default='openapi',
+            help='Output format.')
         parser.add_argument(
             'output',
-            nargs='?', type=argparse.FileType('w'), default=sys.stdout)
+            nargs='?', type=argparse.FileType('w'), default=sys.stdout,
+            help='Path to output file. If not specified, output to stdout')
 
     def handle(self, *args, **options):
         assert coreapi is not None, 'coreapi must be installed.'

--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -1,3 +1,6 @@
+import argparse
+import sys
+
 from django.core.management.base import BaseCommand
 
 from rest_framework.compat import coreapi
@@ -15,6 +18,9 @@ class Command(BaseCommand):
         parser.add_argument('--url', dest="url", default=None, type=str)
         parser.add_argument('--description', dest="description", default=None, type=str)
         parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json', 'corejson'], default='openapi', type=str)
+        parser.add_argument(
+            'output',
+            nargs='?', type=argparse.FileType('w'), default=sys.stdout)
 
     def handle(self, *args, **options):
         assert coreapi is not None, 'coreapi must be installed.'
@@ -29,7 +35,7 @@ class Command(BaseCommand):
 
         renderer = self.get_renderer(options['format'])
         output = renderer.render(schema, renderer_context={})
-        self.stdout.write(output.decode('utf-8'))
+        options['output'].write(output.decode('utf-8'))
 
     def get_renderer(self, format):
         return {

--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -14,10 +14,10 @@ class Command(BaseCommand):
     help = "Generates configured API schema for project."
 
     def add_arguments(self, parser):
-        parser.add_argument('--title', dest="title", default=None, type=str)
-        parser.add_argument('--url', dest="url", default=None, type=str)
-        parser.add_argument('--description', dest="description", default=None, type=str)
-        parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json', 'corejson'], default='openapi', type=str)
+        parser.add_argument('--title')
+        parser.add_argument('--url')
+        parser.add_argument('--description')
+        parser.add_argument('--format', choices=['openapi', 'openapi-json', 'corejson'], default='openapi')
         parser.add_argument(
             'output',
             nargs='?', type=argparse.FileType('w'), default=sys.stdout)


### PR DESCRIPTION
Allow us to write the schemas generated by the `generateschema`
management command to a file. Documentation for the existing options is
included alongside docs for the new option.


Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.