### PR TITLE
Remove duplicate test in `tests/test_utils.py`

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -235,15 +235,6 @@ class UrlsRemoveQueryParamTests(TestCase):
     """
     Tests the remove_query_param functionality.
     """
-    def test_valid_unicode_preserved(self):
-        q = '/?q=%E6%9F%A5%E8%AF%A2'
-        new_key = 'page'
-        new_value = 2
-        value = '%E6%9F%A5%E8%AF%A2'
-
-        assert new_key in replace_query_param(q, new_key, new_value)
-        assert value in replace_query_param(q, new_key, new_value)
-
     def test_valid_unicode_removed(self):
         q = '/?page=2345&q=%E6%9F%A5%E8%AF%A2'
         key = 'page'


### PR DESCRIPTION
## Description
Remove duplicate test. this test already is in https://github.com/encode/django-rest-framework/blob/9ac9c1b2eafa05cf5b6a605ce54e2d5f2f866f1b/tests/test_utils.py#L206

Also, this test is for `replace_query_param` but by mistake placed on `UrlsRemoveQueryParamTests`.