### PR TITLE
remove urlpatterns = format_suffix_patterns(urlpatterns)

### DIFF
--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -121,7 +121,7 @@ Here's our re-wired `snippets/urls.py` file.
 
 Registering the viewsets with the router is similar to providing a urlpattern.  We include two arguments - the URL prefix for the views, and the viewset itself.
 
-The `DefaultRouter` class we're using also automatically creates the API root view for us, so we can now delete the `api_root` method from our `views` module.
+The `DefaultRouter` class we're using also automatically creates the API root view for us, so we can now delete the `api_root` method and `format_suffix_patterns`  from our `views` module.
 
 ## Trade-offs between views vs viewsets
 


### PR DESCRIPTION
if i use If I use DefaultRouter, the original urlpatterns = format_suffix_patterns(urlpatterns) need to be removed, otherwise the error message will be as follows:
django.core.exceptions.ImproperlyConfigured: "^snippets\.(?P<format>[a-z0-9]+)/?\.(?P<format>[a-z0-9]+)/?$ " is not a valid regular expression: redefinition of group name 'format' as group 2; was group 1 at position 40
Performing system checks...

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
