### PR TITLE
add --generator_class CLI option to generateschema

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -45,6 +45,7 @@ You can determine your currently installed version using `pip show`:
 **Date**: [Unreleased][3.10.0-milestone]
 
 * Resolve DeprecationWarning with markdown. [#6317][gh6317]
+* Add `generateschema --generator_class` CLI option
 
 
 ## 3.9.x series

--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from django.utils.module_loading import import_string
 
 from rest_framework import renderers
 from rest_framework.schemas import coreapi
@@ -22,9 +23,13 @@ class Command(BaseCommand):
             parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json', 'corejson'], default='openapi', type=str)
         else:
             parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json'], default='openapi', type=str)
+        parser.add_argument('--generator_class', dest="generator_class", default=None, type=str)
 
     def handle(self, *args, **options):
-        generator_class = self.get_generator_class()
+        if options['generator_class']:
+            generator_class = import_string(options['generator_class'])
+        else:
+            generator_class = self.get_generator_class()
         generator = generator_class(
             url=options['url'],
             title=options['title'],

--- a/tests/schemas/test_managementcommand.py
+++ b/tests/schemas/test_managementcommand.py
@@ -22,6 +22,16 @@ urlpatterns = [
 ]
 
 
+class CustomSchemaGenerator:
+    SCHEMA = {"key": "value"}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_schema(self, **kwargs):
+        return self.SCHEMA
+
+
 @override_settings(ROOT_URLCONF=__name__)
 @pytest.mark.skipif(not uritemplate, reason='uritemplate is not installed')
 class GenerateSchemaTests(TestCase):
@@ -55,6 +65,13 @@ class GenerateSchemaTests(TestCase):
         # Check valid JSON was output.
         out_json = json.loads(self.out.getvalue())
         assert out_json['openapi'] == '3.0.2'
+
+    def test_accepts_custom_schema_generator(self):
+        call_command('generateschema',
+                     '--generator_class={}.{}'.format(__name__, CustomSchemaGenerator.__name__),
+                     stdout=self.out)
+        out_json = yaml.safe_load(self.out.getvalue())
+        assert out_json == CustomSchemaGenerator.SCHEMA
 
     @pytest.mark.skipif(yaml is None, reason='PyYAML is required.')
     @override_settings(REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.AutoSchema'})


### PR DESCRIPTION
## Description

See #6670. Adds the ability to override the SchemaGenerator class from the `generateschema` CLI command.

