### PR TITLE
Clear authentication_classes on ObtainAuthToken View

### DIFF
--- a/rest_framework/authtoken/views.py
+++ b/rest_framework/authtoken/views.py
@@ -13,6 +13,7 @@ class ObtainAuthToken(APIView):
     parser_classes = (parsers.FormParser, parsers.MultiPartParser, parsers.JSONParser,)
     renderer_classes = (renderers.JSONRenderer,)
     serializer_class = AuthTokenSerializer
+    authentication_classes = ()
     if coreapi is not None and coreschema is not None:
         schema = ManualSchema(
             fields=[


### PR DESCRIPTION

## Description

Clear the list of `authentication_classes` in the ObtainAuthToken view to prevent issues when setting the `DEFAULT_AUTHENTICATION_CLASSES` to `TokenAuthentication` as this would prevent any client from obtaining a Token without an existing one.