### PR TITLE
Fix get_search_fields example

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -220,10 +220,13 @@ By default, the search parameter is named `'search`', but this may be overridden
 
 To dynamically change search fields based on request content, it's possible to subclass the `SearchFilter` and override the `get_search_fields()` function. For example, the following subclass will only search on `title` if the query parameter `title_only` is in the request:
 
-    class CustomSearchFilter(self, view, request):
-        if request.query_params.get('title_only'):
-            return ('title',)
-        return super(CustomSearchFilter, self).get_search_fields(view, request)
+    from rest_framework import filters
+    
+    class CustomSearchFilter(filters.SearchFilter):
+        def get_search_fields(self, view, request):
+            if request.query_params.get('title_only'):
+                return ('title',)
+            return super(CustomSearchFilter, self).get_search_fields(view, request)
 
 For more details, see the [Django documentation][search-django-admin].
 


### PR DESCRIPTION
Just noticed something in the docs and created a quick PR. Not linked to any issue that I could find
