### PR TITLE
Fix Python 3 compat in documentation

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -152,7 +152,7 @@ When deserializing data, you always need to call `is_valid()` before attempting 
     serializer.is_valid()
     # False
     serializer.errors
-    # {'email': [u'Enter a valid e-mail address.'], 'created': [u'This field is required.']}
+    # {'email': ['Enter a valid e-mail address.'], 'created': ['This field is required.']}
 
 Each key in the dictionary will be the field name, and the values will be lists of strings of any error messages corresponding to that field.  The `non_field_errors` key may also be present, and will list any general validation errors. The name of the `non_field_errors` key may be customized using the `NON_FIELD_ERRORS_KEY` REST framework setting.
 
@@ -253,7 +253,7 @@ When passing data to a serializer instance, the unmodified data will be made ava
 By default, serializers must be passed values for all required fields or they will raise validation errors. You can use the `partial` argument in order to allow partial updates.
 
     # Update `comment` with partial data
-    serializer = CommentSerializer(comment, data={'content': u'foo bar'}, partial=True)
+    serializer = CommentSerializer(comment, data={'content': 'foo bar'}, partial=True)
 
 ## Dealing with nested objects
 
@@ -293,7 +293,7 @@ When dealing with nested representations that support deserializing the data, an
     serializer.is_valid()
     # False
     serializer.errors
-    # {'user': {'email': [u'Enter a valid e-mail address.']}, 'created': [u'This field is required.']}
+    # {'user': {'email': ['Enter a valid e-mail address.']}, 'created': ['This field is required.']}
 
 Similarly, the `.validated_data` property will include nested data structures.
 
@@ -415,7 +415,7 @@ You can provide arbitrary additional context by passing a `context` argument whe
 
     serializer = AccountSerializer(account, context={'request': request})
     serializer.data
-    # {'id': 6, 'owner': u'denvercoder9', 'created': datetime.datetime(2013, 2, 12, 09, 44, 56, 678870), 'details': 'http://example.com/accounts/6/details'}
+    # {'id': 6, 'owner': 'denvercoder9', 'created': datetime.datetime(2013, 2, 12, 09, 44, 56, 678870), 'details': 'http://example.com/accounts/6/details'}
 
 The context dictionary can be used within any serializer field logic, such as a custom `.to_representation()` method, by accessing the `self.context` attribute.
 
@@ -1094,10 +1094,10 @@ This would then allow you to do the following:
     >>>         model = User
     >>>         fields = ('id', 'username', 'email')
     >>>
-    >>> print UserSerializer(user)
+    >>> print(UserSerializer(user))
     {'id': 2, 'username': 'jonwatts', 'email': 'jon@example.com'}
     >>>
-    >>> print UserSerializer(user, fields=('id', 'email'))
+    >>> print(UserSerializer(user, fields=('id', 'email')))
     {'id': 2, 'email': 'jon@example.com'}
 
 ## Customizing the default fields

--- a/docs/community/3.0-announcement.md
+++ b/docs/community/3.0-announcement.md
@@ -389,7 +389,7 @@ You can include `expiry_date` as a field option on a `ModelSerializer` class.
 These fields will be mapped to `serializers.ReadOnlyField()` instances.
 
     >>> serializer = InvitationSerializer()
-    >>> print repr(serializer)
+    >>> print(repr(serializer))
     InvitationSerializer():
         to_email = EmailField(max_length=75)
         message = CharField(max_length=1000)

--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -137,20 +137,20 @@ Okay, once we've got a few imports out of the way, let's create a couple of code
     snippet = Snippet(code='foo = "bar"\n')
     snippet.save()
 
-    snippet = Snippet(code='print "hello, world"\n')
+    snippet = Snippet(code='print("hello, world")\n')
     snippet.save()
 
 We've now got a few snippet instances to play with.  Let's take a look at serializing one of those instances.
 
     serializer = SnippetSerializer(snippet)
     serializer.data
-    # {'id': 2, 'title': u'', 'code': u'print "hello, world"\n', 'linenos': False, 'language': u'python', 'style': u'friendly'}
+    # {'id': 2, 'title': '', 'code': 'print("hello, world")\n', 'linenos': False, 'language': 'python', 'style': 'friendly'}
 
 At this point we've translated the model instance into Python native datatypes.  To finalize the serialization process we render the data into `json`.
 
     content = JSONRenderer().render(serializer.data)
     content
