### PR TITLE
Fix documentation for specifying an alternate throttle cache

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -82,8 +82,10 @@ The throttle classes provided by REST framework use Django's cache backend.  You
 
 If you need to use a cache other than `'default'`, you can do so by creating a custom throttle class and setting the `cache` attribute.  For example:
 
+    from django.core.cache import caches
+
     class CustomAnonRateThrottle(AnonRateThrottle):
-        cache = get_cache('alternate')
+        cache = caches['alternate']
 
 You'll need to remember to also set your custom throttle class in the `'DEFAULT_THROTTLE_CLASSES'` settings key, or using the `throttle_classes` view attribute.
 


### PR DESCRIPTION
## Description
This PR is a small update to the documentation for specifying an alternate cache for a throttle.  The `get_cache` method was deprecated in Django 1.7 and [removed](https://docs.djangoproject.com/en/2.1/releases/1.9/#features-removed-in-1-9) in Django 1.9.  The new method uses `django.core.cache.caches`.

I've confirmed that the documentation builds and looks reasonable with this change.
