### PR TITLE
Change semantic of OR of two permission classes

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -81,8 +81,9 @@ class OR:
 
     def has_object_permission(self, request, view, obj):
         return (
-            self.op1.has_object_permission(request, view, obj) or
-            self.op2.has_object_permission(request, view, obj)
+            (self.op1.has_permission(request, view) and self.op1.has_object_permission(request, view, obj))
+            or
+            (self.op2.has_permission(request, view) and self.op2.has_object_permission(request, view, obj))
         )
 
 

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -8,7 +8,7 @@ from django.utils import six
 
 from rest_framework import exceptions
 
-SAFE_METHODS = ('GET', 'HEAD', 'OPTIONS')
+SAFE_METHODS = ('GET', 'HEAD','OPTIONS')
 
 
 class OperationHolderMixin:

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -8,7 +8,7 @@ from django.utils import six
 
 from rest_framework import exceptions
 
-SAFE_METHODS = ('GET', 'HEAD','OPTIONS')
+SAFE_METHODS = ('GET', 'HEAD', 'OPTIONS')
 
 
 class OperationHolderMixin:

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -81,9 +81,11 @@ class OR:
 
     def has_object_permission(self, request, view, obj):
         return (
-            (self.op1.has_permission(request, view) and self.op1.has_object_permission(request, view, obj))
-            or
-            (self.op2.has_permission(request, view) and self.op2.has_object_permission(request, view, obj))
+            self.op1.has_permission(request, view)
+            and self.op1.has_object_permission(request, view, obj)
+        ) or (
+            self.op2.has_permission(request, view)
+            and self.op2.has_object_permission(request, view, obj)
         )
 
 


### PR DESCRIPTION
The original semantic of OR is defined as: the request pass either of the two has_permission() check, and pass either of the two has_object_permission() check, which could lead to situations that a request passes has_permission() but fails on has_object_permission() of Permission Class A, fails has_permission() but passes has_object_permission() of Permission Class B, passes the OR permission check. This should not be the desired permission check semantic in applications, because such a request should fail on either Permission Class (on Django object permission) alone, but passes the OR or the two.

My code fix this by changing the semantic so that the request has to pass either class's has_permission() and has_object_permission() to get the Django object permission of the OR check.

Previous related issue: #6402 