### PR TITLE
Fix the way DjangoModelPermissions asks for the model to be checked.

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -184,13 +184,15 @@ class DjangoModelPermissions(BasePermission):
             '`.queryset` or have a `.get_queryset()` method.'
         ).format(self.__class__.__name__)
 
-        if hasattr(view, 'get_queryset'):
+        queryset = getattr(view, 'queryset', None)
+
+        if queryset is None:
             queryset = view.get_queryset()
             assert queryset is not None, (
-                '{}.get_queryset() returned None'.format(view.__class__.__name__)
+                'The value of {0}.queryset and {0}.get_queryset() is None.'.format(view.__class__.__name__)
             )
-            return queryset
-        return view.queryset
+
+        return queryset
 
     def has_permission(self, request, view):
         # Workaround to ensure DjangoModelPermissions are not applied

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -591,4 +591,3 @@ class PermissionsCompositionTests(TestCase):
             permissions.IsAuthenticated
         )
         assert composed_perm().has_permission(request, None) is True
-

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -236,12 +236,14 @@ class ModelPermissionsIntegrationTests(TestCase):
 
         # Faulty `get_queryset()` methods should trigger the above "view does not have a queryset" assertion.
         class View(RootView):
+            queryset = None
+
             def get_queryset(self):
                 return None
         view = View.as_view()
 
         request = factory.get('/', HTTP_AUTHORIZATION=self.permitted_credentials)
-        with self.assertRaisesMessage(AssertionError, 'View.get_queryset() returned None'):
+        with self.assertRaisesMessage(AssertionError, 'The value of View.queryset and View.get_queryset() is None.'):
             view(request)
 
 
@@ -589,3 +591,4 @@ class PermissionsCompositionTests(TestCase):
             permissions.IsAuthenticated
         )
         assert composed_perm().has_permission(request, None) is True
+


### PR DESCRIPTION

## Description
DjangoModelPermissions always use the queryset from MyView.get_queryset() to extract the model name needed for permission verifications. In some cases, .get_queryset() method changes the queryset of the view depending on the conditions for a user. 

In my particular case, I created a custom permission class that verifies if the user has a role, so in a APIView I modified the permission_classes in this order: [DjangoModelPermissions, MyCustomUserPermission]. When I was testing my view, I tried to access with a user that didn't have the role required, therefore the test failed because DjangoModelPermissions tried to obtain the queryset using get_queryset().

When I realized which the problem was, I referred to the DRF documentation finding:

[DjangoModelPermissions](https://www.django-rest-framework.org/api-guide/permissions/#djangomodelpermissions)
> **Using with views that do not include a `queryset` attribute.**

>If you're using this permission with a view that uses an overridden get_queryset() method there may not be a queryset attribute on the view. In this case we suggest also marking the view with a sentinel queryset, so that this class can determine the required permissions. For example:
`queryset = User.objects.none()  # Required for DjangoModelPermissions `

So, I added a queryset attribute with and empty queryset (suggested in the docs) but DjangoModelPermission continues to ask for get_queryset().

My solution to the problem was to modify DjangoModelPermissions._queryset() to always returning the queryset attribute defined in the view, if not,  returning the queryset of get_queryset() method.