### PR TITLE
Add more DRF job sites

### DIFF
--- a/docs/community/jobs.md
+++ b/docs/community/jobs.md
@@ -9,6 +9,7 @@ Looking for a new Django REST Framework related role? On this site we provide a 
 * [https://www.python.org/jobs/][python-org-jobs]
 * [https://djangogigs.com][django-gigs-com]
 * [https://djangojobs.net/jobs/][django-jobs-net]
+* [https://findwork.dev/django-rest-framework-jobs][findwork-dev]
 * [https://www.indeed.com/q-Django-jobs.html][indeed-com]
 * [https://stackoverflow.com/jobs/developer-jobs-using-django][stackoverflow-com]
 * [https://www.upwork.com/o/jobs/browse/skill/django-framework/][upwork-com]
@@ -26,6 +27,7 @@ Wonder how else you can help? One of the best ways you can help Django REST Fram
 [python-org-jobs]: https://www.python.org/jobs/
 [django-gigs-com]: https://djangogigs.com
 [django-jobs-net]: https://djangojobs.net/jobs/
+[findwork-dev]: https://findwork.dev/django-rest-framework-jobs
 [indeed-com]: https://www.indeed.com/q-Django-jobs.html
 [stackoverflow-com]: https://stackoverflow.com/jobs/developer-jobs-using-django
 [upwork-com]: https://www.upwork.com/o/jobs/browse/skill/django-framework/


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Adds findwork.dev as a site for DRF jobs.
