### PR TITLE
Update markdown preprocessor registration

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -38,6 +38,15 @@ You can determine your currently installed version using `pip show`:
 
 ---
 
+## 3.10.x series
+
+### 3.10.0
+
+**Date**: [Unreleased][3.10.0-milestone]
+
+* Resolve DeprecationWarning with markdown. [#6317][gh6317]
+
+
 ## 3.9.x series
 
 ### 3.9.4
@@ -1182,6 +1191,7 @@ For older release notes, [please see the version 2.x documentation][old-release-
 [3.9.0-milestone]: https://github.com/encode/django-rest-framework/milestone/66?closed=1
 [3.9.1-milestone]: https://github.com/encode/django-rest-framework/milestone/70?closed=1
 [3.9.2-milestone]: https://github.com/encode/django-rest-framework/milestone/71?closed=1
+[3.10.0-milestone]: https://github.com/encode/django-rest-framework/milestone/69?closed=1
 
 <!-- 3.0.1 -->
 [gh2013]: https://github.com/encode/django-rest-framework/issues/2013
@@ -2125,3 +2135,6 @@ For older release notes, [please see the version 2.x documentation][old-release-
 
 <!-- 3.9.3 -->
 [gh6613]: https://github.com/encode/django-rest-framework/issues/6613
+
+<!-- 3.10.0 -->
+[gh6317]: https://github.com/encode/django-rest-framework/issues/6317

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -42,13 +42,13 @@ You can determine your currently installed version using `pip show`:
 
 ### 3.9.4
 
-**Date**: [10th May 2019]
+**Date**: 10th May 2019
 
 This is a maintenance release that fixes an error handling bug under Python 2.
 
 ### 3.9.3
 
-**Date**: [29th April 2019]
+**Date**: 29th April 2019
 
 This is the last Django REST Framework release that will support Python 2.
 Be sure to upgrade to Python 3 before upgrading to Django REST Framework 3.10.
@@ -58,7 +58,7 @@ Be sure to upgrade to Python 3 before upgrading to Django REST Framework 3.10.
 
 ### 3.9.2
 
-**Date**: [3rd March 2019][3.9.1-milestone]
+**Date**: [3rd March 2019][3.9.2-milestone]
 
 * Routers: invalidate `_urls` cache on `register()` [#6407][gh6407]
 * Deferred schema renderer creation to avoid requiring pyyaml. [#6416][gh6416]
@@ -1181,7 +1181,7 @@ For older release notes, [please see the version 2.x documentation][old-release-
 [3.8.2-milestone]: https://github.com/encode/django-rest-framework/milestone/68?closed=1
 [3.9.0-milestone]: https://github.com/encode/django-rest-framework/milestone/66?closed=1
 [3.9.1-milestone]: https://github.com/encode/django-rest-framework/milestone/70?closed=1
-[3.9.1-milestone]: https://github.com/encode/django-rest-framework/milestone/71?closed=1
+[3.9.2-milestone]: https://github.com/encode/django-rest-framework/milestone/71?closed=1
 
 <!-- 3.0.1 -->
 [gh2013]: https://github.com/encode/django-rest-framework/issues/2013

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,8 @@ each Python and Django series.
 The following packages are optional:
 
 * [coreapi][coreapi] (1.32.0+) - Schema generation support.
-* [Markdown][markdown] (2.6.0+) - Markdown support for the browsable API.
+* [Markdown][markdown] (3.0.0+) - Markdown support for the browsable API.
+* [Pygments][pygments] (2.4.0+) - Add sytax highlighting to Markdown processing.
 * [django-filter][django-filter] (1.0.1+) - Filtering support.
 * [django-guardian][django-guardian] (1.1.1+) - Object level permissions support.
 
@@ -237,6 +238,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 [eventbrite]: https://www.eventbrite.co.uk/about/
 [coreapi]: https://pypi.org/project/coreapi/
 [markdown]: https://pypi.org/project/Markdown/
+[pygments]: https://pypi.org/project/Pygments/
 [django-filter]: https://pypi.org/project/django-filter/
 [django-guardian]: https://github.com/django-guardian/django-guardian
 [index]: .

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,6 +1,7 @@
 # Optional packages which may be used with REST framework.
 psycopg2-binary>=2.8.2, <2.9
-markdown==2.6.11
+markdown==3.1.1
+pygments==2.4.2
 django-guardian==1.5.0
 django-filter>=2.1.0, <2.2
 coreapi==2.3.1

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -206,7 +206,7 @@ if markdown is not None and pygments is not None:
             return ret.split("\n")
 
     def md_filter_add_syntax_highlight(md):
-        md.preprocessors.add('highlight', CodeBlockPreprocessor(), "_begin")
+        md.preprocessors.register(CodeBlockPreprocessor(), 'highlight', 40)
         return True
 else:
     def md_filter_add_syntax_highlight(md):

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -128,7 +128,7 @@ if 'patch' not in View.http_method_names:
     View.http_method_names = View.http_method_names + ['patch']
 
 
-# Markdown is optional (version 2.6+ required)
+# Markdown is optional (version 3.0+ required)
 try:
     import markdown
 


### PR DESCRIPTION
This is an update to #6412 and fixes #6317. I created a new PR since there were a number of merge conflicts. Also, added `pygments` to the optional test requirements so that the markdown preprocessor is ran during testing.

Thanks @mcab for getting this started.