### PR TITLE
routers: add check on register

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -86,6 +86,8 @@ class BaseRouter(six.with_metaclass(RenameRouterMethods)):
         self.registry = []
 
     def register(self, prefix, viewset, basename=None, base_name=None):
+        assert not hasattr(self, '_urls'), (
+            "You should register all your urls before accessing self.urls.")
         if base_name is not None:
             msg = "The `base_name` argument is pending deprecation in favor of `basename`."
             warnings.warn(msg, PendingDeprecationWarning, 2)


### PR DESCRIPTION
## Description
Trying to register new routes on a router after having accessed the
router `urls` attribute leads to surprising results.
The route is added without error to the router's `registry` but the urls
are not updated, because they are cached in `_urls`.
This commit prevents registering new routes after `_urls` is created.

Another option to solve the issue would be to invalidate the `_urls` cache when a new route is registered.

see https://github.com/encode/django-rest-framework/issues/5660