### PR TITLE
Add `for_model()` static method to ModelSerializer

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -901,6 +901,16 @@ class ModelSerializer(Serializer):
     # "HTTP 201 Created" responses.
     url_field_name = None
 
+    @staticmethod
+    def for_model(model):
+        serializer_name = model.__name__ + 'Serializer'
+        meta = type('Meta', (), {'model': model, 'fields': '__all__'})
+        return type(
+            serializer_name,
+            (ModelSerializer,),
+            {'Meta': meta}
+        )
+
     # Default `create` and `update` behavior...
     def create(self, validated_data):
         """


### PR DESCRIPTION
## Description

This PR adds a method named `for_model()` (name is open to suggestions) to `ModelSerializer`. This function takes a model object as a parameter and creates a serializer which includes all fields in the model.

This is a feature that I think would be useful to have. I haven't spent any time on writing any tests yet because I want to get some feedback if the DRF community finds this useful before spending much time on it. Also, my implementation is probably quite simplistic and doesn't account for any potential edge cases. The intended use is for a quick way to create serializers and not intended to cover any special cases. You should just write your own subclass for that anyway.