### PR TITLE
Docs sidebar improvements (#5638)

### DIFF
--- a/rest_framework/static/rest_framework/docs/css/base.css
+++ b/rest_framework/static/rest_framework/docs/css/base.css
@@ -30,7 +30,7 @@ pre.highlight code {
 
 .sidebar {
   overflow: auto;
-  font-family: verdana;
+  font-family: verdana, sans-serif;
   font-size: 12px;
   font-weight: 200;
   background-color: #2e353d;

--- a/rest_framework/static/rest_framework/docs/css/base.css
+++ b/rest_framework/static/rest_framework/docs/css/base.css
@@ -111,7 +111,11 @@ pre.highlight code {
   border: none;
   border-bottom: 1px solid #23282e;
   margin-left: 0px;
-  text-indent: 10px;
+  line-height: 1.4;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-right: 10px;
+  padding-left: 25px;
 }
 
 .sidebar .menu-list ul .sub-menu li:hover,
@@ -128,11 +132,14 @@ pre.highlight code {
 .sidebar .menu-list ul .sub-menu li a:before,
 .sidebar .menu-list li .sub-menu li a:before {
   font-family: FontAwesome;
+  font-size: 14px;
+  font-weight: bold;
   content: "\f105";
-  display: inline-block;
-  padding-left: 10px;
-  padding-right: 10px;
+  display: inline;
   vertical-align: middle;
+  padding-left: 0;
+  padding-right: 7px;
+  margin-left: -12px;
 }
 
 .sidebar .menu-list li {


### PR DESCRIPTION
## Description

This PR tackles #5638, with a different approach: make the sidebar look good with the default size even if the endpoints names are long.
We could make it resizable if still needed.

Also contains a fallback font when Verdana is missing (`sans-serif`).

Done in pair with @ewjoachim
We also thought about other ideas to improve the sidebar but @tomchristie said there is going to be change with API star.  