### PR TITLE
Use yaml.safe_load instead of load

### DIFF
--- a/tests/schemas/test_managementcommand.py
+++ b/tests/schemas/test_managementcommand.py
@@ -45,7 +45,7 @@ class GenerateSchemaTests(TestCase):
                      '--description=Sample description',
                      stdout=self.out)
         # Check valid YAML was output.
-        schema = yaml.load(self.out.getvalue())
+        schema = yaml.safe_load(self.out.getvalue())
         assert schema['openapi'] == '3.0.2'
 
     def test_renders_openapi_json_schema(self):


### PR DESCRIPTION
Use of PyYAML's yaml.load function without specifying the Loader
parameter has been deprecated, see https://msg.pyyaml.org/load.

Earlier versions of PyYAML already had the alternative safe_load
function, which limits the loader to a subset of YAML constructs, that
is enough for what we need here.

Fixes #6677