### PR TITLE
update docs to use path() / re_path() instead of url()

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ router.register(r'users', UserViewSet)
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    url(r'^', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    re_path(r'^', include(router.urls)),
+    re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ router.register(r'users', UserViewSet)
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    re_path(r'^', include(router.urls)),
-    re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    path('', include(router.urls)),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]
 ```
 

--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -196,7 +196,7 @@ When using `TokenAuthentication`, you may want to provide a mechanism for client
 
     from rest_framework.authtoken import views
     urlpatterns += [
-        url(r'^api-token-auth/', views.obtain_auth_token)
+        re_path(r'^api-token-auth/', views.obtain_auth_token)
     ]
 
 Note that the URL part of the pattern can be whatever you want to use.
@@ -235,7 +235,7 @@ For example, you may return additional user information beyond the `token` value
 And in your `urls.py`:
 
     urlpatterns += [
-        url(r'^api-token-auth/', CustomAuthToken.as_view())
+        re_path(r'^api-token-auth/', CustomAuthToken.as_view())
     ]
 
 

--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -196,7 +196,7 @@ When using `TokenAuthentication`, you may want to provide a mechanism for client
 
     from rest_framework.authtoken import views
     urlpatterns += [
-        re_path(r'^api-token-auth/', views.obtain_auth_token)
+        path('api-token-auth/', views.obtain_auth_token)
     ]
 
 Note that the URL part of the pattern can be whatever you want to use.
@@ -235,7 +235,7 @@ For example, you may return additional user information beyond the `token` value
 And in your `urls.py`:
 
     urlpatterns += [
-        re_path(r'^api-token-auth/', CustomAuthToken.as_view())
+        path('api-token-auth/', CustomAuthToken.as_view())
     ]
 
 

--- a/docs/api-guide/format-suffixes.md
+++ b/docs/api-guide/format-suffixes.md
@@ -29,9 +29,9 @@ Example:
     from blog import views
 
     urlpatterns = [
-        url(r'^/$', views.apt_root),
-        url(r'^comments/$', views.comment_list),
-        url(r'^comments/(?P<pk>[0-9]+)/$', views.comment_detail)
+        re_path(r'^/$', views.apt_root),
+        re_path(r'^comments/$', views.comment_list),
+        re_path(r'^comments/(?P<pk>[0-9]+)/$', views.comment_detail)
     ]
 
     urlpatterns = format_suffix_patterns(urlpatterns, allowed=['json', 'html'])

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -1,5 +1,5 @@
 source: mixins.py
-        generics.py
+generics.py
 
 # Generic views
 
@@ -7,7 +7,7 @@ source: mixins.py
 >
 > &mdash; [Django Documentation][cite]
 
-One of the key benefits of class-based views is the way they allow you to compose bits of reusable behavior.  REST framework takes advantage of this by providing a number of pre-built views that provide for commonly used patterns.
+One of the key benefits of class-based views is the way they allow you to compose bits of reusable behavior. REST framework takes advantage of this by providing a number of pre-built views that provide for commonly used patterns.
 
 The generic views provided by REST framework allow you to quickly build API views that map closely to your database models.
 
@@ -27,7 +27,7 @@ Typically when using the generic views, you'll override the view, and set severa
         serializer_class = UserSerializer
         permission_classes = (IsAdminUser,)
 
-For more complex cases you might also want to override various methods on the view class.  For example.
+For more complex cases you might also want to override various methods on the view class. For example.
 
     class UserList(generics.ListCreateAPIView):
         queryset = User.objects.all()
@@ -40,9 +40,9 @@ For more complex cases you might also want to override various methods on the vi
             serializer = UserSerializer(queryset, many=True)
             return Response(serializer.data)
 
-For very simple cases you might want to pass through any class attributes using the `.as_view()` method.  For example, your URLconf might include something like the following entry:
+For very simple cases you might want to pass through any class attributes using the `.as_view()` method. For example, your URLconf might include something like the following entry:
 
-    re_path(r'^/users/', ListCreateAPIView.as_view(queryset=User.objects.all(), serializer_class=UserSerializer), name='user-list')
+    path('users/', ListCreateAPIView.as_view(queryset=User.objects.all(), serializer_class=UserSerializer), name='user-list')
 
 ---
 
@@ -60,20 +60,20 @@ Each of the concrete generic views provided is built by combining `GenericAPIVie
 
 The following attributes control the basic view behavior.
 
