### PR TITLE
Let SearchFilter subclasses dynamically set search fields

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -218,6 +218,13 @@ For example:
 
 By default, the search parameter is named `'search`', but this may be overridden with the `SEARCH_PARAM` setting.
 
+To dynamically change search fields based on request content, it's possible to subclass the `SearchFilter` and override the `get_search_fields()` function. For example, the following subclass will only search on `title` if the query parameter `title_only` is in the request:
+
+    class CustomSearchFilter(self, view, request):
+        if request.query_params.get('title_only'):
+            return ('title',)
+        return super(CustomSearchFilter, self).get_search_fields(view, request)
+
 For more details, see the [Django documentation][search-django-admin].
 
 ---

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -53,6 +53,14 @@ class SearchFilter(BaseFilterBackend):
     search_title = _('Search')
     search_description = _('A search term.')
 
+    def get_search_fields(self, view, request):
+        """
+        Search fields are obtained from the view, but the request is always
+        passed to this method. Sub-classes can override this method to
+        dynamically change the search fields based on request content.
+        """
+        return getattr(view, 'search_fields', None)
+
     def get_search_terms(self, request):
         """
         Search terms are set by a ?search=... query parameter,
@@ -90,7 +98,7 @@ class SearchFilter(BaseFilterBackend):
         return False
 
     def filter_queryset(self, request, queryset, view):
-        search_fields = getattr(view, 'search_fields', None)
+        search_fields = self.get_search_fields(view, request)
         search_terms = self.get_search_terms(request)
 
         if not search_fields or not search_terms:


### PR DESCRIPTION
- [x] *Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

This pull request refactors `#filter_queryset` and extracts a `#get_search_fields` method, passing in the request in as a second argument (currently unused). This allows subclasses to override this method and dynamically set search fields (vs. overriding the entire `#filter_queryset` method). A few example use cases:

1. Suppose you have 5 search fields, with `email` being one of them. If you run the search terms through a regex and recognize an email, you can dynamically set the search fields only to `email`. (This avoids wasteful searches on the other 4 fields.)

2. Suppose the default search fields are `("^book_title",)`. In combination with overriding the `#get_search_terms` method, a subclass might implement a light lexer/parser to recognize when a search term is encased in quotes, e.g. `"Green Eggs and Ham"` to translate to an _exact_ search of that string on `book_title`. This is how Google searches (roughly) work. Otherwise, the existing behavior would do a prefix search on `['"Green", 'Eggs', 'and', 'Ham"']`.

3. Handling more complex search configurations, e.g. [Google advanced search](https://www.google.com/advanced_search).

Thanks! :heart: DRF!