### PR TITLE
Make code snippets Python 3 compatible

### DIFF
--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -197,7 +197,7 @@ If we're interacting with the API programmatically we need to explicitly provide
 
 If we try to create a snippet without authenticating, we'll get an error:
 
-    http POST http://127.0.0.1:8000/snippets/ code="print 123"
+    http POST http://127.0.0.1:8000/snippets/ code="print(123)"
 
     {
         "detail": "Authentication credentials were not provided."
@@ -205,13 +205,13 @@ If we try to create a snippet without authenticating, we'll get an error:
 
 We can make a successful request by including the username and password of one of the users we created earlier.
 
-    http -a admin:password123 POST http://127.0.0.1:8000/snippets/ code="print 789"
+    http -a admin:password123 POST http://127.0.0.1:8000/snippets/ code="print(789)"
 
     {
         "id": 1,
         "owner": "admin",
         "title": "foo",
-        "code": "print 789",
+        "code": "print(789)",
         "linenos": false,
         "language": "python",
         "style": "friendly"


### PR DESCRIPTION
Previous code snippet used in example were only compatible with Python 2. This makes them compatible with 2.7 and 3.x.