### PR TITLE
Fix lazy translation of ListField errors

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1610,10 +1610,10 @@ class ListField(Field):
         super().__init__(*args, **kwargs)
         self.child.bind(field_name='', parent=self)
         if self.max_length is not None:
-            message = self.error_messages['max_length'].format(max_length=self.max_length)
+            message = lazy(self.error_messages['max_length'].format, str)(max_length=self.max_length)
             self.validators.append(MaxLengthValidator(self.max_length, message=message))
         if self.min_length is not None:
-            message = self.error_messages['min_length'].format(min_length=self.min_length)
+            message = lazy(self.error_messages['min_length'].format, str)(min_length=self.min_length)
             self.validators.append(MinLengthValidator(self.min_length, message=message))
 
     def get_value(self, dictionary):

--- a/tests/importable/__init__.py
+++ b/tests/importable/__init__.py
@@ -1,1 +1,16 @@
-from rest_framework import compat  # noqa
+"""
+This test "app" exists to ensure that parts of Django REST Framework can be
+imported/invoked before Django itself has been fully initialized.
+"""
+
+from rest_framework import compat, serializers  # noqa
+
+
+# test initializing fields with lazy translations
+class ExampleSerializer(serializers.Serializer):
+    charfield = serializers.CharField(min_length=1, max_length=2)
+    integerfield = serializers.IntegerField(min_value=1, max_value=2)
+    floatfield = serializers.FloatField(min_value=1, max_value=2)
+    decimalfield = serializers.DecimalField(max_digits=10, decimal_places=1, min_value=1, max_value=2)
+    durationfield = serializers.DurationField(min_value=1, max_value=2)
+    listfield = serializers.ListField(min_length=1, max_length=2)

--- a/tests/importable/test_installed.py
+++ b/tests/importable/test_installed.py
@@ -4,10 +4,21 @@ from tests import importable
 
 
 def test_installed():
-    # ensure that apps can freely import rest_framework.compat
+    # ensure the test app hasn't been removed from the test suite
     assert 'tests.importable' in settings.INSTALLED_APPS
 
 
-def test_imported():
-    # ensure that the __init__ hasn't been mucked with
+def test_compat():
     assert hasattr(importable, 'compat')
+
+
+def test_serializer_fields_initialization():
+    assert hasattr(importable, 'ExampleSerializer')
+
+    serializer = importable.ExampleSerializer()
+    assert 'charfield' in serializer.fields
+    assert 'integerfield' in serializer.fields
+    assert 'floatfield' in serializer.fields
+    assert 'decimalfield' in serializer.fields
+    assert 'durationfield' in serializer.fields
+    assert 'listfield' in serializer.fields


### PR DESCRIPTION
Spun this off of #6644. 

- Fixes lazy translations for ListField.
- Adds a regression test to ensure that fields with lazily translated validation errors can be imported and instantiated during class creation. This test fails without the corresponding fix to ListField.
- Clarifies purposes of `tests.importable`

<details>

<summary>Test failure snippet:</summary>

```python
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/tests/importable/__init__.py", line 10, in <module>
INTERNALERROR>     class ExampleSerializer(serializers.Serializer):
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/tests/importable/__init__.py", line 16, in ExampleSerializer
INTERNALERROR>     listfield = serializers.ListField(min_length=1, max_length=2)
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/rest_framework/fields.py", line 1613, in __init__
INTERNALERROR>     message = self.error_messages['max_length'].format(max_length=self.max_length)
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/.tox/venvs/py37-django22/lib/python3.7/site-packages/django/utils/functional.py", line 151, in __wrapper__
INTERNALERROR>     res = func(*self.__args, **self.__kw)
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/.tox/venvs/py37-django22/lib/python3.7/site-packages/django/utils/translation/__init__.py", line 79, in gettext
INTERNALERROR>     return _trans.gettext(message)
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/.tox/venvs/py37-django22/lib/python3.7/site-packages/django/utils/translation/trans_real.py", line 285, in gettext
INTERNALERROR>     _default = _default or translation(settings.LANGUAGE_CODE)
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/.tox/venvs/py37-django22/lib/python3.7/site-packages/django/utils/translation/trans_real.py", line 198, in translation
INTERNALERROR>     _translations[language] = DjangoTranslation(language)
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/.tox/venvs/py37-django22/lib/python3.7/site-packages/django/utils/translation/trans_real.py", line 97, in __init__
INTERNALERROR>     self._add_installed_apps_translations()
INTERNALERROR>   File "/Users/bagel/Documents/projects/django-rest-framework/.tox/venvs/py37-django22/lib/python3.7/site-packages/django/utils/translation/trans_real.py", line 139, in _add_installed_apps_translations
INTERNALERROR>     "The translation infrastructure cannot be initialized before the "
INTERNALERROR> django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.

```

</details>