### PR TITLE
Deferred schema renderer creation to avoid requiring pyyaml.

### DIFF
--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -32,8 +32,10 @@ class Command(BaseCommand):
         self.stdout.write(output.decode('utf-8'))
 
     def get_renderer(self, format):
-        return {
-            'corejson': CoreJSONRenderer(),
-            'openapi': OpenAPIRenderer(),
-            'openapi-json': JSONOpenAPIRenderer()
+        renderer_cls = {
+            'corejson': CoreJSONRenderer,
+            'openapi': OpenAPIRenderer,
+            'openapi-json': JSONOpenAPIRenderer,
         }[format]
+
+        return renderer_cls()


### PR DESCRIPTION
Closes #6366.

Generate schema command is currently untested. Even so, not sure _how_ we catch this... 