### PR TITLE
Drop testing Python 3.5 against Django master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
       - { python: "3.5", env: DJANGO=2.0 }
       - { python: "3.5", env: DJANGO=2.1 }
       - { python: "3.5", env: DJANGO=2.2 }
-      - { python: "3.5", env: DJANGO=master }
 
       - { python: "3.6", env: DJANGO=1.11 }
       - { python: "3.6", env: DJANGO=2.0 }

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
        {py34,py35,py36,py37}-django20,
        {py35,py36,py37}-django21
        {py35,py36,py37}-django22
-       {py35,py36,py37}-djangomaster,
+       {py36,py37}-djangomaster,
        base,dist,lint,docs,
 
 [travis:env]


### PR DESCRIPTION
Not supported in Django 3.0.
