### PR TITLE
Fix private attributes ignore in documentation

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -965,7 +965,7 @@ The following class is an example of a generic serializer that can handle coerci
         def to_representation(self, obj):
             for attribute_name in dir(obj):
                 attribute = getattr(obj, attribute_name)
-                if attribute_name('_'):
+                if attribute_name.startswith('_'):
                     # Ignore private attributes.
                     pass
                 elif hasattr(attribute, '__call__'):

--- a/docs/community/3.0-announcement.md
+++ b/docs/community/3.0-announcement.md
@@ -523,7 +523,7 @@ The following class is an example of a generic serializer that can handle coerci
         def to_representation(self, obj):
             for attribute_name in dir(obj):
                 attribute = getattr(obj, attribute_name)
-                if attribute_name('_'):
+                if attribute_name.startswith('_'):
                     # Ignore private attributes.
                     pass
                 elif hasattr(attribute, '__call__'):


### PR DESCRIPTION
Description
---
Fix an error in documentation example. 
Add `.startswith` method to check that `attribute_name` is a private attribute and ignore it.
Without `.startswith` method calling `attribute_name('_')` raises `TypeError: 'str' object is not callable` exception.