### PR TITLE
Fix Markdown version deprecation warning

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -148,10 +148,15 @@ if 'patch' not in View.http_method_names:
 try:
     import markdown
 
-    if markdown.version <= '2.2':
+    if 'version' in dir(markdown):
+        markdown_version = markdown.version  # prior to 3.0 release
+    else:
+        markdown_version = markdown.__version__
+
+    if markdown_version <= '2.2':
         HEADERID_EXT_PATH = 'headerid'
         LEVEL_PARAM = 'level'
-    elif markdown.version < '2.6':
+    elif markdown_version < '2.6':
         HEADERID_EXT_PATH = 'markdown.extensions.headerid'
         LEVEL_PARAM = 'level'
     else:


### PR DESCRIPTION
The `Markdown` package deprecated `markdown.version` replacing it with `markdown.__version__` in the [3.0 release](https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/release-3.0.md#markdownversion-and-markdownversion_info-deprecated) (addressed in [this PR](https://github.com/Python-Markdown/markdown/pull/740)). This fixes this deprecation warning I was getting when running pytest on my project using `djangorestframework==3.9.3` with `markdown==3.1` installed:
```
/usr/local/lib/python2.7/site-packages/rest_framework/test.py:21: in <module>
    from rest_framework.compat import coreapi, requests
/usr/local/lib/python2.7/site-packages/rest_framework/compat.py:192: in <module>
    if markdown.version <= '2.2':
/usr/local/lib/python2.7/site-packages/markdown/pep562.py:241: in __getattr__
    return self._get_attr(name)
/usr/local/lib/python2.7/site-packages/markdown/__init__.py:83: in __getattr__
    stacklevel=(3 if PY37 else 4)
E   DeprecationWarning: 'version' is deprecated. Use '__version__' instead.
```
The tests passed for both `markdown==3.1` and `markdown==2.6.11`