### PR TITLE
Update quickstart to Django 2.0 routing syntax

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -122,8 +122,8 @@ Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
     # Wire up our API using automatic URL routing.
     # Additionally, we include login URLs for the browsable API.
     urlpatterns = [
-        url(r'^', include(router.urls)),
-        url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+        path(r'', include(router.urls)),
+        path(r'api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
 Because we're using viewsets instead of views, we can automatically generate the URL conf for our API, by simply registering the viewsets with a router class.

--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -111,7 +111,7 @@ We can easily break these down into individual views if we need to, but using vi
 
 Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
 
-    from django.conf.urls import url, include
+    from django.conf.urls import include, path
     from rest_framework import routers
     from tutorial.quickstart import views
 

--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -111,7 +111,7 @@ We can easily break these down into individual views if we need to, but using vi
 
 Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
 
-    from django.conf.urls import include, path
+    from django.urls import include, path
     from rest_framework import routers
     from tutorial.quickstart import views
 

--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -122,8 +122,8 @@ Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
     # Wire up our API using automatic URL routing.
     # Additionally, we include login URLs for the browsable API.
     urlpatterns = [
-        path(r'', include(router.urls)),
-        path(r'api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+        path('', include(router.urls)),
+        path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
 Because we're using viewsets instead of views, we can automatically generate the URL conf for our API, by simply registering the viewsets with a router class.


### PR DESCRIPTION
As a new user to DRF, I was confused when I did the Django tutorial (which uses `path`) and then tried out the DRF quickstart and saw that it still used the older ([probably soon to be deprecated](https://docs.djangoproject.com/en/dev/ref/urls/#url)) `url` routing. I think this will help alleviate some confusion for new users.

I believe this was overlooked in #5964.

Related to #5963.

cc @chrisshyi