### PR TITLE
Django's is_authenticated now returns an object -proof of issue

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import Group, Permission, User
 from django.db import models
 from django.test import TestCase
 from django.urls import ResolverMatch
+from django.utils.deprecation import CallableBool
 
 from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
@@ -544,7 +545,7 @@ class CustomPermissionsTests(TestCase):
 
 class FakeUser:
     def __init__(self, auth=False):
-        self.is_authenticated = auth
+        self.is_authenticated = CallableBool(auth)
 
 
 class PermissionsCompositionTests(TestCase):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -5,11 +5,10 @@ import unittest
 import warnings
 
 import django
-from django.contrib.auth.models import Group, Permission, User
+from django.contrib.auth.models import AnonymousUser, Group, Permission, User
 from django.db import models
 from django.test import TestCase
 from django.urls import ResolverMatch
-from django.utils.deprecation import CallableBool
 
 from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
@@ -543,39 +542,46 @@ class CustomPermissionsTests(TestCase):
             self.assertEqual(detail, self.custom_message)
 
 
-class FakeUser:
-    def __init__(self, auth=False):
-        self.is_authenticated = CallableBool(auth)
-
-
 class PermissionsCompositionTests(TestCase):
+
+    def setUp(self):
+        self.username = 'john'
+        self.email = 'lennon@thebeatles.com'
+        self.password = 'password'
+        self.user = User.objects.create_user(
+            self.username,
+            self.email,
+            self.password
+        )
+        self.client.login(username=self.username, password=self.password)
+
     def test_and_false(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=False)
+        request.user = AnonymousUser()
         composed_perm = permissions.IsAuthenticated & permissions.AllowAny
         assert composed_perm().has_permission(request, None) is False
 
     def test_and_true(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=True)
+        request.user = self.user
         composed_perm = permissions.IsAuthenticated & permissions.AllowAny
         assert composed_perm().has_permission(request, None) is True
 
     def test_or_false(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=False)
+        request.user = AnonymousUser()
         composed_perm = permissions.IsAuthenticated | permissions.AllowAny
         assert composed_perm().has_permission(request, None) is True
 
     def test_or_true(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=True)
+        request.user = self.user
         composed_perm = permissions.IsAuthenticated | permissions.AllowAny
         assert composed_perm().has_permission(request, None) is True
 
     def test_several_levels(self):
         request = factory.get('/1', format='json')
-        request.user = FakeUser(auth=True)
+        request.user = self.user
         composed_perm = (
             permissions.IsAuthenticated &
             permissions.IsAuthenticated &


### PR DESCRIPTION
Test Change demonstrating the issue described in https://github.com/encode/django-rest-framework/pull/6286.