### PR TITLE
Don't force implement get_queryset

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -619,7 +619,7 @@ class BrowsableAPIRenderer(BaseRenderer):
         return None
 
     def get_filter_form(self, data, view, request):
-        if not hasattr(view, 'get_queryset') or not hasattr(view, 'filter_backends'):
+        if not hasattr(view, 'get_queryset') or getattr(view, 'filter_backends', None) is None:
             return
 
         # Infer if this is a list view or not.


### PR DESCRIPTION
When I implement GenericAPIView, I can set filter_backends to None, so I don't have to implement get_queryset. Because my view is not related to models.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
