### PR TITLE
Make Markdown 2.6 the minimum compatible version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ each Python and Django series.
 The following packages are optional:
 
 * [coreapi][coreapi] (1.32.0+) - Schema generation support.
-* [Markdown][markdown] (2.1.0+) - Markdown support for the browsable API.
+* [Markdown][markdown] (2.6.0+) - Markdown support for the browsable API.
 * [django-filter][django-filter] (1.0.1+) - Filtering support.
 * [django-crispy-forms][django-crispy-forms] - Improved HTML display for filtering.
 * [django-guardian][django-guardian] (1.1.1+) - Object level permissions support.

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '3.9.2'
+__version__ = '3.9.2.2'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2019 Encode OSS Ltd'

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '3.9.2.2'
+__version__ = '3.9.2'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2019 Encode OSS Ltd'

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -184,10 +184,12 @@ if 'patch' not in View.http_method_names:
 try:
     import markdown
 
-    if markdown.version <= '2.2':
+    if not hasattr(markdown, '__version__') and markdown.version <= '2.2':
         HEADERID_EXT_PATH = 'headerid'
         LEVEL_PARAM = 'level'
-    elif markdown.version < '2.6':
+    elif not hasattr(markdown, '__version__') or (
+                type(markdown.__version__) != type('') and markdown.version < '2.6'
+            ):
         HEADERID_EXT_PATH = 'markdown.extensions.headerid'
         LEVEL_PARAM = 'level'
     else:

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -180,21 +180,12 @@ if 'patch' not in View.http_method_names:
     View.http_method_names = View.http_method_names + ['patch']
 
 
-# Markdown is optional
+# Markdown is optional (version 2.6+ required)
 try:
     import markdown
 
-    if not hasattr(markdown, '__version__') and markdown.version <= '2.2':
-        HEADERID_EXT_PATH = 'headerid'
-        LEVEL_PARAM = 'level'
-    elif ((not hasattr(markdown, '__version__')
-           ) or ((not isinstance(markdown.__version__, type(''))
-                  ) and markdown.version < '2.6')):
-        HEADERID_EXT_PATH = 'markdown.extensions.headerid'
-        LEVEL_PARAM = 'level'
-    else:
-        HEADERID_EXT_PATH = 'markdown.extensions.toc'
-        LEVEL_PARAM = 'baselevel'
+    HEADERID_EXT_PATH = 'markdown.extensions.toc'
+    LEVEL_PARAM = 'baselevel'
 
     def apply_markdown(text):
         """

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -187,9 +187,9 @@ try:
     if not hasattr(markdown, '__version__') and markdown.version <= '2.2':
         HEADERID_EXT_PATH = 'headerid'
         LEVEL_PARAM = 'level'
-    elif not hasattr(markdown, '__version__') or (
-                type(markdown.__version__) != type('') and markdown.version < '2.6'
-            ):
+    elif (not hasattr(markdown, '__version__') or
+            (isinstance(markdown.__version__, type(''))
+            and markdown.version < '2.6')):
         HEADERID_EXT_PATH = 'markdown.extensions.headerid'
         LEVEL_PARAM = 'level'
     else:

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -188,8 +188,8 @@ try:
         HEADERID_EXT_PATH = 'headerid'
         LEVEL_PARAM = 'level'
     elif (not hasattr(markdown, '__version__') or
-            (isinstance(markdown.__version__, type(''))
-            and markdown.version < '2.6')):
+          (isinstance(markdown.__version__, type(''))
+           and markdown.version < '2.6')):
         HEADERID_EXT_PATH = 'markdown.extensions.headerid'
         LEVEL_PARAM = 'level'
     else:

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -187,9 +187,9 @@ try:
     if not hasattr(markdown, '__version__') and markdown.version <= '2.2':
         HEADERID_EXT_PATH = 'headerid'
         LEVEL_PARAM = 'level'
-    elif (not hasattr(markdown, '__version__') or
-          (isinstance(markdown.__version__, type(''))
-           and markdown.version < '2.6')):
+    elif ((not hasattr(markdown, '__version__')
+           ) or ((not isinstance(markdown.__version__, type(''))
+                  ) and markdown.version < '2.6')):
         HEADERID_EXT_PATH = 'markdown.extensions.headerid'
         LEVEL_PARAM = 'level'
     else:


### PR DESCRIPTION
```
The latest version of Markdown now displays a deprecation warning if
accessing markdown.version, by careful use of checking the type and
existence of markdown.__version__ it is possible to handle the changes
to markdown over various releases where markdown.__version__ at first
did not exist before being a module and finally being just a string.
```