### PR TITLE
Removed references to django-crispy-forms

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,6 @@ The following packages are optional:
 * [coreapi][coreapi] (1.32.0+) - Schema generation support.
 * [Markdown][markdown] (2.1.0+) - Markdown support for the browsable API.
 * [django-filter][django-filter] (1.0.1+) - Filtering support.
-* [django-crispy-forms][django-crispy-forms] - Improved HTML display for filtering.
 * [django-guardian][django-guardian] (1.1.1+) - Object level permissions support.
 
 ## Installation
@@ -239,7 +238,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 [coreapi]: https://pypi.org/project/coreapi/
 [markdown]: https://pypi.org/project/Markdown/
 [django-filter]: https://pypi.org/project/django-filter/
-[django-crispy-forms]: https://github.com/maraujop/django-crispy-forms
 [django-guardian]: https://github.com/django-guardian/django-guardian
 [index]: .
 [oauth1-section]: api-guide/authentication/#django-rest-framework-oauth

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -150,13 +150,6 @@ except ImportError:
     yaml = None
 
 
-# django-crispy-forms is optional
-try:
-    import crispy_forms
-except ImportError:
-    crispy_forms = None
-
-
 # requests is optional
 try:
     import requests


### PR DESCRIPTION
django-crispy-forms isn't used anymore