### PR TITLE
Source the correct foreign key will report an error 

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -101,6 +101,8 @@ def get_attribute(instance, attrs):
                 instance = getattr(instance, attr)
         except ObjectDoesNotExist:
             return None
+        if instance == None:
+            return None
         if is_simple_callable(instance):
             try:
                 instance = instance()


### PR DESCRIPTION
When i using the source function of serializers there was a problem, the source of a foreign key field will give me an error named incorrectly and not match any attribute, the foreign key is correct, but I just haven't add data, it is clearly wrong, so I modified the code, let it out key correctly and without adding data return None
