### PR TITLE
Add project_urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,11 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
-    ]
+    ],
+    project_urls={
+        'Funding': 'https://fund.django-rest-framework.org/topics/funding/',
+        'Source': 'https://github.com/encode/django-rest-framework',
+    },
 )
 
 # (*) Please direct queries to the discussion group, rather than to me directly


### PR DESCRIPTION
## Description

Add extra URLs that will show up on PyPI.  See Django for an example:
- https://pypi.org/project/Django/
- https://github.com/django/django/blob/6866c91b638de5368c18713fa851bfe56253ea55/setup.py#L110-L115