### PR TITLE
Replace type('') with six.text_type

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1486,7 +1486,7 @@ class MultipleChoiceField(ChoiceField):
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):
-        if isinstance(data, type('')) or not hasattr(data, '__iter__'):
+        if isinstance(data, six.text_type) or not hasattr(data, '__iter__'):
             self.fail('not_a_list', input_type=type(data).__name__)
         if not self.allow_empty and len(data) == 0:
             self.fail('empty')
@@ -1660,7 +1660,7 @@ class ListField(Field):
         """
         if html.is_html_input(data):
             data = html.parse_html_list(data, default=[])
-        if isinstance(data, (type(''), Mapping)) or not hasattr(data, '__iter__'):
+        if isinstance(data, (six.text_type, Mapping)) or not hasattr(data, '__iter__'):
             self.fail('not_a_list', input_type=type(data).__name__)
         if not self.allow_empty and len(data) == 0:
             self.fail('empty')

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -518,7 +518,7 @@ class ManyRelatedField(Field):
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):
-        if isinstance(data, type('')) or not hasattr(data, '__iter__'):
+        if isinstance(data, six.text_type) or not hasattr(data, '__iter__'):
             self.fail('not_a_list', input_type=type(data).__name__)
         if not self.allow_empty and len(data) == 0:
             self.fail('empty')

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -5,6 +5,7 @@ import pytest
 from django.core.paginator import Paginator as DjangoPaginator
 from django.db import models
 from django.test import TestCase
+from django.utils import six
 
 from rest_framework import (
     exceptions, filters, generics, pagination, serializers, status
@@ -207,7 +208,7 @@ class TestPageNumberPagination:
             ]
         }
         assert self.pagination.display_page_controls
-        assert isinstance(self.pagination.to_html(), type(''))
+        assert isinstance(self.pagination.to_html(), six.text_type)
 
     def test_second_page(self):
         request = Request(factory.get('/', {'page': 2}))
@@ -313,7 +314,7 @@ class TestPageNumberPaginationOverride:
             ]
         }
         assert not self.pagination.display_page_controls
-        assert isinstance(self.pagination.to_html(), type(''))
+        assert isinstance(self.pagination.to_html(), six.text_type)
 
     def test_invalid_page(self):
         request = Request(factory.get('/', {'page': 'invalid'}))
@@ -368,7 +369,7 @@ class TestLimitOffset:
             ]
         }
         assert self.pagination.display_page_controls
-        assert isinstance(self.pagination.to_html(), type(''))
+        assert isinstance(self.pagination.to_html(), six.text_type)
 
     def test_pagination_not_applied_if_limit_or_default_limit_not_set(self):
         class MockPagination(pagination.LimitOffsetPagination):
@@ -631,7 +632,7 @@ class CursorPaginationTestsMixin:
         assert current == [1, 1, 1, 1, 1]
         assert next == [1, 2, 3, 4, 4]
 
-        assert isinstance(self.pagination.to_html(), type(''))
+        assert isinstance(self.pagination.to_html(), six.text_type)
 
     def test_cursor_pagination_with_page_size(self):
         (previous, current, next, previous_url, next_url) = self.get_pages('/?page_size=20')

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,6 +5,7 @@ import re
 from django.core.validators import MaxValueValidator, RegexValidator
 from django.db import models
 from django.test import TestCase
+from django.utils import six
 
 from rest_framework import generics, serializers, status
 from rest_framework.test import APIRequestFactory
@@ -111,7 +112,7 @@ class TestAvoidValidation(TestCase):
         assert not serializer.is_valid()
         assert serializer.errors == {
             'non_field_errors': [
-                'Invalid data. Expected a dictionary, but got %s.' % type('').__name__
+                'Invalid data. Expected a dictionary, but got %s.' % six.text_type.__name__
             ]
         }
 


### PR DESCRIPTION
As all source files import `unicode_literals`, `type('')` is always equivalent to `six.text_type` (`str` on Python 3 and `unicode` on Python 2). Removes the need to call `type()`, is more explicit, and will be easier to catch places to change for when it is time to eventually drop Python 2.