### PR TITLE
Composed permissions should be lazily evaluated

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -5,6 +5,8 @@ versions of Django/Python, and compatibility wrappers around optional packages.
 
 from __future__ import unicode_literals
 
+import sys
+
 from django.conf import settings
 from django.core import validators
 from django.utils import six
@@ -33,6 +35,11 @@ try:
     from django.core.validators import ProhibitNullCharactersValidator  # noqa
 except ImportError:
     ProhibitNullCharactersValidator = None
+
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 
 def get_original_route(urlpattern):
@@ -314,3 +321,7 @@ class MinLengthValidator(CustomValidatorMessage, validators.MinLengthValidator):
 
 class MaxLengthValidator(CustomValidatorMessage, validators.MaxLengthValidator):
     pass
+
+
+# Version Constants.
+PY36 = sys.version_info >= (3, 6)

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -44,13 +44,13 @@ class AND:
 
     def has_permission(self, request, view):
         return (
-            self.op1.has_permission(request, view) &
+            self.op1.has_permission(request, view) and
             self.op2.has_permission(request, view)
         )
 
     def has_object_permission(self, request, view, obj):
         return (
-            self.op1.has_object_permission(request, view, obj) &
+            self.op1.has_object_permission(request, view, obj) and
             self.op2.has_object_permission(request, view, obj)
         )
 
@@ -62,13 +62,13 @@ class OR:
 
     def has_permission(self, request, view):
         return (
-            self.op1.has_permission(request, view) |
+            self.op1.has_permission(request, view) or
             self.op2.has_permission(request, view)
         )
 
     def has_object_permission(self, request, view, obj):
         return (
-            self.op1.has_object_permission(request, view, obj) |
+            self.op1.has_object_permission(request, view, obj) or
             self.op2.has_object_permission(request, view, obj)
         )
 


### PR DESCRIPTION
When composing permissions, all permissions are evaluated even when the outcome is already set. This can lead to errors when the order of the permission was logically set.

For example with `IsReadonly |  IsAssumingNotReadonly`, if `IsReadonly` responds `True` for `GET` requests, logically `IsAssumingNotReadonly` can assume that the method is not `GET`. Presently, this is not the case as `IsAssumingNotReadonly` is being evaluated.

The patch suggests switching to lazy `or` and `and` instead of the bitwise operators.

([Initial report](https://github.com/encode/django-rest-framework/issues/6402#issuecomment-465050530))