### PR TITLE
change `ListSerializer`'s all to iterator 

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -677,7 +677,7 @@ class ListSerializer(BaseSerializer):
         """
         # Dealing with nested relationships, data can be a Manager,
         # so, first get a queryset from the Manager if needed
-        iterable = data.all() if isinstance(data, models.Manager) else data
+        iterable = data.iterator() if isinstance(data, models.Manager) else data
 
         return [
             self.child.to_representation(item) for item in iterable


### PR DESCRIPTION
change `ListSerializer`'s all to iterator. Under a lot of data, the `iterator` better than `all`

## Description
change `ListSerializer`'s all to iterator. Under a lot of data, the `iterator` better than `all` 