### PR TITLE
Handle Django's ValidationErrors in ListField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1639,6 +1639,8 @@ class ListField(Field):
                 result.append(self.child.run_validation(item))
             except ValidationError as e:
                 errors[idx] = e.detail
+            except DjangoValidationError as e:
+                errors[idx] = get_error_detail(e)
 
         if not errors:
             return result


### PR DESCRIPTION
Without this, Django's ValidationErrors will bypass the error collection
from ListField's children.

Here is an example that illustrates this change.

Consider a Serializer that uses ListField like this:

```python
class SomeSerializer(serializers.Serializer):
    uuids = serializers.ListField(
	child=serializers.PrimaryKeyRelatedField(
	    queryset=Model.objects.something(),
	    validators=[SomeCustomValidator()]
	)
    )
```

Validating data that looks like this works fine:

```python
{uuids: ['some-valid-uuid', 'some-valid-uuid']}
```

Raising a DRF ValidationError for one of the children works fine, giving
an error object like:

```python
{'uuids': {0: ErrorDetail(string='Some validation error')}}
```

Raising a Django ValidationError for one of the children works
differently (which serializers.PrimaryKeyRelatedField can do in some
cases, like when the uuid is malformed). It gives an error object like:

```python
{'uuids': ["'X' is not a valid UUID."]}
```

Handling Django's ValidationErrors in ListField explicitly (like in this
pull request), will maintain a regular error interface in this case:

```python
{'uuids': {0: ErrorDetail(string="'X' is not a valid UUID.")}}
```