### PR TITLE
Remove pointless test

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -386,23 +386,6 @@ class TestIncorrectlyConfigured:
         )
 
 
-class TestUnicodeRepr:
-    def test_repr(self):
-        class ExampleSerializer(serializers.Serializer):
-            example = serializers.CharField()
-
-        class ExampleObject:
-            def __init__(self):
-                self.example = '한국'
-
-            def __repr__(self):
-                return repr(self.example)
-
-        instance = ExampleObject()
-        serializer = ExampleSerializer(instance)
-        repr(serializer)  # Should not error.
-
-
 class TestNotRequiredOutput:
     def test_not_required_output_for_dict(self):
         """


### PR DESCRIPTION
The test tested Python functionality, not django-rest-framework
functionality. That is best left to the Python test suite.