### PR TITLE
Incorrect attribute name makes documented example not work

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -127,7 +127,7 @@ Note that you can use both an overridden `.get_queryset()` and generic filtering
         """
         model = Product
         serializer_class = ProductSerializer
-        filterset_class = ProductFilter
+        filter_class = ProductFilter
 
         def get_queryset(self):
             user = self.request.user


### PR DESCRIPTION
Under heading `Overriding the initial queryset` the filter class is overridden which is documented as done by setting `filterset_class`. 
However under django_filters/rest_framework/backends.py in class `DjangoFilterBackend`, the method `get_filter_class` will use attribute `filter_class` instead. 

As a result, when trusting the documentation no filtering will take place at all.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
