### PR TITLE
Adds a few more blocks to base.html to make it more extendable

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -76,6 +76,7 @@
           {% block content %}
 
           <div class="region"  aria-label="{% trans "request form" %}">
+          {% block request_forms %}
           {% if 'GET' in allowed_methods %}
             <form id="get-form" class="pull-right">
               <fieldset>
@@ -148,9 +149,11 @@
               {% trans "Filters" %}
             </button>
           {% endif %}
+          {% endblock request_forms %}
           </div>
 
             <div class="content-main" role="main"  aria-label="{% trans "main content" %}">
+              {% block main_content %}
               <div class="page-header">
                 <h1>{{ name }}</h1>
               </div>
@@ -176,8 +179,10 @@
 
 </span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
               </div>
+              {% endblock %}
             </div>
 
+            {% block edit_forms %}
             {% if display_edit_forms %}
               {% if post_form or raw_data_post_form %}
                 <div {% if post_form %}class="tabbable"{% endif %}>
@@ -273,6 +278,7 @@
                 </div>
               {% endif %}
             {% endif %}
+            {% endblock edit_forms %}
           {% endblock content %}
         </div><!-- /.content -->
       </div><!-- /.container -->

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -76,135 +76,149 @@
           {% block content %}
 
           <div class="region"  aria-label="{% trans "request form" %}">
-          {% block request_forms %}
-          {% if 'GET' in allowed_methods %}
-            <form id="get-form" class="pull-right">
-              <fieldset>
-                {% if api_settings.URL_FORMAT_OVERRIDE %}
-                  <div class="btn-group format-selection">
-                    <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+            {% block request_forms %}
+              {% if 'GET' in allowed_methods %}
+                <form id="get-form" class="pull-right">
+                  <fieldset>
+                    {% if api_settings.URL_FORMAT_OVERRIDE %}
+                      <div class="btn-group format-selection">
+                        <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
 
-                    <button class="btn btn-primary dropdown-toggle js-tooltip" data-toggle="dropdown" title="Specify a format for the GET request">
-                      <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                      {% for format in available_formats %}
-                        <li>
-                          <a class="js-tooltip format-option" href="{% add_query_param request api_settings.URL_FORMAT_OVERRIDE format %}" rel="nofollow" title="Make a GET request on the {{ name }} resource with the format set to `{{ format }}`">{{ format }}</a>
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  </div>
-                {% else %}
-                  <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
-                {% endif %}
-              </fieldset>
-            </form>
-          {% endif %}
+                        <button class="btn btn-primary dropdown-toggle js-tooltip" data-toggle="dropdown" title="Specify a format for the GET request">
+                          <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                          {% for format in available_formats %}
+                            <li>
+                              <a class="js-tooltip format-option" href="{% add_query_param request api_settings.URL_FORMAT_OVERRIDE format %}" rel="nofollow" title="Make a GET request on the {{ name }} resource with the format set to `{{ format }}`">{{ format }}</a>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    {% else %}
+                      <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+                    {% endif %}
+                  </fieldset>
+                </form>
+              {% endif %}
 
-          {% if options_form %}
-            <form class="button-form" action="{{ request.get_full_path }}" data-method="OPTIONS">
-              <button class="btn btn-primary js-tooltip" title="Make an OPTIONS request on the {{ name }} resource">OPTIONS</button>
-            </form>
-          {% endif %}
+              {% if options_form %}
+                <form class="button-form" action="{{ request.get_full_path }}" data-method="OPTIONS">
+                  <button class="btn btn-primary js-tooltip" title="Make an OPTIONS request on the {{ name }} resource">OPTIONS</button>
+                </form>
+              {% endif %}
 
-          {% if delete_form %}
-            <button class="btn btn-danger button-form js-tooltip" title="Make a DELETE request on the {{ name }} resource" data-toggle="modal" data-target="#deleteModal">DELETE</button>
+              {% if delete_form %}
+                <button class="btn btn-danger button-form js-tooltip" title="Make a DELETE request on the {{ name }} resource" data-toggle="modal" data-target="#deleteModal">DELETE</button>
 
