### PR TITLE
Remove sudo from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 cache: pip
 dist: xenial
-
-sudo: false
-
 matrix:
     fast_finish: true
     include:


### PR DESCRIPTION

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

`sudo:` has been deprecated since Travis CI has migrated to the new VM-based infrastructure: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
