### PR TITLE
[BugFix] add "allow_unicode" option to ModelSerializer SlugField

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -88,6 +88,9 @@ def get_field_kwargs(field_name, model_field):
     if decimal_places is not None:
         kwargs['decimal_places'] = decimal_places
 
+    if isinstance(model_field, models.SlugField):
+        kwargs['allow_unicode'] = model_field.allow_unicode
+
     if isinstance(model_field, models.TextField) or (postgres_fields and isinstance(model_field, postgres_fields.JSONField)):
         kwargs['style'] = {'base_template': 'textarea.html'}
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -183,7 +183,7 @@ class TestRegularFieldMappings(TestCase):
                 null_boolean_field = NullBooleanField(required=False)
                 positive_integer_field = IntegerField()
                 positive_small_integer_field = IntegerField()
-                slug_field = SlugField(max_length=100)
+                slug_field = SlugField(allow_unicode=False, max_length=100)
                 small_integer_field = IntegerField()
                 text_field = CharField(max_length=100, style={'base_template': 'textarea.html'})
                 file_field = FileField(max_length=100)


### PR DESCRIPTION
If a SlugField set allow_unicode, the ModelSelializer have not set it.
when user create/update a model, the validator will reject the unicode slug field.
So, this fix add this option in field mapping.
