### PR TITLE
docs: Fix rel=prev/next

### DIFF
--- a/docs_theme/nav.html
+++ b/docs_theme/nav.html
@@ -2,10 +2,10 @@
       <div class="navbar-inner">
         <div class="container-fluid">
           <a class="repo-link btn btn-primary btn-small" href="https://github.com/encode/django-rest-framework/tree/master">GitHub</a>
-          <a class="repo-link btn btn-inverse btn-small {% if not page.next_page %}disabled{% endif %}" rel="prev" {% if page.next_page %}href="{{ page.next_page.url }}"{% endif %}>
+          <a class="repo-link btn btn-inverse btn-small {% if not page.next_page %}disabled{% endif %}" rel="next" {% if page.next_page %}href="{{ page.next_page.url }}"{% endif %}>
             Next <i class="icon-arrow-right icon-white"></i>
           </a>
-          <a class="repo-link btn btn-inverse btn-small {% if not page.previous_page %}disabled{% endif %}" rel="next" {% if page.previous_page %}href="{{ page.previous_page.url }}"{% endif %}>
+          <a class="repo-link btn btn-inverse btn-small {% if not page.previous_page %}disabled{% endif %}" rel="prev" {% if page.previous_page %}href="{{ page.previous_page.url }}"{% endif %}>
             <i class="icon-arrow-left icon-white"></i> Previous
           </a>
           <a id="search_modal_show" class="repo-link btn btn-inverse btn-small" href="#mkdocs_search_modal" data-toggle="modal" data-target="#mkdocs_search_modal"><i class="icon-search icon-white"></i> Search</a>


### PR DESCRIPTION
`rel="prev"` should be set for the link which goes back to the previous page, `rel="next"` for the one which goes forward to the next page.

See e.g. https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types

cc @d0ugal who added those in b8aa7e0c34dc839a47b679aa2402d0f1b98704a0 (almost 5 years ago :wink:)