### PR TITLE
Allow rounding parameter in DecimalField to work before precision validation

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1080,7 +1080,7 @@ class DecimalField(Field):
         if value in (decimal.Decimal('Inf'), decimal.Decimal('-Inf')):
             self.fail('invalid')
 
-        return self.quantize(self.validate_precision(value))
+        return self.validate_precision(self.quantize(value))
 
     def validate_precision(self, value):
         """

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1080,10 +1080,11 @@ class DecimalField(Field):
         if value in (decimal.Decimal('Inf'), decimal.Decimal('-Inf')):
             self.fail('invalid')
 
-        if self.rounding is None:
-            return self.quantize(self.validate_precision(value))
-        else:
-            return self.validate_precision(self.quantize(value))
+        if self.rounding is not None:
+            # It is unnecessary to validate precision when rounding,
+            # since the value will be truncated to the correct size.
+            return self.quantize(value)
+        return self.quantize(self.validate_precision(value))
 
     def validate_precision(self, value):
         """

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1080,7 +1080,10 @@ class DecimalField(Field):
         if value in (decimal.Decimal('Inf'), decimal.Decimal('-Inf')):
             self.fail('invalid')
 
-        return self.validate_precision(self.quantize(value))
+        if self.rounding is None:
+            return self.quantize(self.validate_precision(value))
+        else:
+            return self.validate_precision(self.quantize(value))
 
     def validate_precision(self, value):
         """

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1203,8 +1203,8 @@ class TestRoundingDecimalField(TestCase):
         with pytest.raises(AssertionError) as excinfo:
             serializers.DecimalField(max_digits=1, decimal_places=1, rounding='ROUND_UNKNOWN')
         assert 'Invalid rounding option' in str(excinfo.value)
-        
-        
+
+
 # Date & time serializers...
 class TestDateField(FieldValues):
     """

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1168,6 +1168,12 @@ class TestQuantizedValueForDecimal(TestCase):
         value = field.to_internal_value('12.0').as_tuple()
         expected_digit_tuple = (0, (1, 2, 0, 0), -2)
         assert value == expected_digit_tuple
+    
+    def test_rounding_value_for_decimal(self):
+        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding=ROUND_HALF_UP)
+        value = field.to_internal_value('12.004).as_tuple()
+        expected_digit_tuple = (0, (1, 2, 0, 0), -2)
+        assert value == expected_digit_tuple
 
 
 class TestNoDecimalPlaces(FieldValues):
@@ -1197,8 +1203,8 @@ class TestRoundingDecimalField(TestCase):
         with pytest.raises(AssertionError) as excinfo:
             serializers.DecimalField(max_digits=1, decimal_places=1, rounding='ROUND_UNKNOWN')
         assert 'Invalid rounding option' in str(excinfo.value)
-
-
+        
+        
 # Date & time serializers...
 class TestDateField(FieldValues):
     """

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1168,10 +1168,10 @@ class TestQuantizedValueForDecimal(TestCase):
         value = field.to_internal_value('12.0').as_tuple()
         expected_digit_tuple = (0, (1, 2, 0, 0), -2)
         assert value == expected_digit_tuple
-    
+
     def test_rounding_value_for_decimal(self):
-        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding=ROUND_HALF_UP)
-        value = field.to_internal_value('12.004).as_tuple()
+        field = serializers.DecimalField(max_digits=4, decimal_places=2, rounding=ROUND_DOWN)
+        value = field.to_internal_value('12.004').as_tuple()
         expected_digit_tuple = (0, (1, 2, 0, 0), -2)
         assert value == expected_digit_tuple
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

This is a pretty straightforward case where my naive expectations do not line up with behavior of the code.  The test I've added normally raises a ValidationError, and it should in general without the `rounding` kwarg.  My expectation of this kwarg, though, was that it would work similarly in serialization and deserialization, but it basically has no effect on deserialization because the precision validation is checked first.  I admit this may not be the most elegant way to solve this issue, but I'm open to any suggestions or additional context as to why it is the way it is.