### PR TITLE
Add a 'request_forms' block to base.html

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -76,6 +76,8 @@
           {% block content %}
 
           <div class="region"  aria-label="{% trans "request form" %}">
+          {% block request_forms %}
+          
           {% if 'GET' in allowed_methods %}
             <form id="get-form" class="pull-right">
               <fieldset>
@@ -148,6 +150,8 @@
               {% trans "Filters" %}
             </button>
           {% endif %}
+
+          {% endblock request_forms %}
           </div>
 
             <div class="content-main" role="main"  aria-label="{% trans "main content" %}">


### PR DESCRIPTION
Supersedes: #6337

Resolves: #6339

On advice from @tomchristie, I've deliberately left indentation as it is.

I've also simplified things by only adding a single block instead of three. While not quite as helpful for users wanting to override other bits within the `content` block, it's a smaller change with less of a maintenance commitment.