### PR TITLE
Use the update_fields argument when saving the instance.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -974,13 +974,15 @@ class ModelSerializer(Serializer):
         # Note that unlike `.create()` we don't need to treat many-to-many
         # relationships as being a special case. During updates we already
         # have an instance pk for the relationships to be associated with.
+        update_fields = []
         for attr, value in validated_data.items():
             if attr in info.relations and info.relations[attr].to_many:
                 field = getattr(instance, attr)
                 field.set(value)
             else:
                 setattr(instance, attr, value)
-        instance.save()
+                update_fields.append(attr)
+        instance.save(update_fields=update_fields)
 
         return instance
 


### PR DESCRIPTION
## Description

An update triggered from the `ModelSerializer` currently uses .save() method of the instance without the [update_fields](https://docs.djangoproject.com/en/dev/ref/models/instances/#specifying-which-fields-to-save) argument of the method. This in turn triggers an update of all the fields of the instance in the db backend. 

-----

This pull request adds the update_fields argument, which in turn would make:

 a. The save slightly more efficient. E.g. in cases where the serializer is only configured for a sub-set of all the model's fields, or for cases where the API users only specifies a sub-set of the available fields for update.
 b. Prevents some race conditions. In certain scenarios, doing multiple calls close together but with different fields to update, will result in an unpredictable result.

----

Example race condition:

 - Instance has `{"fieldA": 0, "fieldB": 0}`
 - Update call triggered with the following data `{"fieldA": 1}`
 - Update call triggered with the following data `{"fieldB": 1}`

The result will be one of the following:

 1. `{"fieldA": 1, "fieldB": 1}`
 1. `{"fieldA": 0, "fieldB": 1}`
 1. `{"fieldA": 1, "fieldB": 0}`

With the change in this PR, the result would always be (1) `{"fieldA": 1, "fieldB": 1}`