-* `queryset` - The queryset that should be used for returning objects from this view.  Typically, you must either set this attribute, or override the `get_queryset()` method. If you are overriding a view method, it is important that you call `get_queryset()` instead of accessing this property directly, as `queryset` will get evaluated once, and those results will be cached for all subsequent requests.
-* `serializer_class` - The serializer class that should be used for validating and deserializing input, and for serializing output.  Typically, you must either set this attribute, or override the `get_serializer_class()` method.
-* `lookup_field` - The model field that should be used to for performing object lookup of individual model instances.  Defaults to `'pk'`.  Note that when using hyperlinked APIs you'll need to ensure that *both* the API views *and* the serializer classes set the lookup fields if you need to use a custom value.
-* `lookup_url_kwarg` - The URL keyword argument that should be used for object lookup.  The URL conf should include a keyword argument corresponding to this value.  If unset this defaults to using the same value as `lookup_field`.
+- `queryset` - The queryset that should be used for returning objects from this view. Typically, you must either set this attribute, or override the `get_queryset()` method. If you are overriding a view method, it is important that you call `get_queryset()` instead of accessing this property directly, as `queryset` will get evaluated once, and those results will be cached for all subsequent requests.
+- `serializer_class` - The serializer class that should be used for validating and deserializing input, and for serializing output. Typically, you must either set this attribute, or override the `get_serializer_class()` method.
+- `lookup_field` - The model field that should be used to for performing object lookup of individual model instances. Defaults to `'pk'`. Note that when using hyperlinked APIs you'll need to ensure that _both_ the API views _and_ the serializer classes set the lookup fields if you need to use a custom value.
+- `lookup_url_kwarg` - The URL keyword argument that should be used for object lookup. The URL conf should include a keyword argument corresponding to this value. If unset this defaults to using the same value as `lookup_field`.
 
 **Pagination**:
 
 The following attributes are used to control pagination when used with list views.
 
-* `pagination_class` - The pagination class that should be used when paginating list results. Defaults to the same value as the `DEFAULT_PAGINATION_CLASS` setting, which is `'rest_framework.pagination.PageNumberPagination'`. Setting `pagination_class=None` will disable pagination on this view.
+- `pagination_class` - The pagination class that should be used when paginating list results. Defaults to the same value as the `DEFAULT_PAGINATION_CLASS` setting, which is `'rest_framework.pagination.PageNumberPagination'`. Setting `pagination_class=None` will disable pagination on this view.
 
 **Filtering**:
 
-* `filter_backends` - A list of filter backend classes that should be used for filtering the queryset.  Defaults to the same value as the `DEFAULT_FILTER_BACKENDS` setting.
+- `filter_backends` - A list of filter backend classes that should be used for filtering the queryset. Defaults to the same value as the `DEFAULT_FILTER_BACKENDS` setting.
 
 ### Methods
 
@@ -81,7 +81,7 @@ The following attributes are used to control pagination when used with list view
 
 #### `get_queryset(self)`
 
-Returns the queryset that should be used for list views, and that should be used as the base for lookups in detail views.  Defaults to returning the queryset specified by the `queryset` attribute.
+Returns the queryset that should be used for list views, and that should be used as the base for lookups in detail views. Defaults to returning the queryset specified by the `queryset` attribute.
 
 This method should always be used rather than accessing `self.queryset` directly, as `self.queryset` gets evaluated only once, and those results are cached for all subsequent requests.
 
@@ -95,7 +95,7 @@ For example:
 
 #### `get_object(self)`
 
-Returns an object instance that should be used for detail views.  Defaults to using the `lookup_field` parameter to filter the base queryset.
+Returns an object instance that should be used for detail views. Defaults to using the `lookup_field` parameter to filter the base queryset.
 
 May be overridden to provide more complex behavior, such as object lookups based on more than one URL kwarg.
 
@@ -134,7 +134,7 @@ For example:
 
 #### `get_serializer_class(self)`
 
