### PR TITLE
Fix typo in schemas

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -57,7 +57,7 @@ Schema Naming Collision.
 coreapi.Link for URL path {value_url} cannot be inserted into schema.
 Position conflicts with coreapi.Link for URL path {target_url}.
 
-Attemped to insert link with keys: {keys}.
+Attempted to insert link with keys: {keys}.
 
 Adjust URLs to avoid naming collision or override `SchemaGenerator.get_keys()`
 to customise schema structure.

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -163,7 +163,8 @@ class ViewInspector(object):
     @property
     def view(self):
         """View property."""
-        assert self._view is not None, "Schema generation REQUIRES a view instance. (Hint: you accessed `schema` from the view class rather than an instance.)"
+        assert self._view is not None, "Schema generation REQUIRES a view instance. (Hint: you accessed `schema` from "\
+                                       "the view class rather than an instance.) "
         return self._view
 
     @view.setter
@@ -498,7 +499,8 @@ class DefaultSchema(ViewInspector):
             return result
 
         inspector_class = api_settings.DEFAULT_SCHEMA_CLASS
-        assert issubclass(inspector_class, ViewInspector), "DEFAULT_SCHEMA_CLASS must be set to a ViewInspector (usually an AutoSchema) subclass"
+        assert issubclass(inspector_class, ViewInspector), \
+            "DEFAULT_SCHEMA_CLASS must be set to a ViewInspector (usually an AutoSchema) subclass"
         inspector = inspector_class()
         inspector.view = instance
         return inspector

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -193,7 +193,7 @@ class AutoSchema(ViewInspector):
     """
     Default inspector for APIView
 
-    Responsible for per-view instrospection and schema generation.
+    Responsible for per-view introspection and schema generation.
     """
     def __init__(self, manual_fields=None):
         """
@@ -468,7 +468,7 @@ class ManualSchema(ViewInspector):
         Parameters:
 
         * `fields`: list of `coreapi.Field` instances.
-        * `descripton`: String description for view. Optional.
+        * `description`: String description for view. Optional.
         """
         super(ManualSchema, self).__init__()
         assert all(isinstance(f, coreapi.Field) for f in fields), "`fields` must be a list of coreapi.Field instances"

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -164,8 +164,8 @@ class ViewInspector(object):
     def view(self):
         """View property."""
         assert self._view is not None, (
-            "Schema generation REQUIRES a view instance. (Hint: you accessed `schema` from "
-            "the view class rather than an instance.) "
+            "Schema generation REQUIRES a view instance. (Hint: you accessed "
+            "`schema` from the view class rather than an instance.)"
         )
         return self._view
 

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -163,8 +163,10 @@ class ViewInspector(object):
     @property
     def view(self):
         """View property."""
-        assert self._view is not None, "Schema generation REQUIRES a view instance. (Hint: you accessed `schema` from "\
-                                       "the view class rather than an instance.) "
+        assert self._view is not None, (
+            "Schema generation REQUIRES a view instance. (Hint: you accessed `schema` from "
+            "the view class rather than an instance.) "
+        )
         return self._view
 
     @view.setter
@@ -499,8 +501,9 @@ class DefaultSchema(ViewInspector):
             return result
 
         inspector_class = api_settings.DEFAULT_SCHEMA_CLASS
-        assert issubclass(inspector_class, ViewInspector), \
+        assert issubclass(inspector_class, ViewInspector), (
             "DEFAULT_SCHEMA_CLASS must be set to a ViewInspector (usually an AutoSchema) subclass"
+        )
         inspector = inspector_class()
         inspector.view = instance
         return inspector


### PR DESCRIPTION
Fix typo and too long line in the documentation about schemas.
