### PR TITLE
Docs: Add detail file path in tutorial

### DIFF
--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -35,7 +35,7 @@ The wrappers also provide behaviour such as returning `405 Method Not Allowed` r
 
 Okay, let's go ahead and start using these new components to write a few views.
 
-We don't need our `JSONResponse` class in `views.py` any more, so go ahead and delete that.  Once that's done we can start refactoring our views slightly.
+We don't need our `JSONResponse` class in `snippets/views.py` any more, so go ahead and delete that.  Once that's done we can start refactoring our views slightly.
 
     from rest_framework import status
     from rest_framework.decorators import api_view
@@ -63,7 +63,7 @@ We don't need our `JSONResponse` class in `views.py` any more, so go ahead and d
 
 Our instance view is an improvement over the previous example.  It's a little more concise, and the code now feels very similar to if we were working with the Forms API.  We're also using named status codes, which makes the response meanings more obvious.
 
-Here is the view for an individual snippet, in the `views.py` module.
+Here is the view for an individual snippet, in the `snippets/views.py` module.
 
     @api_view(['GET', 'PUT', 'DELETE'])
     def snippet_detail(request, pk):

--- a/docs/tutorial/3-class-based-views.md
+++ b/docs/tutorial/3-class-based-views.md
@@ -30,7 +30,7 @@ We'll start by rewriting the root view as a class-based view.  All this involves
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-So far, so good.  It looks pretty similar to the previous case, but we've got better separation between the different HTTP methods.  We'll also need to update the instance view in `views.py`.
+So far, so good.  It looks pretty similar to the previous case, but we've got better separation between the different HTTP methods.  We'll also need to update the instance view in `snippets/views.py`.
 
     class SnippetDetail(APIView):
         """
@@ -83,7 +83,7 @@ One of the big wins of using class-based views is that it allows us to easily co
 
 The create/retrieve/update/delete operations that we've been using so far are going to be pretty similar for any model-backed API views we create.  Those bits of common behaviour are implemented in REST framework's mixin classes.
 
-Let's take a look at how we can compose the views by using the mixin classes.  Here's our `views.py` module again.
+Let's take a look at how we can compose the views by using the mixin classes.  Here's our `snippets/views.py` module again.
 
     from snippets.models import Snippet
     from snippets.serializers import SnippetSerializer
@@ -126,7 +126,7 @@ Pretty similar.  Again we're using the `GenericAPIView` class to provide the cor
 
 ## Using generic class-based views
 
-Using the mixin classes we've rewritten the views to use slightly less code than before, but we can go one step further.  REST framework provides a set of already mixed-in generic views that we can use to trim down our `views.py` module even more.
+Using the mixin classes we've rewritten the views to use slightly less code than before, but we can go one step further.  REST framework provides a set of already mixed-in generic views that we can use to trim down our `snippets/views.py` module even more.
 
     from snippets.models import Snippet
     from snippets.serializers import SnippetSerializer

--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -75,7 +75,6 @@ The `HyperlinkedModelSerializer` has the following differences from `ModelSerial
 We can easily re-write our existing serializers to use hyperlinking. In your `snippets/serializers.py` add:
 
     class SnippetSerializer(serializers.HyperlinkedModelSerializer):
-        owner = serializers.ReadOnlyField(source='owner.username')
         highlight = serializers.HyperlinkedIdentityField(view_name='snippet-highlight', format='html')
 
         class Meta:

--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -10,7 +10,7 @@ A `ViewSet` class is only bound to a set of method handlers at the last moment, 
 
 Let's take our current set of views, and refactor them into view sets.
 
-First of all let's refactor our `UserList` and `UserDetail` views into a single `UserViewSet`.  We can remove the two views, and replace them with a single class:
+First of all let's refactor our `UserList` and `UserDetail` views into a single `UserViewSet` in `snippets/views.py`.  We can remove the two views, and replace them with a single class:
 
     from rest_framework import viewsets
 


### PR DESCRIPTION
The writing of the file path was not uniform for each chapter, so I unified to write from the parent's directory.

And remove already written line in [tutorial 4](https://www.django-rest-framework.org/tutorial/4-authentication-and-permissions/).
```
owner = serializers.ReadOnlyField(source='owner.username')
```