### PR TITLE
Improve documentation regarding serializer class on extra actions.

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -129,6 +129,11 @@ You may inspect these attributes to adjust behaviour based on the current action
 
 If you have ad-hoc methods that should be routable, you can mark them as such with the `@action` decorator. Like regular actions, extra actions may be intended for either a single object, or an entire collection. To indicate this, set the `detail` argument to `True` or `False`. The router will configure its URL patterns accordingly. e.g., the `DefaultRouter` will configure detail actions to contain `pk` in their URL patterns.
 
+Your custom action may use a different [Serializer class](serializers.md). To make sure that the generated docs display a form which matches your serializer, you have two options:
+
+* Either: provide a `serializer_class=MySerializer` argument to the `@action()` decorator (see example below)
+* Or: override the `get_serializer_class()` method as described in [GenericAPIView](generic-views.md#genericapiview)
+
 A more complete example of extra actions:
 
     from django.contrib.auth.models import User
@@ -144,7 +149,7 @@ A more complete example of extra actions:
         queryset = User.objects.all()
         serializer_class = UserSerializer
 
-        @action(detail=True, methods=['post'])
+        @action(detail=True, methods=['post'], serializer_class=PasswordSerializer)
         def set_password(self, request, pk=None):
             user = self.get_object()
             serializer = PasswordSerializer(data=request.data)

--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -129,11 +129,6 @@ You may inspect these attributes to adjust behaviour based on the current action
 
 If you have ad-hoc methods that should be routable, you can mark them as such with the `@action` decorator. Like regular actions, extra actions may be intended for either a single object, or an entire collection. To indicate this, set the `detail` argument to `True` or `False`. The router will configure its URL patterns accordingly. e.g., the `DefaultRouter` will configure detail actions to contain `pk` in their URL patterns.
 
-Your custom action may use a different [Serializer class](serializers.md). To make sure that the generated docs display a form which matches your serializer, you have two options:
-
-* Either: provide a `serializer_class=MySerializer` argument to the `@action()` decorator (see example below)
-* Or: override the `get_serializer_class()` method as described in [GenericAPIView](generic-views.md#genericapiview)
-
 A more complete example of extra actions:
 
     from django.contrib.auth.models import User

--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -168,9 +168,9 @@ A more complete example of extra actions:
             serializer = self.get_serializer(recent_users, many=True)
             return Response(serializer.data)
 
-The decorator can additionally take extra arguments that will be set for the routed view only. Any class property of the `ViewSet` is therefore a valid argument for `@action()` (e.g. `serializer_class`, `queryset`, `permission_classes`). For example:
+The decorator can additionally take extra arguments that will be set for the routed view only. Any class property of the `ViewSet` is therefore a valid argument for `@action()` (e.g. `serializer_class`, `queryset`, `permission_classes`). For example, an action which sets a password needs different permissions and a different form to be displayed compared to the regular `UserViewSet`:
 
-        @action(detail=True, methods=['post'], permission_classes=[IsAdminOrIsSelf])
+        @action(detail=True, methods=['post'], permission_classes=[IsAdminOrIsSelf], serializer_class=PasswordSerializer)
         def set_password(self, request, pk=None):
            ...
 

--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -168,7 +168,7 @@ A more complete example of extra actions:
             serializer = self.get_serializer(recent_users, many=True)
             return Response(serializer.data)
 
-The decorator can additionally take extra arguments that will be set for the routed view only.  For example:
+The decorator can additionally take extra arguments that will be set for the routed view only. Any class property of the `ViewSet` is therefore a valid argument for `@action()` (e.g. `serializer_class`, `queryset`, `permission_classes`). For example:
 
         @action(detail=True, methods=['post'], permission_classes=[IsAdminOrIsSelf])
         def set_password(self, request, pk=None):


### PR DESCRIPTION
The documentation does currently not describe how to use a custom `serializer_class` with extra actions. The example uses a custom serializer without using the seralizer_class attribute, resulting in the generated documentation page presenting the wrong form.

The author of the feature described the usage of the `serializer_class` kwarg in his PR https://github.com/encode/django-rest-framework/pull/5605#issuecomment-345420265