### PR TITLE
date and date-time are string types with a format

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -255,14 +255,26 @@ class AutoSchema(ViewInspector):
                 'type': 'array',
             }
 
+        # DateField
+        if isinstance(field, serializers.DateField):
+            return {
+                'type': 'string',
+                'format': 'date'
+            }
+
+        # DateTimeField
+        if isinstance(field, serializers.DateTimeField):
+            return {
+                'type': 'string',
+                'format': 'date-time'
+            }
+
         # Simplest cases, default to 'string' type:
         FIELD_CLASS_SCHEMA_TYPE = {
             serializers.BooleanField: 'boolean',
             serializers.DecimalField: 'number',
             serializers.FloatField: 'number',
             serializers.IntegerField: 'integer',
-            serializers.DateField: 'date',
-            serializers.DateTimeField: 'date-time',
             serializers.JSONField: 'object',
             serializers.DictField: 'object',
         }


### PR DESCRIPTION
## Description

OAS 3.0 requires Date and DateTime types to be `type: string` with a `format: date` or `format: date-time`.

