### PR TITLE
Modify `AND` and `OR` permission operands to have the ability to use custom messages

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -51,18 +51,29 @@ class AND:
     def __init__(self, op1, op2):
         self.op1 = op1
         self.op2 = op2
+        self.message = None
 
     def has_permission(self, request, view):
-        return (
-            self.op1.has_permission(request, view) and
-            self.op2.has_permission(request, view)
-        )
+        if not self.op1.has_permission(request, view):
+            self.message = getattr(self.op1, 'message', None)
+            return False
+
+        if not self.op2.has_permission(request, view):
+            self.message = getattr(self.op2, 'message', None)
+            return False
+
+        return True
 
     def has_object_permission(self, request, view, obj):
-        return (
-            self.op1.has_object_permission(request, view, obj) and
-            self.op2.has_object_permission(request, view, obj)
-        )
+        if not self.op1.has_object_permission(request, view, obj):
+            self.message = getattr(self.op1, 'message', None)
+            return False
+
+        if not self.op2.has_object_permission(request, view, obj):
+            self.message = getattr(self.op2, 'message', None)
+            return False
+
+        return True
 
 
 class OR:

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -2,6 +2,7 @@
 Provides a set of pluggable permission policies.
 """
 from django.http import Http404
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import exceptions
 
@@ -80,6 +81,13 @@ class OR:
     def __init__(self, op1, op2):
         self.op1 = op1
         self.op2 = op2
+        self.message1 = getattr(op1, 'message', None)
+        self.message2 = getattr(op2, 'message', None)
+        self.message = self.message1 or self.message2
+        if self.message1 and self.message2:
+            self.message = '"{0}" {1} "{2}"'.format(
+                self.message1, _('OR'), self.message2,
+            )
 
     def has_permission(self, request, view):
         return (

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -105,6 +105,7 @@ class OR:
 class NOT:
     def __init__(self, op1):
         self.op1 = op1
+        self.message = getattr(self.op1, 'message_inverted', None)
 
     def has_permission(self, request, view):
         return not self.op1.has_permission(request, view)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -490,6 +490,18 @@ class DeniedViewWithDetailAND3(PermissionInstanceView):
     permission_classes = (BasicPermWithDetail & AnotherBasicPermWithDetail,)
 
 
+class DeniedViewWithDetailOR1(PermissionInstanceView):
+    permission_classes = (BasicPerm | BasicPermWithDetail,)
+
+
+class DeniedViewWithDetailOR2(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail | BasicPerm,)
+
+
+class DeniedViewWithDetailOR3(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail | AnotherBasicPermWithDetail,)
+
+
 class DeniedObjectView(PermissionInstanceView):
     permission_classes = (BasicObjectPerm,)
 
@@ -510,6 +522,18 @@ class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
     permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail,)
 
 
+class DeniedObjectViewWithDetailOR1(PermissionInstanceView):
+    permission_classes = (BasicObjectPerm | BasicObjectPermWithDetail,)
+
+
+class DeniedObjectViewWithDetailOR2(PermissionInstanceView):
+    permission_classes = (BasicObjectPermWithDetail | BasicObjectPerm,)
+
+
+class DeniedObjectViewWithDetailOR3(PermissionInstanceView):
+    permission_classes = (BasicObjectPermWithDetail | AnotherBasicObjectPermWithDetail,)
+
+
 denied_view = DeniedView.as_view()
 
 denied_view_with_detail = DeniedViewWithDetail.as_view()
@@ -518,6 +542,10 @@ denied_view_with_detail_and_1 = DeniedViewWithDetailAND1.as_view()
 denied_view_with_detail_and_2 = DeniedViewWithDetailAND2.as_view()
 denied_view_with_detail_and_3 = DeniedViewWithDetailAND3.as_view()
 
+denied_view_with_detail_or_1 = DeniedViewWithDetailOR1.as_view()
+denied_view_with_detail_or_2 = DeniedViewWithDetailOR2.as_view()
+denied_view_with_detail_or_3 = DeniedViewWithDetailOR3.as_view()
+
 denied_object_view = DeniedObjectView.as_view()
 
 denied_object_view_with_detail = DeniedObjectViewWithDetail.as_view()
@@ -525,6 +553,10 @@ denied_object_view_with_detail = DeniedObjectViewWithDetail.as_view()
 denied_object_view_with_detail_and_1 = DeniedObjectViewWithDetailAND1.as_view()
 denied_object_view_with_detail_and_2 = DeniedObjectViewWithDetailAND2.as_view()
 denied_object_view_with_detail_and_3 = DeniedObjectViewWithDetailAND3.as_view()
+
+denied_object_view_with_detail_or_1 = DeniedObjectViewWithDetailOR1.as_view()
+denied_object_view_with_detail_or_2 = DeniedObjectViewWithDetailOR2.as_view()
+denied_object_view_with_detail_or_3 = DeniedObjectViewWithDetailOR3.as_view()
 
 
 class CustomPermissionsTests(TestCase):
@@ -567,6 +599,25 @@ class CustomPermissionsTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(detail, CUSTOM_MESSAGE_1)
 
+    def test_permission_denied_with_custom_detail_or_1(self):
+        response = denied_view_with_detail_or_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_with_custom_detail_or_2(self):
+        response = denied_view_with_detail_or_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_with_custom_detail_or_3(self):
+        response = denied_view_with_detail_or_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        expected_message = '"{0}" OR "{1}"'.format(CUSTOM_MESSAGE_1, CUSTOM_MESSAGE_2)
+        self.assertEqual(detail, expected_message)
+
     def test_permission_denied_for_object(self):
         response = denied_object_view(self.request, pk=1)
         detail = response.data.get('detail')
@@ -598,6 +649,25 @@ class CustomPermissionsTests(TestCase):
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(detail, CUSTOM_MESSAGE_2)
+
+    def test_permission_denied_for_object_with_custom_detail_or_1(self):
+        response = denied_object_view_with_detail_or_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_for_object_with_custom_detail_or_2(self):
+        response = denied_object_view_with_detail_or_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_for_object_with_custom_detail_or_3(self):
+        response = denied_object_view_with_detail_or_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        expected_message = '"{0}" OR "{1}"'.format(CUSTOM_MESSAGE_1, CUSTOM_MESSAGE_2)
+        self.assertEqual(detail, expected_message)
 
 
 class PermissionsCompositionTests(TestCase):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -530,7 +530,7 @@ class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
 
 
 class DeniedObjectViewWithDetailOR1(PermissionInstanceView):
-    permission_classes = (BasicObjectPerm | BasicObjectPermWithDetail,)
+    permission_classes = (BasicObjectPerm | BasicObjectPermWithDetail)
 
 
 class DeniedObjectViewWithDetailOR2(PermissionInstanceView):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -526,7 +526,7 @@ class DeniedObjectViewWithDetailAND2(PermissionInstanceView):
 
 
 class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
-    permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail,)
+    permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail)
 
 
 class DeniedObjectViewWithDetailOR1(PermissionInstanceView):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -522,7 +522,7 @@ class DeniedObjectViewWithDetailAND1(PermissionInstanceView):
 
 
 class DeniedObjectViewWithDetailAND2(PermissionInstanceView):
-    permission_classes = (permissions.AllowAny & AnotherBasicObjectPermWithDetail,)
+    permission_classes = (permissions.AllowAny & AnotherBasicObjectPermWithDetail)
 
 
 class DeniedObjectViewWithDetailAND3(PermissionInstanceView):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -18,6 +18,9 @@ from tests.models import BasicModel
 
 factory = APIRequestFactory()
 
+CUSTOM_MESSAGE_1 = 'Custom: You cannot access this resource'
+CUSTOM_MESSAGE_2 = 'Custom: You do not have permission to view this resource'
+
 
 class BasicSerializer(serializers.ModelSerializer):
     class Meta:
@@ -428,8 +431,15 @@ class BasicPerm(permissions.BasePermission):
 
 
 class BasicPermWithDetail(permissions.BasePermission):
-    message = 'Custom: You cannot access this resource'
+    message = CUSTOM_MESSAGE_1
     code = 'permission_denied_custom'
+
+    def has_permission(self, request, view):
+        return False
+
+
+class AnotherBasicPermWithDetail(permissions.BasePermission):
+    message = CUSTOM_MESSAGE_2
 
     def has_permission(self, request, view):
         return False
@@ -441,8 +451,15 @@ class BasicObjectPerm(permissions.BasePermission):
 
 
 class BasicObjectPermWithDetail(permissions.BasePermission):
-    message = 'Custom: You cannot access this resource'
+    message = CUSTOM_MESSAGE_1
     code = 'permission_denied_custom'
+
+    def has_object_permission(self, request, view, obj):
+        return False
+
+
+class AnotherBasicObjectPermWithDetail(permissions.BasePermission):
+    message = CUSTOM_MESSAGE_2
 
     def has_object_permission(self, request, view, obj):
         return False
@@ -461,6 +478,18 @@ class DeniedViewWithDetail(PermissionInstanceView):
     permission_classes = (BasicPermWithDetail,)
 
 
+class DeniedViewWithDetailAND1(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail & permissions.AllowAny,)
+
+
+class DeniedViewWithDetailAND2(PermissionInstanceView):
+    permission_classes = (permissions.AllowAny & AnotherBasicPermWithDetail,)
+
+
+class DeniedViewWithDetailAND3(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail & AnotherBasicPermWithDetail,)
+
+
 class DeniedObjectView(PermissionInstanceView):
     permission_classes = (BasicObjectPerm,)
 
@@ -469,13 +498,33 @@ class DeniedObjectViewWithDetail(PermissionInstanceView):
     permission_classes = (BasicObjectPermWithDetail,)
 
 
+class DeniedObjectViewWithDetailAND1(PermissionInstanceView):
+    permission_classes = (BasicObjectPermWithDetail & permissions.AllowAny,)
+
+
+class DeniedObjectViewWithDetailAND2(PermissionInstanceView):
+    permission_classes = (permissions.AllowAny & AnotherBasicObjectPermWithDetail,)
+
+
+class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
+    permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail,)
+
+
 denied_view = DeniedView.as_view()
 
 denied_view_with_detail = DeniedViewWithDetail.as_view()
 
+denied_view_with_detail_and_1 = DeniedViewWithDetailAND1.as_view()
+denied_view_with_detail_and_2 = DeniedViewWithDetailAND2.as_view()
+denied_view_with_detail_and_3 = DeniedViewWithDetailAND3.as_view()
+
 denied_object_view = DeniedObjectView.as_view()
 
 denied_object_view_with_detail = DeniedObjectViewWithDetail.as_view()
+
+denied_object_view_with_detail_and_1 = DeniedObjectViewWithDetailAND1.as_view()
+denied_object_view_with_detail_and_2 = DeniedObjectViewWithDetailAND2.as_view()
+denied_object_view_with_detail_and_3 = DeniedObjectViewWithDetailAND3.as_view()
 
 
 class CustomPermissionsTests(TestCase):
@@ -484,36 +533,71 @@ class CustomPermissionsTests(TestCase):
         User.objects.create_user('username', 'username@example.com', 'password')
         credentials = basic_auth_header('username', 'password')
         self.request = factory.get('/1', format='json', HTTP_AUTHORIZATION=credentials)
-        self.custom_message = 'Custom: You cannot access this resource'
         self.custom_code = 'permission_denied_custom'
 
     def test_permission_denied(self):
         response = denied_view(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertNotEqual(detail, self.custom_message)
+        self.assertNotEqual(detail, CUSTOM_MESSAGE_1)
         self.assertNotEqual(detail.code, self.custom_code)
 
     def test_permission_denied_with_custom_detail(self):
         response = denied_view_with_detail(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(detail, self.custom_message)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
         self.assertEqual(detail.code, self.custom_code)
+
+    def test_permission_denied_with_custom_detail_and_1(self):
+        response = denied_view_with_detail_and_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_with_custom_detail_and_2(self):
+        response = denied_view_with_detail_and_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_2)
+
+    def test_permission_denied_with_custom_detail_and_3(self):
+        response = denied_view_with_detail_and_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
 
     def test_permission_denied_for_object(self):
         response = denied_object_view(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertNotEqual(detail, self.custom_message)
+        self.assertNotEqual(detail, CUSTOM_MESSAGE_1)
         self.assertNotEqual(detail.code, self.custom_code)
 
     def test_permission_denied_for_object_with_custom_detail(self):
         response = denied_object_view_with_detail(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(detail, self.custom_message)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
         self.assertEqual(detail.code, self.custom_code)
+
+    def test_permission_denied_for_object_with_custom_detail_and_1(self):
+        response = denied_object_view_with_detail_and_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_for_object_with_custom_detail_and_2(self):
+        response = denied_object_view_with_detail_and_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_2)
+
+    def test_permission_denied_for_object_with_custom_detail_and_3(self):
+        response = denied_object_view_with_detail_and_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_2)
 
 
 class PermissionsCompositionTests(TestCase):


### PR DESCRIPTION
refs #6427

* `AND` - If failed permission has a message, it will be returned.
* `OR` - If both permissions will be failed:
   a) if both permissions have messages - will be returned one message combined from two messages;
    b) if only one permission (from both failed) has a message - this message will be returned (I suppose this is better then return the default one).
* `NOT` - If failed permission has a `message_inverted` attribute, it will be returned. (@iproha94 thanks for this suggestion).
