### PR TITLE
Allow run_validators() to handle non-dict types.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -461,8 +461,11 @@ class Serializer(BaseSerializer):
         """
         Add read_only fields with defaults to value before running validators.
         """
-        to_validate = self._read_only_defaults()
-        to_validate.update(value)
+        if isinstance(value, dict):
+            to_validate = self._read_only_defaults()
+            to_validate.update(value)
+        else:
+            to_validate = value
         super(Serializer, self).run_validators(to_validate)
 
     def to_internal_value(self, data):


### PR DESCRIPTION
Fixes #6053.

`to_internal_value()` is expected to return a dict. #5922 relied on this, but users are implementing custom serialisers that return application objects[*]. This PR bypasses the _read-only defaults_ handling for non-dict objects. 

[*]: This is why static typing will never work for Python 😀

Original test case thanks to @vdel in #6242.