### PR TITLE
Allow suffix_require=None, only non-suffixed URL

### DIFF
--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -76,8 +76,10 @@ def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required, suffix_r
                 new_pattern = path(route, view, kwargs, name)
             else:
                 new_pattern = url(regex, view, kwargs, name)
-
-            ret.append(new_pattern)
+                
+            # If suffix_required is None, we don't need suffix at all
+            if suffix_required is not None:
+                ret.append(new_pattern)
 
     return ret
 
@@ -93,6 +95,7 @@ def format_suffix_patterns(urlpatterns, suffix_required=False, allowed=None):
     suffix_required:
         If `True`, only suffixed URLs will be generated, and non-suffixed
         URLs will not be used.  Defaults to `False`.
+        If None, only non-suffixed URLs will be used.
 
     allowed:
         An optional tuple/list of allowed suffixes.  eg ['json', 'api']


### PR DESCRIPTION
In the current format_suffix_patterns, there are only two options
1) suffix_required=False: URL with both suffix and non-suffixed will be generated
2) suffix_required=True: Only URL with suffixed will be generated.
There is no option for 
3) suffix_required=None: Only URL with non-suffixed will be generated.
By allowing suffix_required to None, we can achieve 3). This makes it cleaner when you use django rest swagger as you will not have duplicated endpoint one with suffix and the other without suffix from appearing.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
