### PR TITLE
Fix requestBody not wrapped in a schema in OpenAPI

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -800,6 +800,9 @@ class OpenAPIAutoSchema(ViewInspector):
 
         return {
             '200': {
-                'content': {ct: content for ct in self.content_types}
+                'content': {
+                    ct: {'schema': content}
+                    for ct in self.content_types
+                }
             }
         }

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -770,7 +770,10 @@ class OpenAPIAutoSchema(ViewInspector):
                 del content['properties'][name]
 
         return {
-            'content': {ct: content for ct in self.content_types}
+            'content': {
+                ct: {'schema': content}
+                for ct in self.content_types
+            }
         }
 
     def _get_responses(self, path, method):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -105,8 +105,8 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         request_body = inspector._get_request_body(path, method)
-        assert request_body['content']['application/json']['required'] == ['text']
-        assert list(request_body['content']['application/json']['properties'].keys()) == ['text']
+        assert request_body['content']['application/json']['schema']['required'] == ['text']
+        assert list(request_body['content']['application/json']['schema']['properties'].keys()) == ['text']
 
     def test_response_body_generation(self):
         path = '/'

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -59,7 +59,7 @@ class TestOperationIntrospection(TestCase):
         assert operation == {
             'operationId': 'ListExamples',
             'parameters': [],
-            'responses': {'200': {'content': {'application/json': {}}}},
+            'responses': {'200': {'content': {'application/json': {'schema': {}}}}},
         }
 
     def test_path_with_id_parameter(self):
@@ -128,8 +128,8 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         responses = inspector._get_responses(path, method)
-        assert responses['200']['content']['application/json']['required'] == ['text']
-        assert list(responses['200']['content']['application/json']['properties'].keys()) == ['text']
+        assert responses['200']['content']['application/json']['schema']['required'] == ['text']
+        assert list(responses['200']['content']['application/json']['schema']['properties'].keys()) == ['text']
 
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')


### PR DESCRIPTION
Fixes #6562, on the OpenAPI generation PR #6532 by @carltongibson: wraps schemas in the `requestBody` property on an operation in a `schema` key.

``` yaml
requestBody:
  content:
    application/json:
      schema:
        properties: ...
        required: ...
```