### PR TITLE
Remove unmaintained digest authentication package

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -391,10 +391,6 @@ Install the package using `pip`.
 
 For details on configuration and usage see the Django REST framework OAuth documentation for [authentication][django-rest-framework-oauth-authentication] and [permissions][django-rest-framework-oauth-permissions].
 
-## Digest Authentication
-
-HTTP digest authentication is a widely implemented scheme that was intended to replace HTTP basic authentication, and which provides a simple encrypted authentication mechanism. [Juan Riaza][juanriaza] maintains the [djangorestframework-digestauth][djangorestframework-digestauth] package which provides HTTP digest authentication support for REST framework.
-
 ## JSON Web Token Authentication
 
 JSON Web Token is a fairly new standard which can be used for token-based authentication. Unlike the built-in TokenAuthentication scheme, JWT Authentication doesn't need to use a database to validate a token. A package for JWT authentication is [djangorestframework-simplejwt][djangorestframework-simplejwt] which provides some features as well as a pluggable token blacklist app.


### PR DESCRIPTION
https://github.com/juanriaza/django-rest-framework-digestauth has not been updated in 5 years and is currently incompatible with the latest DRF ecosystem.