-            <!-- Delete Modal -->
-            <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-              <div class="modal-dialog">
-                <div class="modal-content">
-                  <div class="modal-body">
-                    <h4 class="text-center">Are you sure you want to delete this {{ name }}?</h4>
-                  </div>
-                  <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                    <form class="button-form" action="{{ request.get_full_path }}" data-method="DELETE">
-                      <button class="btn btn-danger">Delete</button>
-                    </form>
+                <!-- Delete Modal -->
+                <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-body">
+                        <h4 class="text-center">Are you sure you want to delete this {{ name }}?</h4>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        <form class="button-form" action="{{ request.get_full_path }}" data-method="DELETE">
+                          <button class="btn btn-danger">Delete</button>
+                        </form>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          {% endif %}
+              {% endif %}
 
-          {% if extra_actions %}
-            <div class="dropdown" style="float: right; margin-right: 10px">
-              <button class="btn btn-default" id="extra-actions-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                {% trans "Extra Actions" %}
-                <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="extra-actions-menu">
-                {% for action_name, url in extra_actions|items %}
-                <li><a href="{{ url }}">{{ action_name }}</a></li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endif %}
+              {% if extra_actions %}
+                <div class="dropdown" style="float: right; margin-right: 10px">
+                  <button class="btn btn-default" id="extra-actions-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                    {% trans "Extra Actions" %}
+                    <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu" aria-labelledby="extra-actions-menu">
+                    {% for action_name, url in extra_actions|items %}
+                    <li><a href="{{ url }}">{{ action_name }}</a></li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              {% endif %}
 
-          {% if filter_form %}
-            <button style="float: right; margin-right: 10px" data-toggle="modal" data-target="#filtersModal" class="btn btn-default">
-              <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>
-              {% trans "Filters" %}
-            </button>
-          {% endif %}
-          {% endblock request_forms %}
+              {% if filter_form %}
+                <button style="float: right; margin-right: 10px" data-toggle="modal" data-target="#filtersModal" class="btn btn-default">
+                  <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>
+                  {% trans "Filters" %}
+                </button>
+              {% endif %}
+            {% endblock request_forms %}
           </div>
 
             <div class="content-main" role="main"  aria-label="{% trans "main content" %}">
               {% block main_content %}
-              <div class="page-header">
-                <h1>{{ name }}</h1>
-              </div>
-              <div style="float:left">
-                {% block description %}
-                  {{ description }}
-                {% endblock %}
-              </div>
+                <div class="page-header">
+                  <h1>{{ name }}</h1>
+                </div>
+                <div style="float:left">
+                  {% block description %}
+                    {{ description }}
+                  {% endblock %}
+                </div>
 
-              {% if paginator %}
-                <nav style="float: right">
-                  {% get_pagination_html paginator %}
-                </nav>
-              {% endif %}
+                {% if paginator %}
+                  <nav style="float: right">
+                    {% get_pagination_html paginator %}
+                  </nav>
+                {% endif %}
 
-              <div class="request-info" style="clear: both" aria-label="{% trans "request info" %}">
-                <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
-              </div>
+                <div class="request-info" style="clear: both" aria-label="{% trans "request info" %}">
+                  <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
+                </div>
 
-              <div class="response-info" aria-label="{% trans "response info" %}">
-                <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
-<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
+                <div class="response-info" aria-label="{% trans "response info" %}">
+                  <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
+  <b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
 
-</span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
-              </div>
+  </span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
+                </div>
               {% endblock %}
             </div>
 
             {% block edit_forms %}
