### PR TITLE
Adds DRF Access Policy to permissions 3rd party section

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -281,6 +281,10 @@ Also note that the generic views will only check the object-level permissions fo
 
 The following third party packages are also available.
 
+## DRF - Access Policy
+
+The [Django REST - Access Policy][drf-access-policy] package provides a way to define complex access rules in declaritive policy classes that are attached to view sets or function-based views. The policies are defined in JSON in a format similer to AWS' Identity & Access Management policies. 
+
 ## Composed Permissions
 
 The [Composed Permissions][composed-permissions] package provides a simple way to define complex and multi-depth (with logic operators) permission objects, using small and reusable components.
@@ -320,3 +324,4 @@ The [Django Rest Framework Role Filters][django-rest-framework-role-filters] pac
 [djangorestframework-api-key]: https://github.com/florimondmanca/djangorestframework-api-key
 [django-rest-framework-role-filters]: https://github.com/allisson/django-rest-framework-role-filters
 [django-rest-framework-guardian]: https://github.com/rpkilby/django-rest-framework-guardian
+[drf-access-policy]: https://github.com/rsinger86/drf-access-policy

--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -197,6 +197,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [djangorestframework-composed-permissions][djangorestframework-composed-permissions] - Provides a simple way to define complex permissions.
 * [rest_condition][rest-condition] - Another extension for building complex permissions in a simple and convenient way.
 * [dry-rest-permissions][dry-rest-permissions] - Provides a simple way to define permissions for individual api actions.
+* [drf-access-policy][drf-access-policy] - Declarative and flexible permissions inspired by AWS' IAM policies.
 
 ### Serializers
 
@@ -208,6 +209,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [django-rest-framework-serializer-extensions][drf-serializer-extensions] -
   Enables black/whitelisting fields, and conditionally expanding child serializers on a per-view/request basis.
 * [djangorestframework-queryfields][djangorestframework-queryfields] - Serializer mixin allowing clients to control which fields will be sent in the API response.
+* [drf-flex-fields][drf-flex-fields] - Serializer providing dynamic field expansion and sparse field sets via URL parameters.
 
 ### Serializer fields
 
@@ -340,3 +342,5 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [djangorestframework-datatables]: https://github.com/izimobil/django-rest-framework-datatables
 [django-rest-framework-condition]: https://github.com/jozo/django-rest-framework-condition
 [django-rest-witchcraft]: https://github.com/shosca/django-rest-witchcraft
+[drf-access-policy]: https://github.com/rsinger86/drf-access-policy
+[drf-flex-fields]: https://github.com/rsinger86/drf-flex-fields


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Hi! This is just an addition to the 3rd party packages section of the permissions docs. 
