### PR TITLE
Fix BytesWarning in test_schemas.py

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1358,4 +1358,4 @@ def test_schema_handles_exception():
     response = schema_view(request)
     response.render()
     assert response.status_code == 403
-    assert "You do not have permission to perform this action." in str(response.content)
+    assert b"You do not have permission to perform this action." in response.content


### PR DESCRIPTION
When Python is run with the -b command line argument, the following
warning was previously emitted:

tests/test_schemas.py::test_schema_handles_exception
  .../django-rest-framework/tests/test_schemas.py:1361: BytesWarning: str() on a bytes instance
    assert "You do not have permission to perform this action." in str(response.content)

To fix this warning decode the bytes with an explicit encoding.

For details on the -b command line argument, see:

https://docs.python.org/3/using/cmdline.html#cmdoption-b