### PR TITLE
remove usage of django's lazy function for error messages

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 import sys
 
 from django.conf import settings
-from django.core import validators
 from django.utils import six
 from django.views.generic import View
 
@@ -292,36 +291,6 @@ else:
     SHORT_SEPARATORS = (b',', b':')
     LONG_SEPARATORS = (b', ', b': ')
     INDENT_SEPARATORS = (b',', b': ')
-
-
-class CustomValidatorMessage(object):
-    """
-    We need to avoid evaluation of `lazy` translated `message` in `django.core.validators.BaseValidator.__init__`.
-    https://github.com/django/django/blob/75ed5900321d170debef4ac452b8b3cf8a1c2384/django/core/validators.py#L297
-
-    Ref: https://github.com/encode/django-rest-framework/pull/5452
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.message = kwargs.pop('message', self.message)
-        super(CustomValidatorMessage, self).__init__(*args, **kwargs)
-
-
-class MinValueValidator(CustomValidatorMessage, validators.MinValueValidator):
-    pass
-
-
-class MaxValueValidator(CustomValidatorMessage, validators.MaxValueValidator):
-    pass
-
-
-class MinLengthValidator(CustomValidatorMessage, validators.MinLengthValidator):
-    pass
-
-
-class MaxLengthValidator(CustomValidatorMessage, validators.MaxLengthValidator):
-    pass
-
 
 # Version Constants.
 PY36 = sys.version_info >= (3, 6)


### PR DESCRIPTION
In my benchmarks, using Django's lazy function inside `__init__` method of serializers makes serialization process 3 times slower. This commit:
1. Removes usages of this function.
2. Postpone error formatting to the steps after raising `ValidationError`.
3. Keeps the code compatible for users who already overrided Field classes to have their own error messages.