### PR TITLE
Fix DeprecationWarning in tests when accessing collections.abc classes via collections

### DIFF
--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import re
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
 
 import pytest
 from django.conf.urls import include, url
@@ -16,7 +16,7 @@ from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import permissions, serializers, status
-from rest_framework.compat import coreapi
+from rest_framework.compat import coreapi, MutableMapping
 from rest_framework.decorators import action
 from rest_framework.renderers import (
     AdminRenderer, BaseRenderer, BrowsableAPIRenderer, DocumentationRenderer,

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -16,7 +16,7 @@ from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import permissions, serializers, status
-from rest_framework.compat import coreapi, MutableMapping
+from rest_framework.compat import MutableMapping, coreapi
 from rest_framework.decorators import action
 from rest_framework.renderers import (
     AdminRenderer, BaseRenderer, BrowsableAPIRenderer, DocumentationRenderer,

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -5,13 +5,12 @@ import inspect
 import pickle
 import re
 import unittest
-from collections import Mapping
 
 import pytest
 from django.db import models
 
 from rest_framework import exceptions, fields, relations, serializers
-from rest_framework.compat import unicode_repr
+from rest_framework.compat import unicode_repr, Mapping
 from rest_framework.fields import Field
 
 from .models import (

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -10,7 +10,7 @@ import pytest
 from django.db import models
 
 from rest_framework import exceptions, fields, relations, serializers
-from rest_framework.compat import unicode_repr, Mapping
+from rest_framework.compat import Mapping, unicode_repr
 from rest_framework.fields import Field
 
 from .models import (


### PR DESCRIPTION
This is a follow up PR on #6268 to fix similar cases in tests as noted in https://github.com/encode/django-rest-framework/pull/6268#issuecomment-453858077

Thanks for the library :)