### PR TITLE
Fix schema generation of `ManyRelatedField` to detect the child type

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -51,8 +51,10 @@ def field_to_schema(field):
             description=description
         )
     elif isinstance(field, serializers.ManyRelatedField):
+        related_field_schema = field_to_schema(field.child_relation)
+
         return coreschema.Array(
-            items=coreschema.String(),
+            items=related_field_schema,
             title=title,
             description=description
         )


### PR DESCRIPTION
This implements the changes mentioned in https://github.com/encode/django-rest-framework/pull/6438#issuecomment-469916730 so that a `ManyRelatedField` will now document the correct inner type. Before it was being forced to a `String`, which was incorrect for the default case and also incorrect for a few other edge cases as well.