### PR TITLE
Fix #6341 - BaseUniqueForValidator uses instance

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -215,6 +215,17 @@ class BaseUniqueForValidator(object):
         if missing_items:
             raise ValidationError(missing_items, code='required')
 
+    def _get_field_values(self, attrs):
+        """Returns tuple (value, date_value) from attrs or instance"""
+        value = attrs.get(self.field)
+        date_value = attrs.get(self.date_field)
+        if hasattr(self, "instance") and self.instance is not None:
+            if value is None:
+                value = getattr(self.instance, self.field)
+            if date_value is None:
+                date_value = getattr(self.instance, self.date_field)
+        return (value, date_value)
+
     def filter_queryset(self, attrs, queryset):
         raise NotImplementedError('`filter_queryset` must be implemented.')
 
@@ -251,8 +262,7 @@ class UniqueForDateValidator(BaseUniqueForValidator):
     message = _('This field must be unique for the "{date_field}" date.')
 
     def filter_queryset(self, attrs, queryset):
-        value = attrs[self.field]
-        date = attrs[self.date_field]
+        value, date = self._get_field_values(attrs)
 
         filter_kwargs = {}
         filter_kwargs[self.field_name] = value
@@ -266,8 +276,7 @@ class UniqueForMonthValidator(BaseUniqueForValidator):
     message = _('This field must be unique for the "{date_field}" month.')
 
     def filter_queryset(self, attrs, queryset):
-        value = attrs[self.field]
-        date = attrs[self.date_field]
+        value, date = self._get_field_values(attrs)
 
         filter_kwargs = {}
         filter_kwargs[self.field_name] = value
@@ -279,8 +288,7 @@ class UniqueForYearValidator(BaseUniqueForValidator):
     message = _('This field must be unique for the "{date_field}" year.')
 
     def filter_queryset(self, attrs, queryset):
-        value = attrs[self.field]
-        date = attrs[self.date_field]
+        value, date = self._get_field_values(attrs)
 
         filter_kwargs = {}
         filter_kwargs[self.field_name] = value

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -204,6 +204,9 @@ class BaseUniqueForValidator(object):
         The `UniqueFor<Range>Validator` classes always force an implied
         'required' state on the fields they are applied to.
         """
+        if hasattr(self, "instance") and self.instance is not None:
+            return
+
         missing_items = {
             field_name: self.missing_message
             for field_name in [self.field, self.date_field]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -381,11 +381,13 @@ class UniqueForDateSerializer(serializers.ModelSerializer):
 
 
 class TestUniquenessForDateValidation(TestCase):
+
     def setUp(self):
         self.instance = UniqueForDateModel.objects.create(
             slug='existing',
             published='2000-01-01'
         )
+        self.instance.refresh_from_db()  # published becomes datetime
 
     def test_repr(self):
         serializer = UniqueForDateSerializer()
@@ -422,6 +424,12 @@ class TestUniquenessForDateValidation(TestCase):
             'published': datetime.date(2000, 1, 2)
         }
 
+    def test_unique_for_date_for_partial(self):
+        serializer = UniqueForDateSerializer(
+            instance=self.instance, data={}, partial=True
+        )
+        assert serializer.is_valid(), serializer.errors
+
     def test_updated_instance_excluded_from_unique_for_date(self):
         """
         When performing an update, the existing instance does not count
@@ -456,6 +464,7 @@ class UniqueForMonthTests(TestCase):
         self.instance = UniqueForMonthModel.objects.create(
             slug='existing', published='2017-01-01'
         )
+        self.instance.refresh_from_db()  # published becomes datetime
 
     def test_not_unique_for_month(self):
         data = {'slug': 'existing', 'published': '2017-01-01'}
@@ -473,6 +482,12 @@ class UniqueForMonthTests(TestCase):
             'slug': 'existing',
             'published': datetime.date(2017, 2, 1)
         }
+
+    def test_unique_for_month_for_partial(self):
+        serializer = UniqueForMonthSerializer(
+            instance=self.instance, data={}, partial=True
+        )
+        assert serializer.is_valid(), serializer.errors
 
 # Tests for `UniqueForYearValidator`
 # ----------------------------------
@@ -495,6 +510,7 @@ class UniqueForYearTests(TestCase):
         self.instance = UniqueForYearModel.objects.create(
             slug='existing', published='2017-01-01'
         )
+        self.instance.refresh_from_db()  # published becomes datetime
 
     def test_not_unique_for_year(self):
         data = {'slug': 'existing', 'published': '2017-01-01'}
@@ -512,6 +528,12 @@ class UniqueForYearTests(TestCase):
             'slug': 'existing',
             'published': datetime.date(2018, 1, 1)
         }
+
+    def test_unique_for_year_for_partial(self):
+        serializer = UniqueForYearSerializer(
+            instance=self.instance, data={}, partial=True
+        )
+        assert serializer.is_valid(), serializer.errors
 
 
 class HiddenFieldUniqueForDateModel(models.Model):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -582,6 +582,13 @@ class ValidatorsTests(TestCase):
         with pytest.raises(ValidationError):
             validator.enforce_required_fields(attrs)
 
+    def test_validator_passes_with_instance(self):
+        validator = BaseUniqueForValidator(queryset=object(), field='foo',
+                                           date_field='bar')
+        validator.instance = object()
+
+        assert validator.enforce_required_fields({}) is None
+
     def test_validator_raises_error_when_abstract_method_called(self):
         validator = BaseUniqueForValidator(queryset=object(), field='foo',
                                            date_field='bar')


### PR DESCRIPTION
Ensures that the UniqueFor[Date,Month,Year]Validator classes do not raise errors when a serializer is partially updated without the fields with the uniqueness constraint.

To try and help make review of this PR as easy as possible, I will first push a regression test that is meant to fail, and then push the fix (as outlined in issue #6341).