### PR TITLE
Pass request to authenticate_credentials in TokenAuthentication

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -189,9 +189,9 @@ class TokenAuthentication(BaseAuthentication):
             msg = _('Invalid token header. Token string should not contain invalid characters.')
             raise exceptions.AuthenticationFailed(msg)
 
-        return self.authenticate_credentials(token)
+        return self.authenticate_credentials(token, request)
 
-    def authenticate_credentials(self, key):
+    def authenticate_credentials(self, key, request=None):
         model = self.get_model()
         try:
             token = model.objects.select_related('user').get(key=key)


### PR DESCRIPTION
It may help if you need to filter tokens based on information from request.
E.g. in multi-tenant application request may contain current tenant object.
Right not user have to copy paste authenticate method for one line change.