### PR TITLE
Switch optional requirement to psycopg2 package

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,5 +1,5 @@
 # Optional packages which may be used with REST framework.
-psycopg2-binary>=2.8.2, <2.9
+psycopg2>=2.8.2, <2.9
 markdown==2.6.11
 django-guardian==1.5.0
 django-filter>=2.1.0, <2.2


### PR DESCRIPTION
The psycopg2 project recommends _not_ using the psycopg2-binary package.
Here are the relevant warnings:

​http://initd.org/psycopg/docs/install.html#binary-install-from-pypi

> Note: The psycopg2-binary package is meant for beginners to start
> playing with Python and PostgreSQL without the need to meet the build
> requirements.
>
> If you are the maintainer of a publish package depending on psycopg2
> you shouldn’t use ‘psycopg2-binary’ as a module dependency. For
> production use you are advised to use the source distribution.
>
> Note: The binary packages come with their own versions of a few C
> libraries, among which libpq and libssl, which will be used regardless
> of other libraries available on the client: upgrading the system
> libraries will not upgrade the libraries used by psycopg2. Please
> build psycopg2 from source if you want to maintain binary
> upgradeability.
>
> Warning: The psycopg2 wheel package comes packaged, among the others,
> with its own libssl binary. This may create conflicts with other
> extension modules binding with libssl as well, for instance with the
> Python ssl module: in some cases, under concurrency, the interaction
> between the two libraries may result in a segfault. In case of doubts
> you are advised to use a package built from source.