### PR TITLE
Use raw_id_fields to avoid selecting all users

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -3,10 +3,9 @@ from django.contrib import admin
 from rest_framework.authtoken.models import Token
 
 
+@admin.register(Token)
 class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
     ordering = ('-created',)
-
-
-admin.site.register(Token, TokenAdmin)
+    raw_id_fields = ('user',)


### PR DESCRIPTION
In most applications, there are many users, this will lead to a non performant admin page if you want to modify or add a new token.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
