### PR TITLE
WIP:Need to pass root request object to authenticate, not DRF's Request c…

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import HTTP_HEADER_ENCODING, exceptions
 from rest_framework.request import Request as DRFRequest
 
+
 def get_authorization_header(request):
     """
     Return request's 'Authorization:' header, as a bytestring.

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -12,7 +12,7 @@ from django.utils.six import text_type
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import HTTP_HEADER_ENCODING, exceptions
-
+from rest_framework.request import Request as DRFRequest
 
 def get_authorization_header(request):
     """
@@ -94,6 +94,8 @@ class BasicAuthentication(BaseAuthentication):
             get_user_model().USERNAME_FIELD: userid,
             'password': password
         }
+        if request and isinstance(request, DRFRequest):
+            request = request._request
         user = authenticate(request=request, **credentials)
 
         if user is None:


### PR DESCRIPTION
## Description

When passing DRF's `Request` to `authenticate()` in `BasicAuthentication` if an authentication middleware calls `request.user` as the user is not yet authenticated DRF's `Request` will call `authenticate()` and will cause a recursive loop. 

Instead of passing DRF's `Request` we need to pass the request obj it wraps.

Testing this would require a mock middleware of some sort which I am not sure how to test.
