### PR TITLE
permissions must return a boolean to allow &/| operator comparison

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -110,7 +110,7 @@ class IsAuthenticated(BasePermission):
     """
 
     def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated
+        return bool(request.user and request.user.is_authenticated)
 
 
 class IsAdminUser(BasePermission):
@@ -119,7 +119,7 @@ class IsAdminUser(BasePermission):
     """
 
     def has_permission(self, request, view):
-        return request.user and request.user.is_staff
+        return bool(request.user and request.user.is_staff)
 
 
 class IsAuthenticatedOrReadOnly(BasePermission):
@@ -128,7 +128,7 @@ class IsAuthenticatedOrReadOnly(BasePermission):
     """
 
     def has_permission(self, request, view):
-        return (
+        return bool(
             request.method in SAFE_METHODS or
             request.user and
             request.user.is_authenticated

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import Group, Permission, User
 from django.db import models
 from django.test import TestCase
 from django.urls import ResolverMatch
+from django.utils.deprecation import CallableBool
 
 from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
@@ -544,7 +545,7 @@ class CustomPermissionsTests(TestCase):
 
 class FakeUser:
     def __init__(self, auth=False):
-        self.is_authenticated = auth
+        self.is_authenticated = CallableBool(auth)
 
 
 class PermissionsCompositionTests(TestCase):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -5,11 +5,10 @@ import unittest
 import warnings
 
 import django
-from django.contrib.auth.models import Group, Permission, User
+from django.contrib.auth.models import AnonymousUser, Group, Permission, User
 from django.db import models
 from django.test import TestCase
 from django.urls import ResolverMatch
-from django.utils.deprecation import CallableBool
 
 from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
@@ -543,39 +542,46 @@ class CustomPermissionsTests(TestCase):
             self.assertEqual(detail, self.custom_message)
 
 
-class FakeUser:
-    def __init__(self, auth=False):
-        self.is_authenticated = CallableBool(auth)
-
-
 class PermissionsCompositionTests(TestCase):
+
+    def setUp(self):
+        self.username = 'john'
+        self.email = 'lennon@thebeatles.com'
+        self.password = 'password'
+        self.user = User.objects.create_user(
+            self.username,
+            self.email,
+            self.password
+        )
+        self.client.login(username=self.username, password=self.password)
+
     def test_and_false(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=False)
+        request.user = AnonymousUser()
         composed_perm = permissions.IsAuthenticated & permissions.AllowAny
         assert composed_perm().has_permission(request, None) is False
 
     def test_and_true(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=True)
+        request.user = self.user
         composed_perm = permissions.IsAuthenticated & permissions.AllowAny
         assert composed_perm().has_permission(request, None) is True
 
     def test_or_false(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=False)
+        request.user = AnonymousUser()
         composed_perm = permissions.IsAuthenticated | permissions.AllowAny
         assert composed_perm().has_permission(request, None) is True
 
     def test_or_true(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=True)
+        request.user = self.user
         composed_perm = permissions.IsAuthenticated | permissions.AllowAny
         assert composed_perm().has_permission(request, None) is True
 
     def test_several_levels(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=True)
+        request.user = self.user
         composed_perm = (
             permissions.IsAuthenticated &
             permissions.IsAuthenticated &


### PR DESCRIPTION
`x and y` actually returns object y when both are true. This means`SomePermission & IsAuthenticated` will fail with `TypeError: unsupported operand type(s) for &: 'instance' and 'bool'` as `IsAuthenticated` now returns a `CallableBool` which does not overload `__ror__` (at least in Django==1.11.16)

An alternative approach is explicitly calling `bool()` in `AND` and `OR`, which would allow `has_permission` to return truthy non boolean objects, but i feel permissions should be more explicit than that. If this approach makes sense I can add tests.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
