### PR TITLE
don't sort YAML keys

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -44,6 +44,7 @@ You can determine your currently installed version using `pip show`:
 
 **Date**: [Unreleased][3.10.0-milestone]
 
+* Updated PyYaml dependency for OpenAPI schema generation to `pyyaml>=5.1` [#6680][gh6680]
 * Resolve DeprecationWarning with markdown. [#6317][gh6317]
 
 
@@ -2137,4 +2138,5 @@ For older release notes, [please see the version 2.x documentation][old-release-
 [gh6613]: https://github.com/encode/django-rest-framework/issues/6613
 
 <!-- 3.10.0 -->
+[gh6680]: https://github.com/encode/django-rest-framework/issues/6680
 [gh6317]: https://github.com/encode/django-rest-framework/issues/6317

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -6,4 +6,4 @@ django-guardian==1.5.0
 django-filter>=2.1.0, <2.2
 coreapi==2.3.1
 coreschema==0.0.4
-pyyaml
+pyyaml>=5.1

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -1049,7 +1049,7 @@ class OpenAPIRenderer(BaseRenderer):
         assert yaml, 'Using OpenAPIRenderer, but `pyyaml` is not installed.'
 
     def render(self, data, media_type=None, renderer_context=None):
-        return yaml.dump(data, default_flow_style=False).encode('utf-8')
+        return yaml.dump(data, default_flow_style=False, sort_keys=False).encode('utf-8')
 
 
 class JSONOpenAPIRenderer(BaseRenderer):

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -54,7 +54,7 @@ def endpoint_ordering(endpoint):
         'PATCH': 3,
         'DELETE': 4
     }.get(method, 5)
-    return (path, method_priority)
+    return (method_priority,)
 
 
 _PATH_PARAMETER_COMPONENT_RE = re.compile(


### PR DESCRIPTION
## Description

This adds a new PyYAML >= 5.1 feature to suppress sorting the dict when dumping to yaml.
This makes the openapi.yaml file more human-readable with keys appearing in the order they were added.

@carltongibson another candidate for 3.10?