### PR TITLE
Fix typo in github.com URL.

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -534,7 +534,7 @@ Comma-separated values are a plain-text tabular data format, that can be easily 
 [messagepack]: https://msgpack.org/
 [juanriaza]: https://github.com/juanriaza
 [mjumbewu]: https://github.com/mjumbewu
-[flipperpa]: https://githuc.com/flipperpa
+[flipperpa]: https://github.com/flipperpa
 [wharton]: https://github.com/wharton
 [drf-renderer-xlsx]: https://github.com/wharton/drf-renderer-xlsx
 [vbabiy]: https://github.com/vbabiy


### PR DESCRIPTION
## Description

Fix a typo in a github.com URL.