### PR TITLE
Add example of gender-neutral language in contributing guide. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ When answering questions make sure to help future contributors find their way ar
 
 Please keep the tone polite & professional.  For some users a discussion on the REST framework mailing list or ticket tracker may be their first engagement with the open source community.  First impressions count, so let's try to make everyone feel welcome.
 
-Be mindful in the language you choose.  As an example, in an environment that is heavily male-dominated, posts that start 'Hey guys,' can come across as unintentionally exclusive.  It's just as easy, and more inclusive to use gender neutral language in those situations.
+Be mindful in the language you choose.  As an example, in an environment that is heavily male-dominated, posts that start 'Hey guys,' can come across as unintentionally exclusive.  It's just as easy, and more inclusive to use gender neutral language in those situations. (e.g. 'Hey folks,')
 
 The [Django code of conduct][code-of-conduct] gives a fuller set of guidelines for participating in community forums.
 


### PR DESCRIPTION
- [x] *Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Tiny suggestion to include an example of an acceptable alternative to 'Hey guys,'.

My thinking is this'll make it just a bit easier for people to use inclusive language. 'folks' is just my personal go-to.  Can't hurt anyways, right?