### PR TITLE
Made release notes path a clickable link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-docs/community/release-notes.md
+[docs/community/release-notes.md](./docs/community/release-notes.md)


### PR DESCRIPTION
## Description

Just a small update to make the release notes file path a clickable link for better ease of use.