### PR TITLE
 Fix issue with validation of `NullBooleanField` with choices

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -100,7 +100,8 @@ def get_field_kwargs(field_name, model_field):
     if model_field.has_default() or model_field.blank or model_field.null:
         kwargs['required'] = False
 
-    if model_field.null and not isinstance(model_field, models.NullBooleanField):
+    is_null_boolean_field = isinstance(model_field, models.NullBooleanField)
+    if (model_field.null and not is_null_boolean_field) or (model_field.choices and is_null_boolean_field):
         kwargs['allow_null'] = True
 
     if model_field.blank and (isinstance(model_field, models.CharField) or

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -363,6 +363,27 @@ class TestRegularFieldMappings(TestCase):
 
         ExampleSerializer()
 
+    def test_null_boolean_field_choices(self):
+
+        class Trivial(models.Model):
+            CHECKLIST_OPTIONS = (
+                (None, 'none'),
+                (True, 'checked'),
+                (False, 'N/A'),
+            )
+
+            name = models.CharField(max_length=255)
+            theoretically_nullable_field = models.NullBooleanField(choices=CHECKLIST_OPTIONS)
+
+        class TrivialSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = Trivial
+                fields = '__all__'
+
+        trivial_serialized = TrivialSerializer(data=dict(name='test', theoretically_nullable_field=None))
+        self.assertTrue(trivial_serialized.is_valid())
+        self.assertEqual(trivial_serialized.errors, {})
+
 
 class TestDurationFieldMapping(TestCase):
     def test_duration_field(self):


### PR DESCRIPTION
`get_field_kwargs` function will not set `allow_null` kwarg to `True` for `models.NullBooleanField`.
But in case choices provided for this field, we need to set `allow_null` to `True`, since all fields
with provided choices will be validated as `ChoiceField` (see `ModelSerializer.build_standard_field(...)`).

Refs: #6115 