### PR TITLE
Add operationId on OpenAPI operations

### DIFF
--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -57,6 +57,7 @@ class TestOperationIntrospection(TestCase):
 
         operation = inspector.get_operation(path, method)
         assert operation == {
+            'operationId': 'ListExamples',
             'parameters': [],
             'responses': {'200': {'content': {'application/json': {}}}},
         }


### PR DESCRIPTION
This pull request adds an `operationId` property on generated OpenAPI operations from #6532. This property is recommended in the OpenAPI specification and is actually a requirement if we want the generated schema to have any use with OpenAPI clients ; most client libraries will use those operation IDs to build methods. See the [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operation-object) in the OpenAPI spec for more info.

Example with `openapi3` and an hypothetical `ThingsListAPIView`:

``` python
>>> import yaml
>>> from openapi3 import OpenAPI
>>> api = OpenAPI(yaml.safe_load(open('schema.yml').read()))
>>> api.call_ListThings()
[{'id': 1, 'name': 'thing1'}, {'id': 2, 'name': 'thing2'}]
```

Same example with `apistar`:


``` python
>>> import apistar
>>> api = apistar.Client(open('schema.yml').read())
>>> c.request('ListThings')
[{'id': 1, 'name': 'thing1'}, {'id': 2, 'name': 'thing2'}]
```

TODO:

- [ ] Probably more unit tests
- [ ] Allow setting a custom operation ID on views with an attribute?
- [ ] Raise exceptions when operation IDs are not unique across a schema

Fixes #6542