-Returns the class that should be used for the serializer.  Defaults to returning the `serializer_class` attribute.
+Returns the class that should be used for the serializer. Defaults to returning the `serializer_class` attribute.
 
 May be overridden to provide dynamic behavior, such as using different serializers for read and write operations, or providing different serializers to different types of users.
 
@@ -149,11 +149,11 @@ For example:
 
 The following methods are provided by the mixin classes, and provide easy overriding of the object save or deletion behavior.
 
-* `perform_create(self, serializer)` - Called by `CreateModelMixin` when saving a new object instance.
-* `perform_update(self, serializer)` - Called by `UpdateModelMixin` when saving an existing object instance.
-* `perform_destroy(self, instance)` - Called by `DestroyModelMixin` when deleting an object instance.
+- `perform_create(self, serializer)` - Called by `CreateModelMixin` when saving a new object instance.
+- `perform_update(self, serializer)` - Called by `UpdateModelMixin` when saving an existing object instance.
+- `perform_destroy(self, instance)` - Called by `DestroyModelMixin` when deleting an object instance.
 
-These hooks are particularly useful for setting attributes that are implicit in the request, but are not part of the request data.  For instance, you might set an attribute on the object based on the request user, or based on a URL keyword argument.
+These hooks are particularly useful for setting attributes that are implicit in the request, but are not part of the request data. For instance, you might set an attribute on the object based on the request user, or based on a URL keyword argument.
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
@@ -178,17 +178,17 @@ You can also use these hooks to provide additional validation, by raising a `Val
 
 You won't typically need to override the following methods, although you might need to call into them if you're writing custom views using `GenericAPIView`.
 
-* `get_serializer_context(self)` - Returns a dictionary containing any extra context that should be supplied to the serializer.  Defaults to including `'request'`, `'view'` and `'format'` keys.
-* `get_serializer(self, instance=None, data=None, many=False, partial=False)` - Returns a serializer instance.
-* `get_paginated_response(self, data)` - Returns a paginated style `Response` object.
-* `paginate_queryset(self, queryset)` - Paginate a queryset if required, either returning a page object, or `None` if pagination is not configured for this view.
-* `filter_queryset(self, queryset)` - Given a queryset, filter it with whichever filter backends are in use, returning a new queryset.
+- `get_serializer_context(self)` - Returns a dictionary containing any extra context that should be supplied to the serializer. Defaults to including `'request'`, `'view'` and `'format'` keys.
+- `get_serializer(self, instance=None, data=None, many=False, partial=False)` - Returns a serializer instance.
+- `get_paginated_response(self, data)` - Returns a paginated style `Response` object.
+- `paginate_queryset(self, queryset)` - Paginate a queryset if required, either returning a page object, or `None` if pagination is not configured for this view.
+- `filter_queryset(self, queryset)` - Given a queryset, filter it with whichever filter backends are in use, returning a new queryset.
 
 ---
 
 # Mixins
 
-The mixin classes provide the actions that are used to provide the basic view behavior.  Note that the mixin classes provide action methods rather than defining the handler methods, such as `.get()` and `.post()`, directly.  This allows for more flexible composition of behavior.
+The mixin classes provide the actions that are used to provide the basic view behavior. Note that the mixin classes provide action methods rather than defining the handler methods, such as `.get()` and `.post()`, directly. This allows for more flexible composition of behavior.
 
 The mixin classes can be imported from `rest_framework.mixins`.
 
@@ -196,13 +196,13 @@ The mixin classes can be imported from `rest_framework.mixins`.
 
 Provides a `.list(request, *args, **kwargs)` method, that implements listing a queryset.
 
-If the queryset is populated, this returns a `200 OK` response, with a serialized representation of the queryset as the body of the response.  The response data may optionally be paginated.
+If the queryset is populated, this returns a `200 OK` response, with a serialized representation of the queryset as the body of the response. The response data may optionally be paginated.
 
 ## CreateModelMixin
 
 Provides a `.create(request, *args, **kwargs)` method, that implements creating and saving a new model instance.
 
-If an object is created this returns a `201 Created` response, with a serialized representation of the object as the body of the response.  If the representation contains a key named `url`, then the `Location` header of the response will be populated with that value.
+If an object is created this returns a `201 Created` response, with a serialized representation of the object as the body of the response. If the representation contains a key named `url`, then the `Location` header of the response will be populated with that value.
 
 If the request data provided for creating the object was invalid, a `400 Bad Request` response will be returned, with the error details as the body of the response.
 
@@ -210,13 +210,13 @@ If the request data provided for creating the object was invalid, a `400 Bad Req
 
 Provides a `.retrieve(request, *args, **kwargs)` method, that implements returning an existing model instance in a response.
 
