### PR TITLE
Add tests for unique validation for bulk creation in model serializers

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -118,6 +118,26 @@ class TestUniquenessValidation(TestCase):
         serializer = UniquenessIntegerSerializer(data={'integer': 'abc'})
         assert serializer.is_valid()
 
+    def test_validate_uniqueness_in_bulk_creation(self):
+        data = [{'username': 'existing'}, {'username': 'non-existing'}]
+        serializer = UniquenessSerializer(data=data, many=True)
+        assert not serializer.is_valid()
+        assert serializer.errors == [
+            {'username': ['uniqueness model with this username already exists.']},
+            {},
+        ]
+
+    def test_validate_uniqueness_between_data_items_in_bulk_creation(self):
+        data = [{'username': 'non-existing'}, {'username': 'non-existing'}]
+        serializer = UniquenessSerializer(data=data, many=True)
+        assert serializer.is_valid()
+        assert serializer.save()
+        # assert not serializer.is_valid()
+        # assert serializer.errors == [
+        #     {'username': ['uniqueness model with this username already exists.']},
+        #     {'username': ['uniqueness model with this username already exists.']},
+        # ]
+
 
 # Tests for `UniqueTogetherValidator`
 # -----------------------------------

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -136,7 +136,7 @@ class TestUniquenessValidation(TestCase):
         # assert serializer.errors == [
         #     {'username': ['uniqueness model with this username already exists.']},
         #     {'username': ['uniqueness model with this username already exists.']},
-        # ]
+        # ] # 
 
 
 # Tests for `UniqueTogetherValidator`


### PR DESCRIPTION
## Description
The unique validation in model serializers only checks for existing entries on the database. If the serializer is instanced with `many=True` and receives more than one item in the data argument having the same value for a unique field, the `.is_valid()` method returns `True`, but calling `.save()` will raise an `IntegrityError`.

Related to issue #6395 
