### PR TITLE
Update highlight markdown preprocessor to use register instead of add

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -42,7 +42,8 @@ You can determine your currently installed version using `pip show`:
 
 ### 3.9.2 - IN DEVELOPMENT
 
-...
+* Resolve DeprecationWarning with markdown. [#6317][gh6317]
+* Upgrade markdown to 3.0.1 to avoid deprecation issue.
 
 ### 3.9.1
 

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,6 +1,6 @@
 # Optional packages which may be used with REST framework.
 psycopg2-binary==2.7.5
-markdown==2.6.11
+markdown==3.0.1
 django-guardian==1.5.0
 django-filter==1.1.0
 coreapi==2.3.1

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -258,7 +258,7 @@ if markdown is not None and pygments is not None:
             return ret.split("\n")
 
     def md_filter_add_syntax_highlight(md):
-        md.preprocessors.add('highlight', CodeBlockPreprocessor(), "_begin")
+        md.preprocessors.register(CodeBlockPreprocessor(), 'highlight', 40)
         return True
 else:
     def md_filter_add_syntax_highlight(md):


### PR DESCRIPTION
## Description

refs #6317.

The issue mentioned that `preprocessors` from markdown now use `register` instead of `add`.

I followed the reference in the issue to see how `preprocessors.register(` is called, and updated the call accordingly. The only thing I'm unsure about is the priority, because `add()` had a call to place at the beginning, while `register()` relies on sorting. Since none go above 30, I believed 40 to be a safe bet.

I've ran tests (came back the same) and searched through docs, and I haven't seen this particular function mentioned, so, I'm unsure how to properly make sure this works.