### PR TITLE
 Fix CursorPagination when objects get deleted between calls (#6504) 

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -589,7 +589,7 @@ class CursorPagination(BasePagination):
         if not self.has_next:
             return None
 
-        if self.cursor and self.cursor.reverse and self.cursor.offset != 0:
+        if self.page and self.cursor and self.cursor.reverse and self.cursor.offset != 0:
             # If we're reversing direction and we have an offset cursor
             # then we cannot use the first position we find as a marker.
             compare = self._get_position_from_instance(self.page[-1], self.ordering)
@@ -597,12 +597,14 @@ class CursorPagination(BasePagination):
             compare = self.next_position
         offset = 0
 
+        has_item_with_unique_position = False
         for item in reversed(self.page):
             position = self._get_position_from_instance(item, self.ordering)
             if position != compare:
                 # The item in this position and the item following it
                 # have different positions. We can use this position as
                 # our marker.
+                has_item_with_unique_position = True
                 break
 
             # The item in this position has the same position as the item
@@ -611,7 +613,7 @@ class CursorPagination(BasePagination):
             compare = position
             offset += 1
 
-        else:
+        if self.page and not has_item_with_unique_position:
             # There were no unique positions in the page.
             if not self.has_previous:
                 # We are on the first page.
@@ -630,6 +632,9 @@ class CursorPagination(BasePagination):
                 offset = self.cursor.offset + self.page_size
                 position = self.previous_position
 
+        if not self.page:
+            position = self.next_position
+
         cursor = Cursor(offset=offset, reverse=False, position=position)
         return self.encode_cursor(cursor)
 
@@ -637,7 +642,7 @@ class CursorPagination(BasePagination):
         if not self.has_previous:
             return None
 
-        if self.cursor and not self.cursor.reverse and self.cursor.offset != 0:
+        if self.page and self.cursor and not self.cursor.reverse and self.cursor.offset != 0:
             # If we're reversing direction and we have an offset cursor
             # then we cannot use the first position we find as a marker.
             compare = self._get_position_from_instance(self.page[0], self.ordering)
@@ -645,12 +650,14 @@ class CursorPagination(BasePagination):
             compare = self.previous_position
         offset = 0
 
+        has_item_with_unique_position = False
         for item in self.page:
             position = self._get_position_from_instance(item, self.ordering)
             if position != compare:
                 # The item in this position and the item following it
                 # have different positions. We can use this position as
                 # our marker.
+                has_item_with_unique_position = True
                 break
 
             # The item in this position has the same position as the item
@@ -659,7 +666,7 @@ class CursorPagination(BasePagination):
             compare = position
             offset += 1
 
-        else:
+        if self.page and not has_item_with_unique_position:
             # There were no unique positions in the page.
             if not self.has_next:
                 # We are on the final page.
@@ -677,6 +684,9 @@ class CursorPagination(BasePagination):
                 # where we end up skipping back a few extra items.
                 offset = 0
                 position = self.next_position
+
+        if not self.page:
+            position = self.previous_position
 
         cursor = Cursor(offset=offset, reverse=True, position=position)
         return self.encode_cursor(cursor)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -634,6 +634,52 @@ class CursorPaginationTestsMixin:
 
         assert isinstance(self.pagination.to_html(), six.text_type)
 
+    def test_cursor_pagination_current_page_empty_forward(self):
+        # Regression test for #6504
+        self.pagination.base_url = "/"
+
+        # We have a cursor on the element at position 100, but this element doesn't exist
+        # anymore.
+        cursor = pagination.Cursor(reverse=False, offset=0, position=100)
+        url = self.pagination.encode_cursor(cursor)
+        self.pagination.base_url = "/"
+
+        # Loading the page with this cursor doesn't crash
+        (previous, current, next, previous_url, next_url) = self.get_pages(url)
+
+        # The previous url doesn't crash either
+        (previous, current, next, previous_url, next_url) = self.get_pages(previous_url)
+
+        # And point to things that are not completely off.
+        assert previous == [7, 7, 7, 8, 9]
+        assert current == [9, 9, 9, 9, 9]
+        assert next == []
+        assert previous_url is not None
+        assert next_url is not None
+
+    def test_cursor_pagination_current_page_empty_reverse(self):
+        # Regression test for #6504
+        self.pagination.base_url = "/"
+
+        # We have a cursor on the element at position 100, but this element doesn't exist
+        # anymore.
+        cursor = pagination.Cursor(reverse=True, offset=0, position=100)
+        url = self.pagination.encode_cursor(cursor)
+        self.pagination.base_url = "/"
+
+        # Loading the page with this cursor doesn't crash
+        (previous, current, next, previous_url, next_url) = self.get_pages(url)
+
+        # The previous url doesn't crash either
+        (previous, current, next, previous_url, next_url) = self.get_pages(next_url)
+
+        # And point to things that are not completely off.
+        assert previous == [7, 7, 7, 7, 8]
+        assert current == []
+        assert next is None
+        assert previous_url is not None
+        assert next_url is None
+
     def test_cursor_pagination_with_page_size(self):
         (previous, current, next, previous_url, next_url) = self.get_pages('/?page_size=20')
 


### PR DESCRIPTION
Pair-coded with ❤️  and with the excellent @tomquinonero, at the DjangoCon Europe 2019 Copenhagen. Thank you 👍 ✨ 

## Description

Fixes #6504. This is a bug in the CursorPagination algorithm, occuring when the current page is based on a "position" for which there is no corresponding element (a.k.a page is empty), it will generate offset-based cursors for previous (and in some cases next) pages, and following those links crash.

## Fix

The fix is in 3 parts:
- Make sure to generate correct links: offset-based pagination should only be used when several consecutive items have the same `position`. One could argue that if the page is empty, all its elements are indeed equal, but it's obviously not the intended behaviour.
- Make sure an incorrect offset doesn't crash
- Make sure that the pages that used to crash now (work and) give appropriate cursors: if the page is empty, then cursors should simply use the current position.

I'm not sure I made the correct fix. I've made a fix, but I have not 100% confidence in this.

## Test

Re-using the current testing architecture to test for this was hard, so the closest to doing what I described in the Reproduction steps below in the tests was to manually craft a cursor based on a non-existing position. It did trigger the bug (as you can check if you want, the repro being in a previous commit from the actual fix), but I have to admit I'm not really sure about the values of "current", "previous" and "next", and I couldn't really test for the cursor values the way I'd have liked to.

## Comments regarding the code:

It's out-of-scope for this PR, but I've found the logic of cursor based pagination a bit hard to follow and especially hard to test. If I were to make a PR to implement a more functional version where the logic would be separated from the url-generation features and the ORM fetching, so as to unit-test extensively the logic, would it be accepted ? It would be quite a few changes in a potentially complex part of the code, but I'm afraid the current implementation may have other corner cases lurking around, especially when objects are deleted between calls.

## Reproduction

How I was able to reproduce locally: 

```python
REST_FRAMEWORK = {
    "DEFAULT_PAGINATION_CLASS": "app.pagination.Pagination",
    "PAGE_SIZE": 5,
}

class Book(models.Model):
    title = models.CharField(max_length=20)
    

class BookSerializer(serializers.ModelSerializer):
    class Meta:
        model = Book
        fields = ("id", "title")


class BookViewSet(viewsets.ModelViewSet):
    """
    A simple ViewSet for listing or retrieving users.
    """

    serializer_class = BookSerializer
    queryset = Book.objects.all()


class Pagination(pagination.CursorPagination):
    ordering = "id"

router = DefaultRouter()
router.register(r"books", BookViewSet, basename="book")

urlpatterns = [path("admin/", admin.site.urls)] + router.urls
```
Then:
```python
In [26]: for i in range(10):
...:     Book.objects.create(title=str(i))
```

`runserver`, go to `/books`, go to 2nd page

```python
In [29]: Book.objects.filter(pk__in=Book.objects.all().order_by("pk")[4:].values
    ...: ("pk")).delete()
Out[29]: (10, {'app.Book': 10})
```

Now in your browser, (reload the page if you want), follow link to the previous page, observe the traceback.

After this patch, no more error, the previous page displays the last elements.