### PR TITLE
Remove unnecessary bytes() calls

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -88,7 +88,7 @@ class JSONRenderer(BaseRenderer):
         Render `data` into JSON, returning a bytestring.
         """
         if data is None:
-            return bytes()
+            return b''
 
         renderer_context = renderer_context or {}
         indent = self.get_indent(accepted_media_type, renderer_context)

--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -73,7 +73,7 @@ class Response(SimpleTemplateResponse):
                 'renderer returned unicode, and did not specify '
                 'a charset value.'
             )
-            return bytes(ret.encode(charset))
+            return ret.encode(charset)
 
         if not ret:
             del self['Content-Type']

--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -185,7 +185,7 @@ class APIRequestFactory(DjangoRequestFactory):
 
             # Coerce text to bytes if required.
             if isinstance(ret, str):
-                ret = bytes(ret.encode(renderer.charset))
+                ret = ret.encode(renderer.charset)
 
         return ret, content_type
 


### PR DESCRIPTION
- Use a simpler literal for an empty bytes object.
- `.encode()` always returns a new immutable bytes object, no need to coerce it a 2nd time.