### PR TITLE
Remove unnecessary compatibility shims from rest_framework/compat.py

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -3,7 +3,6 @@ The `compat` module provides support for backwards compatibility with older
 versions of Django/Python, and compatibility wrappers around optional packages.
 """
 import sys
-from collections.abc import Mapping, MutableMapping  # noqa
 
 from django.conf import settings
 from django.core import validators

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -6,6 +6,7 @@ import inspect
 import re
 import uuid
 from collections import OrderedDict
+from collections.abc import Mapping
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -30,7 +31,7 @@ from pytz.exceptions import InvalidTimeError
 
 from rest_framework import ISO_8601
 from rest_framework.compat import (
-    Mapping, MaxLengthValidator, MaxValueValidator, MinLengthValidator,
+    MaxLengthValidator, MaxValueValidator, MinLengthValidator,
     MinValueValidator, ProhibitNullCharactersValidator
 )
 from rest_framework.exceptions import ErrorDetail, ValidationError

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -14,6 +14,7 @@ import copy
 import inspect
 import traceback
 from collections import OrderedDict
+from collections.abc import Mapping
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -25,7 +26,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import Mapping, postgres_fields
+from rest_framework.compat import postgres_fields
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.fields import get_error_detail, set_value
 from rest_framework.settings import api_settings

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
+from collections.abc import MutableMapping
 
 from django.utils.encoding import force_text
 
-from rest_framework.compat import MutableMapping
 from rest_framework.utils import json
 
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,5 +1,6 @@
 import re
 from collections import OrderedDict
+from collections.abc import MutableMapping
 
 import pytest
 from django.conf.urls import include, url
@@ -12,7 +13,7 @@ from django.utils.safestring import SafeText
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import permissions, serializers, status
-from rest_framework.compat import MutableMapping, coreapi
+from rest_framework.compat import coreapi
 from rest_framework.decorators import action
 from rest_framework.renderers import (
     AdminRenderer, BaseRenderer, BrowsableAPIRenderer, DocumentationRenderer,

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -2,12 +2,12 @@ import inspect
 import pickle
 import re
 from collections import ChainMap
+from collections.abc import Mapping
 
 import pytest
 from django.db import models
 
 from rest_framework import exceptions, fields, relations, serializers
-from rest_framework.compat import Mapping
 from rest_framework.fields import Field
 
 from .models import (


### PR DESCRIPTION
For Python 3, collections.abc.Mapping and collections.abc.MutableMapping
are always available from the stdlib.