### PR TITLE
Added support for RFC 7159

### DIFF
--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -93,3 +93,17 @@ class JSONEncoderTests(TestCase):
         """
         foo = MockList()
         assert self.encoder.default(foo) == [1, 2, 3]
+
+    def test_encode_int_outside_rfc7159_range(self):
+        # Values lower than minimum allowed must fail
+        with pytest.raises(ValueError):
+            self.encoder.default(self.encoder.rfc7159_min_number - 1)
+
+        # Values greater than maximum allowed must fail
+        with pytest.raises(ValueError):
+            self.encoder.default(self.encoder.rfc7159_max_number + 1)
+
+        # Values within RFC 7159 range are allowed
+        self.encoder.default(self.encoder.rfc7159_min_number) == self.encoder.rfc7159_min_number
+        self.encoder.default(self.encoder.rfc7159_max_number) == self.encoder.rfc7159_max_number
+        self.encoder.default(42) == 42


### PR DESCRIPTION
* Min and max numbers are "configurable" (by overriding them in a new encoder)
* Enforcement can be disabled by setting flag to false (same as above)

## Description

This PR fixes #5007 about keeping [JSON encoder](https://github.com/encode/django-rest-framework/issues/5007#issuecomment-287910802) restricted to the number range described in [RFC 7159](https://tools.ietf.org/html/rfc7159#section-6)