### PR TITLE
Update version and release notes for v3.9.3.

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -42,6 +42,16 @@ You can determine your currently installed version using `pip show`:
 
 ### 3.9.2
 
+**Date**: [29th April 2019]
+
+This is the last Django REST Framework release that will support Python 2.
+Be sure to upgrade to Python 3 before upgrading to Django REST Framework 3.10.
+
+* Adjusted the compat check for django-guardian to allow the last guardian
+  version (v1.4.9) compatible with Python 2. [#6613][gh6613]
+
+### 3.9.2
+
 **Date**: [3rd March 2019][3.9.1-milestone]
 
 * Routers: invalidate `_urls` cache on `register()` [#6407][gh6407]
@@ -2106,3 +2116,6 @@ For older release notes, [please see the version 2.x documentation][old-release-
 [gh6340]: https://github.com/encode/django-rest-framework/issues/6340
 [gh6416]: https://github.com/encode/django-rest-framework/issues/6416
 [gh6407]: https://github.com/encode/django-rest-framework/issues/6407
+
+<!-- 3.9.3 -->
+[gh6613]: https://github.com/encode/django-rest-framework/issues/6613

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '3.9.2'
+__version__ = '3.9.3'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2019 Encode OSS Ltd'


### PR DESCRIPTION
Final release before dropping Python 2. 

- [x] Ensure the pull request increments the version to `*.*.*` in [`restframework/__init__.py`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/__init__.py).
- [x] Confirm with @tomchristie that release is finalized and ready to go.
- [x] Ensure that release date is included in pull request.
- [ ] Merge the release pull request.
- [ ] Push the package to PyPI with `./setup.py publish`.
- [ ] Tag the release, with `git tag -a *.*.* -m 'version *.*.*'; git push --tags`.
- [ ] Deploy the documentation with `mkdocs gh-deploy`.
- [ ] Make a release announcement on the [discussion group](https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework).
- [ ] Make a release announcement on twitter.