### PR TITLE
Fix nullable `source='*'` fields

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -493,6 +493,11 @@ class Field:
         if data is None:
             if not self.allow_null:
                 self.fail('null')
+            # Nullable `source='*'` fields should not be skipped when its named
+            # field is given a null value. This is because `source='*'` means
+            # the field is passed the entire object, which is not null.
+            elif self.source == '*':
+                return (False, None)
             return (True, None)
 
         return (False, data)


### PR DESCRIPTION
Fixes #3451, #5635, and #6609.

## Description

When a field like `CustomField(source='*', allow_null=True)` is attempting to validate a null value, the `Field.validate_empty_values()` method returns `(True, None)`. This indicates that further validation should be skipped. However, `set_value` breaks, because the empty `source_attrs` indicates that a dictionary should be provided, but the value returned from `validate_empty_values` is `None`. 

This an unusual edge case, but I'd argue it's valid. Although the given value may be null, `source='*'` indicates that the field is validating the whole object, not just the given value. If we decide *not* validating is the correct behavior, then `validate_empty_values` should at least return an empty dict.

## Other considerations

I'm not entirely sure what the behavior should be when `CustomField(required=False)` or `Serializer(partial=True)`. 