-            {% if display_edit_forms %}
-              {% if post_form or raw_data_post_form %}
-                <div {% if post_form %}class="tabbable"{% endif %}>
-                  {% if post_form %}
-                    <ul class="nav nav-tabs form-switcher">
-                      <li>
-                        <a name='html-tab' href="#post-object-form" data-toggle="tab">HTML form</a>
-                      </li>
-                      <li>
-                        <a name='raw-tab' href="#post-generic-content-form" data-toggle="tab">Raw data</a>
-                      </li>
-                    </ul>
-                  {% endif %}
-
-                  <div class="well tab-content">
+              {% if display_edit_forms %}
+                {% if post_form or raw_data_post_form %}
+                  <div {% if post_form %}class="tabbable"{% endif %}>
                     {% if post_form %}
-                      <div class="tab-pane" id="post-object-form">
-                        {% with form=post_form %}
-                          <form action="{{ request.get_full_path }}" method="POST" enctype="multipart/form-data" class="form-horizontal" novalidate>
+                      <ul class="nav nav-tabs form-switcher">
+                        <li>
+                          <a name='html-tab' href="#post-object-form" data-toggle="tab">HTML form</a>
+                        </li>
+                        <li>
+                          <a name='raw-tab' href="#post-generic-content-form" data-toggle="tab">Raw data</a>
+                        </li>
+                      </ul>
+                    {% endif %}
+
+                    <div class="well tab-content">
+                      {% if post_form %}
+                        <div class="tab-pane" id="post-object-form">
+                          {% with form=post_form %}
+                            <form action="{{ request.get_full_path }}" method="POST" enctype="multipart/form-data" class="form-horizontal" novalidate>
+                              <fieldset>
+                                {% csrf_token %}
+                                {{ post_form }}
+                                <div class="form-actions">
+                                  <button class="btn btn-primary" title="Make a POST request on the {{ name }} resource">POST</button>
+                                </div>
+                              </fieldset>
+                            </form>
+                          {% endwith %}
+                        </div>
+                      {% endif %}
+
+                      <div {% if post_form %}class="tab-pane"{% endif %} id="post-generic-content-form">
+                        {% with form=raw_data_post_form %}
+                          <form action="{{ request.get_full_path }}" method="POST" class="form-horizontal">
                             <fieldset>
-                              {% csrf_token %}
-                              {{ post_form }}
+                              {% include "rest_framework/raw_data_form.html" %}
                               <div class="form-actions">
                                 <button class="btn btn-primary" title="Make a POST request on the {{ name }} resource">POST</button>
                               </div>
@@ -212,72 +226,58 @@
                           </form>
                         {% endwith %}
                       </div>
-                    {% endif %}
-
-                    <div {% if post_form %}class="tab-pane"{% endif %} id="post-generic-content-form">
-                      {% with form=raw_data_post_form %}
-                        <form action="{{ request.get_full_path }}" method="POST" class="form-horizontal">
-                          <fieldset>
-                            {% include "rest_framework/raw_data_form.html" %}
-                            <div class="form-actions">
-                              <button class="btn btn-primary" title="Make a POST request on the {{ name }} resource">POST</button>
-                            </div>
-                          </fieldset>
-                        </form>
-                      {% endwith %}
                     </div>
                   </div>
-                </div>
-              {% endif %}
+                {% endif %}
 
-              {% if put_form or raw_data_put_form or raw_data_patch_form %}
-                <div {% if put_form %}class="tabbable"{% endif %}>
-                  {% if put_form %}
-                    <ul class="nav nav-tabs form-switcher">
-                      <li>
-                        <a name='html-tab' href="#put-object-form" data-toggle="tab">HTML form</a>
-                      </li>
-                      <li>
-                        <a  name='raw-tab' href="#put-generic-content-form" data-toggle="tab">Raw data</a>
-                      </li>
-                    </ul>
-                  {% endif %}
-
-                  <div class="well tab-content">
+                {% if put_form or raw_data_put_form or raw_data_patch_form %}
+                  <div {% if put_form %}class="tabbable"{% endif %}>
                     {% if put_form %}
