### PR TITLE
Replace all usage ugettext functions with the non-u versions

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -6,7 +6,7 @@ import binascii
 
 from django.contrib.auth import authenticate, get_user_model
 from django.middleware.csrf import CsrfViewMiddleware
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import HTTP_HEADER_ENCODING, exceptions
 

--- a/rest_framework/authtoken/apps.py
+++ b/rest_framework/authtoken/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AuthTokenConfig(AppConfig):

--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -3,7 +3,7 @@ import os
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Token(models.Model):

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import authenticate
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -8,8 +8,8 @@ import math
 
 from django.http import JsonResponse
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from rest_framework import status
 from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
@@ -230,9 +230,9 @@ class Throttled(APIException):
             wait = math.ceil(wait)
             detail = ' '.join((
                 detail,
-                force_text(ungettext(self.extra_detail_singular.format(wait=wait),
-                                     self.extra_detail_plural.format(wait=wait),
-                                     wait))))
+                force_text(ngettext(self.extra_detail_singular.format(wait=wait),
+                                    self.extra_detail_plural.format(wait=wait),
+                                    wait))))
         self.wait = wait
         super().__init__(detail, code)
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -25,7 +25,7 @@ from django.utils.formats import localize_input, sanitize_separators
 from django.utils.functional import lazy
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.timezone import utc
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from pytz.exceptions import InvalidTimeError
 
 from rest_framework import ISO_8601

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -12,7 +12,7 @@ from django.db.models.constants import LOOKUP_SEP
 from django.db.models.sql.constants import ORDER_PATTERN
 from django.template import loader
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import RemovedInDRF310Warning
 from rest_framework.compat import (

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -10,7 +10,7 @@ from django.core.paginator import InvalidPage
 from django.core.paginator import Paginator as DjangoPaginator
 from django.template import loader
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.exceptions import NotFound

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -7,7 +7,7 @@ from django.db.models import Manager
 from django.db.models.query import QuerySet
 from django.urls import NoReverseMatch, Resolver404, get_script_prefix, resolve
 from django.utils.encoding import smart_text, uri_to_iri
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.fields import (
     Field, empty, get_attribute, is_simple_callable, iter_options

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -11,7 +11,7 @@ from weakref import WeakKeyDictionary
 
 from django.db import models
 from django.utils.encoding import force_text, smart_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import exceptions, serializers
 from rest_framework.compat import coreapi, coreschema, uritemplate

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -23,7 +23,7 @@ from django.db.models.fields import Field as DjangoModelField
 from django.db.models.fields import FieldDoesNotExist
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.compat import Mapping, postgres_fields
 from rest_framework.exceptions import ErrorDetail, ValidationError

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -7,7 +7,7 @@ object creation, and makes it possible to switch between using the implicit
 `ModelSerializer` class and an equivalent explicit `Serializer` class.
 """
 from django.db import DataError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
 from rest_framework.utils.representation import smart_repr

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -1,6 +1,6 @@
 import re
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import exceptions
 from rest_framework.compat import unicode_http_header

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class RESTFrameworkModel(models.Model):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 from django.test import RequestFactory, TestCase
 from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import (
     APIException, ErrorDetail, Throttled, _get_error_details, bad_request,

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -9,7 +9,7 @@ from django.http.request import HttpRequest
 from django.template import loader
 from django.test import TestCase, override_settings
 from django.utils.safestring import SafeText
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import permissions, serializers, status
 from rest_framework.compat import MutableMapping, coreapi


### PR DESCRIPTION
On Python 3, the ugettext functions are a simple aliases of their non-u
counterparts (the 'u' represents Python 2 unicode type). Starting with
Django 3.0, the u versions will be deprecated.

https://docs.djangoproject.com/en/dev/releases/3.0/#id2

> django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(),
> ungettext(), and ungettext_lazy() are deprecated in favor of the
> functions that they’re aliases for:
> django.utils.translation.gettext(), gettext_lazy(), gettext_noop(),
> ngettext(), and ngettext_lazy().