### PR TITLE
Avoid api_settings attribute evaluation at import time (#6478)

### DIFF
--- a/rest_framework/schemas/__init__.py
+++ b/rest_framework/schemas/__init__.py
@@ -29,13 +29,17 @@ from .inspectors import AutoSchema, DefaultSchema, ManualSchema  # noqa
 def get_schema_view(
         title=None, url=None, description=None, urlconf=None, renderer_classes=None,
         public=False, patterns=None, generator_class=SchemaGenerator,
-        authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
-        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
+        authentication_classes=None, permission_classes=None):
     """
     Return a schema view.
     """
     # Avoid import cycle on APIView
     from .views import SchemaView
+    # Avoid api_settings attribute evaluation at import time
+    if authentication_classes is None:
+        authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
+    if permission_classes is None:
+        permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES
     generator = generator_class(
         title=title, url=url, description=description,
         urlconf=urlconf, patterns=patterns,


### PR DESCRIPTION
## Description

This PR fixes issue #6478

Unfortunately, there is no easy way to reproduce the error with an unit test. To reproduce the issue the import needs to happen at the right time (e.g. before the Django apps are loaded).
