### PR TITLE
Fix example to be Python 3.x and 2.7 compatible

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -22,7 +22,7 @@ To do so, open the Django shell, using `python manage.py shell`, then import the
 
     >>> from myapp.serializers import AccountSerializer
     >>> serializer = AccountSerializer()
-    >>> print repr(serializer)  # Or `print(repr(serializer))` in Python 3.x.
+    >>> print(repr(serializer))
     AccountSerializer():
         id = IntegerField(label='ID', read_only=True)
         name = CharField(allow_blank=True, max_length=100, required=False)


### PR DESCRIPTION
## Description

In response to this comment: https://github.com/encode/django-rest-framework/issues/6230#issuecomment-449595754

This is compatible with both Python 3.x and 2.7.

```py
print(repr(serializer))
```