### PR TITLE
Permissions: Add ~ operator to permissions composition

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -121,7 +121,7 @@ Provided they inherit from `rest_framework.permissions.BasePermission`, permissi
             }
             return Response(content)
 
-__Note:__ it only supports & -and- and | -or-.
+__Note:__ it supports & (and), | (or) and ~ (not).
 
 ---
 

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -24,6 +24,19 @@ class OperationHolderMixin:
     def __ror__(self, other):
         return OperandHolder(OR, other, self)
 
+    def __invert__(self):
+        return SingleOperandHolder(NOT, self)
+
+
+class SingleOperandHolder(OperationHolderMixin):
+    def __init__(self, operator_class, op1_class):
+        self.operator_class = operator_class
+        self.op1_class = op1_class
+
+    def __call__(self, *args, **kwargs):
+        op1 = self.op1_class(*args, **kwargs)
+        return self.operator_class(op1)
+
 
 class OperandHolder(OperationHolderMixin):
     def __init__(self, operator_class, op1_class, op2_class):
@@ -71,6 +84,17 @@ class OR:
             self.op1.has_object_permission(request, view, obj) |
             self.op2.has_object_permission(request, view, obj)
         )
+
+
+class NOT:
+    def __init__(self, op1):
+        self.op1 = op1
+
+    def has_permission(self, request, view):
+        return not self.op1.has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        return not self.op1.has_object_permission(request, view, obj)
 
 
 class BasePermissionMetaclass(OperationHolderMixin, type):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -579,7 +579,19 @@ class PermissionsCompositionTests(TestCase):
         composed_perm = permissions.IsAuthenticated | permissions.AllowAny
         assert composed_perm().has_permission(request, None) is True
 
-    def test_several_levels(self):
+    def test_not_false(self):
+        request = factory.get('/1', format='json')
+        request.user = AnonymousUser()
+        composed_perm = ~permissions.IsAuthenticated
+        assert composed_perm().has_permission(request, None) is True
+
+    def test_not_true(self):
+        request = factory.get('/1', format='json')
+        request.user = self.user
+        composed_perm = ~permissions.AllowAny
+        assert composed_perm().has_permission(request, None) is False
+
+    def test_several_levels_without_negation(self):
         request = factory.get('/1', format='json')
         request.user = self.user
         composed_perm = (
@@ -587,6 +599,17 @@ class PermissionsCompositionTests(TestCase):
             permissions.IsAuthenticated &
             permissions.IsAuthenticated &
             permissions.IsAuthenticated
+        )
+        assert composed_perm().has_permission(request, None) is True
+
+    def test_several_levels_and_precedence_with_negation(self):
+        request = factory.get('/1', format='json')
+        request.user = self.user
+        composed_perm = (
+            permissions.IsAuthenticated &
+            ~ permissions.IsAdminUser &
+            permissions.IsAuthenticated &
+            ~(permissions.IsAdminUser & permissions.IsAdminUser)
         )
         assert composed_perm().has_permission(request, None) is True
 


### PR DESCRIPTION
This PR add support for `~` "NOT" operator.
Recent updates from @xordoquy add support for `&` "AND" and `|` "OR" operator with permissions. I felt `~` "NOT" was missing.

We could now do something like `permission_classes = (~cond1 & cond2)`.

I updated only a very tiny bit of the documentation.

If we keep going further with this approach, I don't know if the mentions of "Composed Permissions" and "Rest Condition" will stay relevant. More documentation on how to compose permissions could be a good thing, it is a bit discrete right now.