### PR TITLE
Don't cache _readable_fields and _writable_fields

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -361,18 +361,17 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
             fields[key] = value
         return fields
 
-    @cached_property
+    @property
     def _writable_fields(self):
-        return [
-            field for field in self.fields.values() if not field.read_only
-        ]
+        for field in self.fields.values():
+            if not field.read_only:
+                yield field
 
-    @cached_property
+    @property
     def _readable_fields(self):
-        return [
-            field for field in self.fields.values()
-            if not field.write_only
-        ]
+        for field in self.fields.values():
+            if not field.write_only:
+                yield field
 
     def get_fields(self):
         """

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -219,7 +219,7 @@ class TestReadOnly:
         Read-only fields should not be writable, even with default ()
         """
         serializer = self.Serializer()
-        assert len(serializer._writable_fields) == 1
+        assert len(list(serializer._writable_fields)) == 1
 
     def test_validate_read_only(self):
         """


### PR DESCRIPTION
It might be useful for a serializer with many many fields which uses
read_only and write_only on a large percentage of the fields. But the
memory usage and statefulness it adds are not worth it for the common
case.