### PR TITLE
add OpenAPI schema initialization

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -327,6 +327,33 @@ May be used to pass a canonical URL for the schema.
         url='https://www.example.org/api/'
     )
 
+#### `openapi_schema`
+
+May be used to pass a static initial OpenAPI schema document, typically
+containing top-level OpenAPI fields. The schema document will
+be added to by the AutoSchema generator.
+
+    schema_view = get_schema_view(
+        openapi_schema = {
+            'info': {
+                'title': 'my title',
+                'version': '1.0',
+                'contact': {
+                    'name': 'API Support',
+                    'url': 'http://www.example.com/support',
+                    'email': 'support@example.com'
+                },
+                'license': {
+                    'name': 'Apache 2.0',
+                    'url': 'https://www.apache.org/licenses/LICENSE-2.0.html'
+            }.
+            'servers': [
+                {'url': 'https://api.example.com'}
+            ]
+        }
+    )
+
+
 #### `urlconf`
 
 A string representing the import path to the URL conf that you want

--- a/rest_framework/schemas/__init__.py
+++ b/rest_framework/schemas/__init__.py
@@ -28,7 +28,7 @@ from .coreapi import AutoSchema, ManualSchema, SchemaGenerator  # noqa
 
 
 def get_schema_view(
-        title=None, url=None, description=None, urlconf=None, renderer_classes=None,
+        title=None, url=None, description=None, openapi_schema=None, urlconf=None, renderer_classes=None,
         public=False, patterns=None, generator_class=None,
         authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
         permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
@@ -41,10 +41,17 @@ def get_schema_view(
         else:
             generator_class = openapi.SchemaGenerator
 
-    generator = generator_class(
-        title=title, url=url, description=description,
-        urlconf=urlconf, patterns=patterns,
-    )
+    if isinstance(generator_class, openapi.SchemaGenerator):
+        generator = generator_class(
+            title=title, url=url, description=description,
+            urlconf=urlconf, patterns=patterns,
+            openapi_schema=openapi_schema,
+        )
+    else:
+        generator = generator_class(
+            title=title, url=url, description=description,
+            urlconf=urlconf, patterns=patterns,
+        )
 
     # Avoid import cycle on APIView
     from .views import SchemaView

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -163,7 +163,7 @@ class BaseSchemaGenerator(object):
     # Set by 'SCHEMA_COERCE_PATH_PK'.
     coerce_path_pk = None
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None):
+    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, **kwargs):
         if url and not url.endswith('/'):
             url += '/'
 

--- a/tests/schemas/test_get_schema_view.py
+++ b/tests/schemas/test_get_schema_view.py
@@ -12,6 +12,11 @@ class GetSchemaViewTests(TestCase):
         assert isinstance(schema_view.initkwargs['schema_generator'], openapi.SchemaGenerator)
         assert renderers.OpenAPIRenderer in schema_view.cls().renderer_classes
 
+    def test_openapi_initialized(self):
+        schema_view = get_schema_view(openapi_schema={'info': {'title': 'With OpenAPI'}})
+        assert isinstance(schema_view.initkwargs['schema_generator'], openapi.SchemaGenerator)
+        assert renderers.OpenAPIRenderer in schema_view.cls().renderer_classes
+
     @pytest.mark.skipif(not coreapi.coreapi, reason='coreapi is not installed')
     def test_coreapi(self):
         with override_settings(REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.AutoSchema'}):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -226,6 +226,29 @@ class TestGenerator(TestCase):
 
         assert 'openapi' in schema
         assert 'paths' in schema
+        assert 'info' in schema
+        assert 'title' in schema['info']
+        assert 'version' in schema['info']
+        assert schema['info']['title'] is None
+        assert schema['info']['version'] == 'TODO'
+
+    def test_schema_initializer(self):
+        """Construction of top-level dictionary with an initializer."""
+        class MyListView(views.ExampleListView):
+            schema = AutoSchema(openapi_schema={'info': {'title': 'mytitle', 'version': 'myversion'}})
+
+        patterns = [
+            url(r'^example/?$', MyListView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=patterns)
+
+        request = create_request('/')
+        schema = generator.get_schema(request=request)
+
+        assert 'info' in schema
+        assert 'title' in schema['info']
+        assert 'version' in schema['info']
+        assert schema['info']['title'] == 'mytitle' and schema['info']['version'] == 'myversion'
 
     def test_serializer_datefield(self):
         patterns = [


### PR DESCRIPTION
## Description

This adds the ability to provide an initial OpenAPI schema doc with some default content. Example:

```python
class MyListView(views.ExampleListView):
    schema = AutoSchema(openapi_schema={'info': {'title': 'mytitle', 'version': 'myversion'}})
```
@carltongibson: I expect some of my changes are not quite correctly styled, so please review and suggest changes/reject, as you see fit.