### PR TITLE
fix openapi // path prefix

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -249,7 +249,7 @@ class BaseSchemaGenerator(object):
         /api/v1/users/
         /api/v1/users/{pk}/
 
-        The path prefix is '/api/v1/'
+        The path prefix is '/api/v1'
         """
         prefixes = []
         for path in paths:

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -35,12 +35,14 @@ class SchemaGenerator(BaseSchemaGenerator):
         if not paths:
             return None
         prefix = self.determine_path_prefix(paths)
+        if prefix == '/':  # no prefix
+            prefix = ''
 
         for path, method, view in view_endpoints:
             if not self.has_view_permissions(path, method, view):
                 continue
             operation = view.schema.get_operation(path, method)
-            subpath = '/' + path[len(prefix):]
+            subpath = path[len(prefix):]
             result.setdefault(subpath, {})
             result[subpath][method.lower()] = operation
 

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -214,6 +214,20 @@ class TestGenerator(TestCase):
         assert 'get' in example_operations
         assert 'post' in example_operations
 
+    def test_prefixed_paths_construction(self):
+        """Construction of the `paths` key with a common prefix."""
+        patterns = [
+            url(r'^api/v1/example/?$', views.ExampleListView.as_view()),
+            url(r'^api/v1/example/{pk}/?$', views.ExampleDetailView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=patterns)
+        generator._initialise_endpoints()
+
+        paths = generator.get_paths()
+
+        assert '/example/' in paths
+        assert '/example/{id}/' in paths
+
     def test_schema_construction(self):
         """Construction of the top level dictionary."""
         patterns = [


### PR DESCRIPTION
## Description

Fixes `//` prefix for a path that has a common prefix. Prior to this fix, urls with a common prefix
would result in a doubled `/`. For example:
```python
router = routers.DefaultRouter()
router.register(r'courses', views.CourseViewSet)

urlpatterns = [
    path('v1/', include(router.urls)),
```

generates this schema:

```yaml
paths:
  //courses/:
    get:
```

Here's reproducing it showing that the assumption of trailing `/` being returned (as documented) is incorrect:
https://github.com/encode/django-rest-framework/blob/3e210ae48d250b36c66c2b438b8ac1428fa24f3b/rest_framework/schemas/generators.py#L239-L253
```
Python 3.6.6 (default, Jul 27 2018, 14:31:43) 
[GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from rest_framework.schemas.openapi import SchemaGenerator
>>> s=SchemaGenerator()
>>> paths=['/api/v1/users/', '/api/v1/users/{pk}/']
>>> s.determine_path_prefix(paths)
'/api/v1'
>>> 
```

With the fix, this generates:
```yaml
paths:
  /courses/:
    get:
```
