### PR TITLE
Fix: AttributeError when Schema Endpoint requires authentication

### DIFF
--- a/rest_framework/schemas/views.py
+++ b/rest_framework/schemas/views.py
@@ -31,3 +31,10 @@ class SchemaView(APIView):
         if schema is None:
             raise exceptions.PermissionDenied()
         return Response(schema)
+
+    def handle_exception(self, exc):
+        if isinstance(exc, (exceptions.NotAuthenticated,
+                            exceptions.AuthenticationFailed)):
+            self.request.accepted_renderer = renderers.JSONRenderer()
+
+        return super(SchemaView, self).handle_exception(exc)


### PR DESCRIPTION
## Description

When getting a `not_authenticated` exception, `JSONOpenAPIRenderer` and `OpenAPIRenderer` were trying to call `get_structure` with an invalid format for `data` attribute, wich was raising an `AttributeError` exception while trying to access `data.title`

Fixes #6258 