### PR TITLE
Always add all requests to all throttling classes history

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -23,6 +23,9 @@ As with permissions and authentication, throttling in REST framework is always d
 Before running the main body of the view each throttle in the list is checked.
 If any throttle check fails an `exceptions.Throttled` exception will be raised, and the main body of the view will not run.
 
+**Note:** Prior to version 3.10, throttle checking stopped on the first failure encountered.
+This has been changed in 3.10 so that all throttles are checked.
+
 ## Setting the throttling policy
 
 The default throttling policy may be set globally, using the `DEFAULT_THROTTLE_CLASSES` and `DEFAULT_THROTTLE_RATES` settings.  For example.

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -38,6 +38,20 @@ You can determine your currently installed version using `pip show`:
 
 ---
 
+## 3.10.x series
+
+### 3.10.0
+
+**Date**: [?][3.10.0-milestone]
+
+* **Breaking Change**:  Always add all requests to all throttling classes history. [#6666][gh6666], [#6667][gh6667]
+
+    Following this change, the throttling classes based on `SimpleRateThrottle` (this includes `AnonRateThrottle`, `UserRateThrottle` and `ScopedRateThrottle`) will add all requests to their history, even ones that are being throttled. In order to maintain the old behaviour, change the implementation of `throttle_failure()` on the throttling classes you're using to only `return False`.
+
+    In addition, the `APIView`'s `check_throttles()` method is now calling `allow_request()` on each throttle even when one of them is already causing the current request to be throttled. The wait time returned is the largest from all failing throttles. Previously it would check them in order and raise the first time one would disallow the request. 
+
+    This punishes brute-forcing, rewarding clients that wait for the full duration of the suggested throttle wait time before making new requests, and also makes setting multiple throttling classes more useful as they all receive every request regardless of what is happening with the others.
+
 ## 3.9.x series
 
 ### 3.9.3

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -350,9 +350,13 @@ class APIView(View):
         Check if request should be throttled.
         Raises an appropriate exception if the request is throttled.
         """
+        throttle_durations = []
         for throttle in self.get_throttles():
             if not throttle.allow_request(request, self):
-                self.throttled(request, throttle.wait())
+                throttle_durations.append(throttle.wait())
+
+        if throttle_durations:
+            self.throttled(request, max(throttle_durations))
 
     def determine_version(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
## Description
Always add all requests to all throttling classes history

- Even when the request is going to fail because of the current throttle
- Even when another throttling class already failed the request

This punishes brute-forcing, rewarding clients that wait for the full duration of the suggested throttle wait time before making new requests, and also makes setting multiple throttling classes more efficient/useful.

Fixes #6666
Fixes #6667

(The 2 issues are different but it was simpler to do both in a single PR to avoid test conflicts)