-    # '{"id": 2, "title": "", "code": "print \\"hello, world\\"\\n", "linenos": false, "language": "python", "style": "friendly"}'
+    # '{"id": 2, "title": "", "code": "print(\\"hello, world\\")\\n", "linenos": false, "language": "python", "style": "friendly"}'
 
 Deserialization is similar.  First we parse a stream into Python native datatypes...
 
@@ -165,7 +165,7 @@ Deserialization is similar.  First we parse a stream into Python native datatype
     serializer.is_valid()
     # True
     serializer.validated_data
-    # OrderedDict([('title', ''), ('code', 'print "hello, world"\n'), ('linenos', False), ('language', 'python'), ('style', 'friendly')])
+    # OrderedDict([('title', ''), ('code', 'print("hello, world")\n'), ('linenos', False), ('language', 'python'), ('style', 'friendly')])
     serializer.save()
     # <Snippet: Snippet object>
 
@@ -175,7 +175,7 @@ We can also serialize querysets instead of model instances.  To do so we simply 
 
     serializer = SnippetSerializer(Snippet.objects.all(), many=True)
     serializer.data
-    # [OrderedDict([('id', 1), ('title', u''), ('code', u'foo = "bar"\n'), ('linenos', False), ('language', 'python'), ('style', 'friendly')]), OrderedDict([('id', 2), ('title', u''), ('code', u'print "hello, world"\n'), ('linenos', False), ('language', 'python'), ('style', 'friendly')]), OrderedDict([('id', 3), ('title', u''), ('code', u'print "hello, world"'), ('linenos', False), ('language', 'python'), ('style', 'friendly')])]
+    # [OrderedDict([('id', 1), ('title', ''), ('code', 'foo = "bar"\n'), ('linenos', False), ('language', 'python'), ('style', 'friendly')]), OrderedDict([('id', 2), ('title', ''), ('code', 'print("hello, world")\n'), ('linenos', False), ('language', 'python'), ('style', 'friendly')]), OrderedDict([('id', 3), ('title', ''), ('code', 'print("hello, world")'), ('linenos', False), ('language', 'python'), ('style', 'friendly')])]
 
 ## Using ModelSerializers
 
@@ -338,7 +338,7 @@ Finally, we can get a list of all of the snippets:
       {
         "id": 2,
         "title": "",
-        "code": "print \"hello, world\"\n",
+        "code": "print(\"hello, world\")\n",
         "linenos": false,
         "language": "python",
         "style": "friendly"
@@ -354,7 +354,7 @@ Or we can get a particular snippet by referencing its id:
     {
       "id": 2,
       "title": "",
-      "code": "print \"hello, world\"\n",
+      "code": "print(\"hello, world\")\n",
       "linenos": false,
       "language": "python",
       "style": "friendly"

--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -143,7 +143,7 @@ We can get a list of all of the snippets, as before.
       {
         "id": 2,
         "title": "",
-        "code": "print \"hello, world\"\n",
+        "code": "print(\"hello, world\")\n",
         "linenos": false,
         "language": "python",
         "style": "friendly"
@@ -163,24 +163,24 @@ Or by appending a format suffix:
 Similarly, we can control the format of the request that we send, using the `Content-Type` header.
 
     # POST using form data
-    http --form POST http://127.0.0.1:8000/snippets/ code="print 123"
+    http --form POST http://127.0.0.1:8000/snippets/ code="print(123)"
 
     {
       "id": 3,
       "title": "",
-      "code": "print 123",
+      "code": "print(123)",
       "linenos": false,
       "language": "python",
       "style": "friendly"
     }
 
     # POST using JSON
-    http --json POST http://127.0.0.1:8000/snippets/ code="print 456"
+    http --json POST http://127.0.0.1:8000/snippets/ code="print(456)"
 
     {
         "id": 4,
         "title": "",
-        "code": "print 456",
+        "code": "print(456)",
         "linenos": false,
         "language": "python",
         "style": "friendly"


### PR DESCRIPTION
## Description

- Replace `print x` with `print(x)`
- Remove `u` prefix from strings

Inspired by the work done in encode/django-rest-framework#6376