### PR TITLE
Fix a Python2.7 compatibility issue when calling urlparse

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -22,7 +22,7 @@ try:
     import urllib.parse as urlparse   # noqa
 except ImportError:
     # Python 2.7
-    from urlparse import urlparse   # noqa
+    import urlparse   # noqa
 
 try:
     from django.urls import (  # noqa


### PR DESCRIPTION
## Description

Fixes #6303 
With Python2.7 it was not possible to use the compatibility layer provided by DRF for urlparse due to wrong import.

From what I saw, the new `OpenAPIRenderer` [seems un-tested,](https://codecov.io/gh/encode/django-rest-framework/src/master/rest_framework/renderers.py#L948) we should try to add some tests if possible. 