-If an object can be retrieved this returns a `200 OK` response, with a serialized representation of the object as the body of the response.  Otherwise it will return a `404 Not Found`.
+If an object can be retrieved this returns a `200 OK` response, with a serialized representation of the object as the body of the response. Otherwise it will return a `404 Not Found`.
 
 ## UpdateModelMixin
 
 Provides a `.update(request, *args, **kwargs)` method, that implements updating and saving an existing model instance.
 
-Also provides a `.partial_update(request, *args, **kwargs)` method, which is similar to the `update` method, except that all fields for the update will be optional.  This allows support for HTTP `PATCH` requests.
+Also provides a `.partial_update(request, *args, **kwargs)` method, which is similar to the `update` method, except that all fields for the update will be optional. This allows support for HTTP `PATCH` requests.
 
 If an object is updated this returns a `200 OK` response, with a serialized representation of the object as the body of the response.
 
@@ -232,7 +232,7 @@ If an object is deleted this returns a `204 No Content` response, otherwise it w
 
 # Concrete View Classes
 
-The following classes are the concrete generic views.  If you're using generic views this is normally the level you'll be working at unless you need heavily customized behavior.
+The following classes are the concrete generic views. If you're using generic views this is normally the level you'll be working at unless you need heavily customized behavior.
 
 The view classes can be imported from `rest_framework.generics`.
 
