### PR TITLE
Use raw user IDs in authtoken admin

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -6,6 +6,7 @@ from rest_framework.authtoken.models import Token
 class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
+    raw_id_fields = ('user',)
     ordering = ('-created',)
 
 


### PR DESCRIPTION
Display raw user IDs in the `authtoken` admin view to prevent timing out when trying to load from a database with potentially thousands of users.

See: https://github.com/encode/django-rest-framework/issues/4494