### PR TITLE
Pass through memo in __deepcopy__ as required by the docs

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -614,7 +614,7 @@ class Field:
             for item in self._args
         ]
         kwargs = {
-            key: (copy.deepcopy(value) if (key not in ('validators', 'regex')) else value)
+            key: (copy.deepcopy(value, memo) if (key not in ('validators', 'regex')) else value)
             for key, value in self._kwargs.items()
         }
         return self.__class__(*args, **kwargs)


### PR DESCRIPTION
This is needed to avoid problems with recursive loops. See
https://docs.python.org/3.7/library/copy.html
toward the end.
