### PR TITLE
Remove condition that cleans values from DictField improperly

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1718,8 +1718,6 @@ class DictField(Field):
         """
         Dicts of native values <- Dicts of primitive datatypes.
         """
-        if html.is_html_input(data):
-            data = html.parse_html_dict(data)
         if not isinstance(data, dict):
             self.fail('not_a_dict', input_type=type(data).__name__)
         return self.run_child_validation(data)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1997,6 +1997,17 @@ class TestDictField(FieldValues):
         output = field.run_validation(None)
         assert output is None
 
+    def test_html_input_as_dict(self):
+        """
+        HTML inputs should be converted to dict
+        """
+        class TestSerializer(serializers.Serializer):
+            properties = serializers.DictField()
+
+        serializer = TestSerializer(data=QueryDict('properties.key1=value1&properties.key2=value2'))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'properties': {'key1': 'value1', 'key2': 'value2'}}
+
 
 class TestNestedDictField(FieldValues):
     """


### PR DESCRIPTION
I had some troubles to use `serializers.DictField()` in regular POST requests (x-www-form-urlencoded).
If I make a POST using JSON everything works well, but when I try to use http params my serializer always returns the field empty.

Code:
```python
class FoolSerializer(serializers.Serializer):
    name = serializers.CharField()
    location = serializers.DictField()
```

Request:
```
curl -d "name=Test&location.city=Orlando&location.state=FL" -X POST http://localhost:8000/endpoint
```

Result:

```
ipdb> serializer
FoolSerializer(data=<QueryDict: {'name': ['Test'], 'location.city': ['Orlando'], 'location.state': ['FL']}>):
    name = CharField()
    location = DictField()

ipdb> serializer.data
{'name': 'Test', 'location': {}}

ipdb> serializer.validated_data
OrderedDict([('name', 'Test'), ('location', {})])
```

Problem and Solution:

There's a condition to check if the data is coming from "html input" in order to convert in a dictionary. 
The problem is the condition is executing twice in two different methods (`get_value()` and `to_internal_value()`).
The first execution works well and does its job.
But, in the second time it's cleaning all the dictionary improperly.
It seems the second execution isn't necessary.
I removed that and the dictionary is working again.