### PR TITLE
Remove unnecessary assignments immediately before a return statement

### DIFF
--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -83,8 +83,7 @@ class FormParser(BaseParser):
         """
         parser_context = parser_context or {}
         encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
-        data = QueryDict(stream.read(), encoding=encoding)
-        return data
+        return QueryDict(stream.read(), encoding=encoding)
 
 
 class MultiPartParser(BaseParser):

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -684,7 +684,7 @@ class BrowsableAPIRenderer(BaseRenderer):
             csrf_header_name = csrf_header_name[5:]
         csrf_header_name = csrf_header_name.replace('_', '-')
 
-        context = {
+        return {
             'content': self.get_content(renderer, data, accepted_media_type, renderer_context),
             'code_style': pygments_css(self.code_style),
             'view': view,
@@ -720,7 +720,6 @@ class BrowsableAPIRenderer(BaseRenderer):
             'csrf_cookie_name': csrf_cookie_name,
             'csrf_header_name': csrf_header_name
         }
-        return context
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         """

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -185,9 +185,7 @@ class EndpointEnumerator(object):
                 )
                 api_endpoints.extend(nested_endpoints)
 
-        api_endpoints = sorted(api_endpoints, key=endpoint_ordering)
-
-        return api_endpoints
+        return sorted(api_endpoints, key=endpoint_ordering)
 
     def get_path_from_regex(self, path_regex):
         """
@@ -196,8 +194,7 @@ class EndpointEnumerator(object):
         path = simplify_regex(path_regex)
 
         # Strip Django 2.0 convertors as they are incompatible with uritemplate format
-        path = re.sub(_PATH_PARAMETER_COMPONENT_RE, r'{\g<parameter>}', path)
-        return path
+        return re.sub(_PATH_PARAMETER_COMPONENT_RE, r'{\g<parameter>}', path)
 
     def should_include_endpoint(self, path, callback):
         """

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -436,8 +436,7 @@ class AutoSchema(ViewInspector):
         by_name = OrderedDict((f.name, f) for f in fields)
         for f in update_with:
             by_name[f.name] = f
-        fields = list(by_name.values())
-        return fields
+        return list(by_name.values())
 
     def get_encoding(self, path, method):
         """

--- a/rest_framework/utils/representation.py
+++ b/rest_framework/utils/representation.py
@@ -45,9 +45,7 @@ def smart_repr(value):
     # <django.core.validators.RegexValidator object at 0x1047af050>
     # Should be presented as
     # <django.core.validators.RegexValidator object>
-    value = re.sub(' at 0x[0-9A-Fa-f]{4,32}>', '>', value)
-
-    return value
+    return re.sub(' at 0x[0-9A-Fa-f]{4,32}>', '>', value)
 
 
 def field_repr(field, force_many=False):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -79,8 +79,7 @@ class MockView(APIView):
     renderer_classes = (RendererA, RendererB)
 
     def get(self, request, **kwargs):
-        response = Response(DUMMYCONTENT, status=DUMMYSTATUS)
-        return response
+        return Response(DUMMYCONTENT, status=DUMMYSTATUS)
 
 
 class MockGETView(APIView):


### PR DESCRIPTION
Cleans up the pattern:

    ...
    myvar = <expression>
    return myvar

To:

    ...
    return <expression>