### PR TITLE
Use `basename` instead of `base_name` to get rid of deprecation warning

### DIFF
--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -636,7 +636,7 @@ class BrowsableAPIRendererTests(URLPatternsTestCase):
             raise NotImplementedError
 
     router = SimpleRouter()
-    router.register('examples', ExampleViewSet, base_name='example')
+    router.register('examples', ExampleViewSet, basename='example')
     urlpatterns = [url(r'^api/', include(router.urls))]
 
     def setUp(self):

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -121,7 +121,7 @@ class BasicViewSet(viewsets.ViewSet):
 
 class TestSimpleRouter(URLPatternsTestCase, TestCase):
     router = SimpleRouter()
-    router.register('basics', BasicViewSet, base_name='basic')
+    router.register('basics', BasicViewSet, basename='basic')
 
     urlpatterns = [
         url(r'^api/', include(router.urls)),


### PR DESCRIPTION
## Description

Use `basename` instead of `base_name` to get rid of deprecation warning in `test_renderers.py` and `test_routers.py`.