@@ -312,7 +312,7 @@ Extends: [GenericAPIView], [RetrieveModelMixin], [UpdateModelMixin], [DestroyMod
 
 # Customizing the generic views
 
-Often you'll want to use the existing generic views, but use some slightly customized behavior.  If you find yourself reusing some bit of customized behavior in multiple places, you might want to refactor the behavior into a common class that you can then just apply to any view or viewset as needed.
+Often you'll want to use the existing generic views, but use some slightly customized behavior. If you find yourself reusing some bit of customized behavior in multiple places, you might want to refactor the behavior into a common class that you can then just apply to any view or viewset as needed.
 
 ## Creating custom mixins
 
@@ -345,7 +345,7 @@ Using custom mixins is a good option if you have custom behavior that needs to b
 
 ## Creating custom base classes
 
-If you are using a mixin across multiple views, you can take this a step further and create your own set of base views that can then be used throughout your project.  For example:
+If you are using a mixin across multiple views, you can take this a step further and create your own set of base views that can then be used throughout your project. For example:
 
     class BaseRetrieveView(MultipleFieldLookupMixin,
                            generics.RetrieveAPIView):
@@ -383,13 +383,12 @@ The [django-rest-framework-bulk package][django-rest-framework-bulk] implements 
 
 [Django Rest Multiple Models][django-rest-multiple-models] provides a generic view (and mixin) for sending multiple serialized models and/or querysets via a single API request.
 
-
 [cite]: https://docs.djangoproject.com/en/stable/ref/class-based-views/#base-vs-generic-views
-[GenericAPIView]: #genericapiview
-[ListModelMixin]: #listmodelmixin
-[CreateModelMixin]: #createmodelmixin
-[RetrieveModelMixin]: #retrievemodelmixin
-[UpdateModelMixin]: #updatemodelmixin
-[DestroyModelMixin]: #destroymodelmixin
+[genericapiview]: #genericapiview
+[listmodelmixin]: #listmodelmixin
+[createmodelmixin]: #createmodelmixin
+[retrievemodelmixin]: #retrievemodelmixin
+[updatemodelmixin]: #updatemodelmixin
+[destroymodelmixin]: #destroymodelmixin
 [django-rest-framework-bulk]: https://github.com/miki725/django-rest-framework-bulk
 [django-rest-multiple-models]: https://github.com/MattBroach/DjangoRestMultipleModels

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -42,7 +42,7 @@ For more complex cases you might also want to override various methods on the vi
 
 For very simple cases you might want to pass through any class attributes using the `.as_view()` method.  For example, your URLconf might include something like the following entry:
 
-    url(r'^/users/', ListCreateAPIView.as_view(queryset=User.objects.all(), serializer_class=UserSerializer), name='user-list')
+    re_path(r'^/users/', ListCreateAPIView.as_view(queryset=User.objects.all(), serializer_class=UserSerializer), name='user-list')
 
 ---
 

--- a/docs/api-guide/parsers.md
+++ b/docs/api-guide/parsers.md
@@ -122,7 +122,7 @@ If it is called without a `filename` URL keyword argument, then the client must 
     # urls.py
     urlpatterns = [
         # ...
-        url(r'^upload/(?P<filename>[^/]+)$', FileUploadView.as_view())
+        re_path(r'^upload/(?P<filename>[^/]+)$', FileUploadView.as_view())
     ]
 
 ---

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -60,7 +60,7 @@ For example, you can append `router.urls` to a list of existing views...
     router.register(r'accounts', AccountViewSet)
 
     urlpatterns = [
-        url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
+        re_path(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
     ]
 
     urlpatterns += router.urls
@@ -68,22 +68,22 @@ For example, you can append `router.urls` to a list of existing views...
 Alternatively you can use Django's `include` function, like so...
 
     urlpatterns = [
-        url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        url(r'^', include(router.urls)),
+        re_path(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
+        re_path(r'^', include(router.urls)),
     ]
 
 You may use `include` with an application namespace:
 
     urlpatterns = [
-        url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        url(r'^api/', include((router.urls, 'app_name'))),
+        re_path(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
+        re_path(r'^api/', include((router.urls, 'app_name'))),
     ]
 
 Or both an application and instance namespace:
 
     urlpatterns = [
-        url(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        url(r'^api/', include((router.urls, 'app_name'), namespace='instance_name')),
+        re_path(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
+        re_path(r'^api/', include((router.urls, 'app_name'), namespace='instance_name')),
     ]
 
 See Django's [URL namespaces docs][url-namespace-docs] and the [`include` API reference][include-api-reference] for more details.

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -69,21 +69,21 @@ Alternatively you can use Django's `include` function, like so...
 
     urlpatterns = [
         re_path(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        re_path(r'^', include(router.urls)),
+        path('', include(router.urls)),
     ]
 
 You may use `include` with an application namespace:
 
     urlpatterns = [
         re_path(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        re_path(r'^api/', include((router.urls, 'app_name'))),
+        path('api/', include((router.urls, 'app_name'))),
     ]
 
 Or both an application and instance namespace:
 
     urlpatterns = [
         re_path(r'^forgot-password/$', ForgotPasswordFormView.as_view()),
-        re_path(r'^api/', include((router.urls, 'app_name'), namespace='instance_name')),
+        path('api/', include((router.urls, 'app_name'), namespace='instance_name')),
     ]
 
 See Django's [URL namespaces docs][url-namespace-docs] and the [`include` API reference][include-api-reference] for more details.

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -358,7 +358,7 @@ List of url patterns to limit the schema introspection to. If you only want the 
 to be exposed in the schema:
 
     schema_url_patterns = [
-        url(r'^api/', include('myproject.api.urls')),
+        re_path(r'^api/', include('myproject.api.urls')),
     ]
 
     schema_view = get_schema_view(

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -358,7 +358,7 @@ List of url patterns to limit the schema introspection to. If you only want the 
 to be exposed in the schema:
 
     schema_url_patterns = [
-        re_path(r'^api/', include('myproject.api.urls')),
+        path('api/', include('myproject.api.urls')),
     ]
 
     schema_view = get_schema_view(

--- a/docs/api-guide/versioning.md
+++ b/docs/api-guide/versioning.md
@@ -161,8 +161,8 @@ In the following example we're giving a set of views two different possible URL 
 
     # urls.py
     urlpatterns = [
-        re_path(r'^v1/bookings/', include('bookings.urls', namespace='v1')),
-        re_path(r'^v2/bookings/', include('bookings.urls', namespace='v2'))
+        path('v1/bookings/', include('bookings.urls', namespace='v1')),
+        path('v2/bookings/', include('bookings.urls', namespace='v2'))
     ]
 
 Both `URLPathVersioning` and `NamespaceVersioning` are reasonable if you just need a simple versioning scheme. The `URLPathVersioning` approach might be better suitable for small ad-hoc projects, and the `NamespaceVersioning` is probably easier to manage for larger projects.

--- a/docs/api-guide/versioning.md
+++ b/docs/api-guide/versioning.md
@@ -155,14 +155,14 @@ In the following example we're giving a set of views two different possible URL 
 
     # bookings/urls.py
     urlpatterns = [
-        url(r'^$', bookings_list, name='bookings-list'),
-        url(r'^(?P<pk>[0-9]+)/$', bookings_detail, name='bookings-detail')
+        re_path(r'^$', bookings_list, name='bookings-list'),
+        re_path(r'^(?P<pk>[0-9]+)/$', bookings_detail, name='bookings-detail')
     ]
 
     # urls.py
     urlpatterns = [
-        url(r'^v1/bookings/', include('bookings.urls', namespace='v1')),
-        url(r'^v2/bookings/', include('bookings.urls', namespace='v2'))
+        re_path(r'^v1/bookings/', include('bookings.urls', namespace='v1')),
+        re_path(r'^v2/bookings/', include('bookings.urls', namespace='v2'))
     ]
 
 Both `URLPathVersioning` and `NamespaceVersioning` are reasonable if you just need a simple versioning scheme. The `URLPathVersioning` approach might be better suitable for small ad-hoc projects, and the `NamespaceVersioning` is probably easier to manage for larger projects.

--- a/docs/community/3.5-announcement.md
+++ b/docs/community/3.5-announcement.md
@@ -69,7 +69,7 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    url(r'^swagger/$', schema_view),
+    re_path(r'^swagger/$', schema_view),
     ...
 ]
 ```
@@ -199,7 +199,7 @@ Make sure to include the view before your router urls. For example:
 
     urlpatterns = [
         url('^$', schema_view),
-        url(r'^', include(router.urls)),
+        re_path(r'^', include(router.urls)),
     ]
 
 ### Schema path representations

--- a/docs/community/3.5-announcement.md
+++ b/docs/community/3.5-announcement.md
@@ -199,7 +199,7 @@ Make sure to include the view before your router urls. For example:
 
     urlpatterns = [
         url('^$', schema_view),
-        re_path(r'^', include(router.urls)),
+        path('', include(router.urls)),
     ]
 
 ### Schema path representations

--- a/docs/community/3.6-announcement.md
+++ b/docs/community/3.6-announcement.md
@@ -73,7 +73,7 @@ To install the API documentation, you'll need to include it in your projects URL
 
     urlpatterns = [
         ...
-        url(r'^docs/', include_docs_urls(title=API_TITLE, description=API_DESCRIPTION))
+        re_path(r'^docs/', include_docs_urls(title=API_TITLE, description=API_DESCRIPTION))
     ]
 
 Once installed you should see something a little like this:

--- a/docs/community/3.6-announcement.md
+++ b/docs/community/3.6-announcement.md
@@ -73,7 +73,7 @@ To install the API documentation, you'll need to include it in your projects URL
 
     urlpatterns = [
         ...
-        re_path(r'^docs/', include_docs_urls(title=API_TITLE, description=API_DESCRIPTION))
+        path('docs/', include_docs_urls(title=API_TITLE, description=API_DESCRIPTION))
     ]
 
 Once installed you should see something a little like this:

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ If you're intending to use the browsable API you'll probably also want to add RE
 
     urlpatterns = [
         ...
-        url(r'^api-auth/', include('rest_framework.urls'))
+        re_path(r'^api-auth/', include('rest_framework.urls'))
     ]
 
 Note that the URL path can be whatever you want.
@@ -169,8 +169,8 @@ Here's our project's root `urls.py` module:
     # Wire up our API using automatic URL routing.
     # Additionally, we include login URLs for the browsable API.
     urlpatterns = [
-        url(r'^', include(router.urls)),
-        url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+        re_path(r'^', include(router.urls)),
+        re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
 You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ If you're intending to use the browsable API you'll probably also want to add RE
 
     urlpatterns = [
         ...
-        re_path(r'^api-auth/', include('rest_framework.urls'))
+        path('api-auth/', include('rest_framework.urls'))
     ]
 
 Note that the URL path can be whatever you want.
@@ -169,8 +169,8 @@ Here's our project's root `urls.py` module:
     # Wire up our API using automatic URL routing.
     # Additionally, we include login URLs for the browsable API.
     urlpatterns = [
-        re_path(r'^', include(router.urls)),
-        re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+        path('', include(router.urls)),
+        path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
 You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.

--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -384,7 +384,7 @@ First, install the API documentation views. These will include the schema resour
 
     urlpatterns = [
         ...
-        url(r'^docs/', include_docs_urls(title='My API service'))
+        re_path(r'^docs/', include_docs_urls(title='My API service'))
     ]
 
 Once the API documentation URLs are installed, you'll be able to include both the required JavaScript resources. Note that the ordering of these two lines is important, as the schema loading requires CoreAPI to already be installed.

--- a/docs/topics/api-clients.md
+++ b/docs/topics/api-clients.md
@@ -384,7 +384,7 @@ First, install the API documentation views. These will include the schema resour
 
     urlpatterns = [
         ...
-        re_path(r'^docs/', include_docs_urls(title='My API service'))
+        path('docs/', include_docs_urls(title='My API service'))
     ]
 
 Once the API documentation URLs are installed, you'll be able to include both the required JavaScript resources. Note that the ordering of these two lines is important, as the schema loading requires CoreAPI to already be installed.

--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -26,7 +26,7 @@ To install the API documentation, you'll need to include it in your project's UR
 
     urlpatterns = [
         ...
-        re_path(r'^docs/', include_docs_urls(title='My API title'))
+        path('docs/', include_docs_urls(title='My API title'))
     ]
 
 This will include two different views:
@@ -48,7 +48,7 @@ You may ensure views are given a `request` instance by calling `include_docs_url
     urlpatterns = [
         ...
         # Generate schema with valid `request` instance:
-        re_path(r'^docs/', include_docs_urls(title='My API title', public=False))
+        path('docs/', include_docs_urls(title='My API title', public=False))
     ]
 
 

--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -26,7 +26,7 @@ To install the API documentation, you'll need to include it in your project's UR
 
     urlpatterns = [
         ...
-        url(r'^docs/', include_docs_urls(title='My API title'))
+        re_path(r'^docs/', include_docs_urls(title='My API title'))
     ]
 
 This will include two different views:
@@ -48,7 +48,7 @@ You may ensure views are given a `request` instance by calling `include_docs_url
     urlpatterns = [
         ...
         # Generate schema with valid `request` instance:
-        url(r'^docs/', include_docs_urls(title='My API title', public=False))
+        re_path(r'^docs/', include_docs_urls(title='My API title', public=False))
     ]
 
 

--- a/rest_framework/templates/rest_framework/docs/error.html
+++ b/rest_framework/templates/rest_framework/docs/error.html
@@ -48,7 +48,7 @@ being applied unexpectedly?</p>
 when including the docs urls:</p>
 
 <pre>
-   re_path(r'^docs/', include_docs_urls(title='Your API',
+   path('docs/', include_docs_urls(title='Your API',
                                     authentication_classes=[],
                                     permission_classes=[])),
 </pre>

--- a/rest_framework/templates/rest_framework/docs/error.html
+++ b/rest_framework/templates/rest_framework/docs/error.html
@@ -48,7 +48,7 @@ being applied unexpectedly?</p>
 when including the docs urls:</p>
 
 <pre>
-   url(r'^docs/', include_docs_urls(title='Your API',
+   re_path(r'^docs/', include_docs_urls(title='Your API',
                                     authentication_classes=[],
                                     permission_classes=[])),
 </pre>


### PR DESCRIPTION
## Description

The docs always use `url()` in examples. However, re_path is recommended by the django docs and url()[ is likely to be deprecated](https://docs.djangoproject.com/en/2.0/ref/urls/#url)
