### PR TITLE
Use the get_username() method instead of the username attribute

### DIFF
--- a/rest_framework/templates/rest_framework/docs/auth/session.html
+++ b/rest_framework/templates/rest_framework/docs/auth/session.html
@@ -12,7 +12,7 @@
     <div class="modal-body">
 
         {% if user.is_authenticated %}
-          <h4 class="text-center">You are logged in as {{ user.username }}.</h4>
+          <h4 class="text-center">You are logged in as {{ user.get_username }}.</h4>
         {% else %}
 
           <div class="text-center">


### PR DESCRIPTION
Use the get_username() method instead of the username attribute as recommended in Django

Cf. https://docs.djangoproject.com/en/dev/ref/contrib/auth/#django.contrib.auth.models.User.get_username