### PR TITLE
Fix XSS caused by disabled autoescaping in the default DRF Browsable API view templates

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -171,10 +171,10 @@
               </div>
 
               <div class="response-info" aria-label="{% trans "response info" %}">
-                <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
+                <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% for key, val in response_headers|items %}
 <b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
 
-</span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
+</span>{{ content|urlize_quoted_links }}</pre>
               </div>
             </div>
 

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -336,6 +336,12 @@ def urlize_quoted_links(text, trim_url_limit=None, nofollow=True, autoescape=Tru
         return limit is not None and (len(x) > limit and ('%s...' % x[:max(0, limit - 3)])) or x
 
     safe_input = isinstance(text, SafeData)
+
+    # Unfortunately, Django built-in cannot be used here, because escaping
+    # is to be performed on words, which have been forcibly coerced to text
+    def conditional_escape(text):
+        return escape(text) if autoescape and not safe_input else text
+
     words = word_split_re.split(force_text(text))
     for i, word in enumerate(words):
         if '.' in word or '@' in word or ':' in word:
@@ -376,21 +382,15 @@ def urlize_quoted_links(text, trim_url_limit=None, nofollow=True, autoescape=Tru
             # Make link.
             if url:
                 trimmed = trim_url(middle)
-                if autoescape and not safe_input:
-                    lead, trail = escape(lead), escape(trail)
-                    url, trimmed = escape(url), escape(trimmed)
+                lead, trail = conditional_escape(lead), conditional_escape(trail)
+                url, trimmed = conditional_escape(url), conditional_escape(trimmed)
                 middle = '<a href="%s"%s>%s</a>' % (url, nofollow_attr, trimmed)
-                words[i] = mark_safe('%s%s%s' % (lead, middle, trail))
+                words[i] = '%s%s%s' % (lead, middle, trail)
             else:
-                if safe_input:
-                    words[i] = mark_safe(word)
-                elif autoescape:
-                    words[i] = escape(word)
-        elif safe_input:
-            words[i] = mark_safe(word)
-        elif autoescape:
-            words[i] = escape(word)
-    return ''.join(words)
+                words[i] = conditional_escape(word)
+        else:
+            words[i] = conditional_escape(word)
+    return mark_safe(''.join(words))
 
 
 @register.filter

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -305,6 +305,15 @@ class URLizerTests(TestCase):
             '&quot;foo_set&quot;: [\n    &quot;<a href="http://api/foos/1/">http://api/foos/1/</a>&quot;\n], '
         self._urlize_dict_check(data)
 
+    def test_template_render_with_autoescape(self):
+        """
+        Test that HTML is correctly escaped in Browsable API views.
+        """
+        template = Template("{% load rest_framework %}{{ content|urlize_quoted_links }}")
+        rendered = template.render(Context({'content': '<script>alert()</script> http://example.com'}))
+        assert rendered == '&lt;script&gt;alert()&lt;/script&gt;' \
+                           ' <a href="http://example.com" rel="nofollow">http://example.com</a>'
+
     def test_template_render_with_noautoescape(self):
         """
         Test if the autoescape value is getting passed to urlize_quoted_links filter.
@@ -312,8 +321,8 @@ class URLizerTests(TestCase):
         template = Template("{% load rest_framework %}"
                             "{% autoescape off %}{{ content|urlize_quoted_links }}"
                             "{% endautoescape %}")
-        rendered = template.render(Context({'content': '"http://example.com"'}))
-        assert rendered == '"<a href="http://example.com" rel="nofollow">http://example.com</a>"'
+        rendered = template.render(Context({'content': '<b> "http://example.com" </b>'}))
+        assert rendered == '<b> "<a href="http://example.com" rel="nofollow">http://example.com</a>" </b>'
 
 
 @unittest.skipUnless(coreapi, 'coreapi is not installed')


### PR DESCRIPTION
As requested in #6191.