-                      <div class="tab-pane" id="put-object-form">
-                        <form action="{{ request.get_full_path }}" data-method="PUT" enctype="multipart/form-data" class="form-horizontal" novalidate>
-                          <fieldset>
-                            {{ put_form }}
-                            <div class="form-actions">
-                              <button class="btn btn-primary js-tooltip" title="Make a PUT request on the {{ name }} resource">PUT</button>
-                            </div>
-                          </fieldset>
-                        </form>
-                      </div>
+                      <ul class="nav nav-tabs form-switcher">
+                        <li>
+                          <a name='html-tab' href="#put-object-form" data-toggle="tab">HTML form</a>
+                        </li>
+                        <li>
+                          <a  name='raw-tab' href="#put-generic-content-form" data-toggle="tab">Raw data</a>
+                        </li>
+                      </ul>
                     {% endif %}
 
-                    <div {% if put_form %}class="tab-pane"{% endif %} id="put-generic-content-form">
-                      {% with form=raw_data_put_or_patch_form %}
-                        <form action="{{ request.get_full_path }}" data-method="PUT" class="form-horizontal">
-                          <fieldset>
-                            {% include "rest_framework/raw_data_form.html" %}
-                            <div class="form-actions">
-                              {% if raw_data_put_form %}
+                    <div class="well tab-content">
+                      {% if put_form %}
+                        <div class="tab-pane" id="put-object-form">
+                          <form action="{{ request.get_full_path }}" data-method="PUT" enctype="multipart/form-data" class="form-horizontal" novalidate>
+                            <fieldset>
+                              {{ put_form }}
+                              <div class="form-actions">
                                 <button class="btn btn-primary js-tooltip" title="Make a PUT request on the {{ name }} resource">PUT</button>
-                              {% endif %}
-                              {% if raw_data_patch_form %}
-                              <button data-method="PATCH" class="btn btn-primary js-tooltip" title="Make a PATCH request on the {{ name }} resource">PATCH</button>
+                              </div>
+                            </fieldset>
+                          </form>
+                        </div>
+                      {% endif %}
+
+                      <div {% if put_form %}class="tab-pane"{% endif %} id="put-generic-content-form">
+                        {% with form=raw_data_put_or_patch_form %}
+                          <form action="{{ request.get_full_path }}" data-method="PUT" class="form-horizontal">
+                            <fieldset>
+                              {% include "rest_framework/raw_data_form.html" %}
+                              <div class="form-actions">
+                                {% if raw_data_put_form %}
+                                  <button class="btn btn-primary js-tooltip" title="Make a PUT request on the {{ name }} resource">PUT</button>
                                 {% endif %}
-                            </div>
-                          </fieldset>
-                        </form>
-                      {% endwith %}
+                                {% if raw_data_patch_form %}
+                                <button data-method="PATCH" class="btn btn-primary js-tooltip" title="Make a PATCH request on the {{ name }} resource">PATCH</button>
+                                  {% endif %}
+                              </div>
+                            </fieldset>
+                          </form>
+                        {% endwith %}
+                      </div>
                     </div>
                   </div>
-                </div>
+                {% endif %}
               {% endif %}
-            {% endif %}
             {% endblock edit_forms %}
           {% endblock content %}
         </div><!-- /.content -->


### PR DESCRIPTION
## Description 

I currently have a need to output an additional form at the top of the page in the browsable API view. I'm happy creating a Renderer class with custom template to achieve this (extending `api.html`). But currently, my only option is to copy the entire `content` block from `base.html` in order to add something small. This is less than ideal.

Breaking the `content` block up into a few smaller blocks makes it easier to override just the relevant part of the template, with very few downsides.

With these changes in place, adding a custom request form to the template becomes as simple as:

```
{% block request_forms %}
    {{ block.super }}
    <div class="my-custom-form"></div>
{% endblock %}
```

Any/all feedback welcome :)
