### PR TITLE
feature(Secure API docs): added new flag to switch on/off the authent…

### DIFF
--- a/rest_framework/documentation.py
+++ b/rest_framework/documentation.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, url
+from django.contrib.auth.decorators import login_required
 
 from rest_framework.renderers import (
     CoreJSONRenderer, DocumentationRenderer, SchemaJSRenderer
@@ -77,8 +78,14 @@ def include_docs_urls(
         authentication_classes=authentication_classes,
         permission_classes=permission_classes,
     )
-    urls = [
-        url(r'^$', docs_view, name='docs-index'),
-        url(r'^schema.js$', schema_js_view, name='schema-js')
-    ]
+    if api_settings.SECURE_DOCS is False:
+        urls = [
+            url(r'^$', docs_view, name='docs-index'),
+            url(r'^schema.js$', schema_js_view, name='schema-js')
+        ]
+    else:
+        urls = [
+            url(r'^$', login_required(docs_view), name='docs-index'),
+            url(r'^schema.js$', login_required(schema_js_view), name='schema-js')
+        ]
     return include((urls, 'api-docs'), namespace='api-docs')

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -128,6 +128,9 @@ DEFAULTS = {
         'retrieve': 'read',
         'destroy': 'delete'
     },
+
+    # Documentation
+    'SECURE_DOCS': False
 }
 
 


### PR DESCRIPTION
Added a new flag to switch on/off the authentication needed to view the documentation of the APIs

## Description

### Motivation

Hi,

I had to work recently on making docs for our APIs which were built using rest-framework. It was an easy task but my organisation needed that the documentation pages should be visible to internal users only. I implemented it by overriding the `include_docs_urls`.

So, I thought it will be better if this security option is provided by default. So, here is my feature request for the same.

### Changes

I have added a flag, `SECURE_DOCS` which is `False` by default, meaning authentication will be off by default.

If the flag is ON, then docs URL endpoint will require login.

### Tests

I ran `./runtests.py` after making the changes, and here are the final results,

```
=========================================================== short test summary info ===========================================================
SKIP [1] /Users/luvpreetsingh/.virtualenvs/drf/lib/python3.6/site-packages/_pytest/nose.py:23: requires python 3.5

=================================================== 1283 passed, 1 skipped in 11.28 seconds ===================================================
Running flake8 code linting
flake8 passed
Running isort code checking
Skipped 13 files
isort passed
```

P.S - It is my first contribution to DRF, so please bear with any mistakes made by me. Suggestions are most welcome.