### PR TITLE
Add get_read_only_fields method to Modelserializer.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1333,6 +1333,9 @@ class ModelSerializer(Serializer):
 
     # Methods for determining additional keyword arguments to apply...
 
+    def get_read_only_fields(self):
+        return getattr(self.Meta, 'read_only_fields', None)
+
     def get_extra_kwargs(self):
         """
         Return a dictionary mapping field names to a dictionary of
@@ -1340,7 +1343,7 @@ class ModelSerializer(Serializer):
         """
         extra_kwargs = copy.deepcopy(getattr(self.Meta, 'extra_kwargs', {}))
 
-        read_only_fields = getattr(self.Meta, 'read_only_fields', None)
+        read_only_fields = self.get_read_only_fields()
         if read_only_fields is not None:
             if not isinstance(read_only_fields, (list, tuple)):
                 raise TypeError(

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -154,6 +154,57 @@ class TestModelSerializer(TestCase):
         with self.assertRaisesMessage(ValueError, msginitial):
             serializer.is_valid()
 
+    def test_read_only_fields(self):
+        class TestModel(models.Model):
+            field1 = models.CharField(max_length=255)
+            field2 = models.CharField(max_length=255)
+
+        class TestSerializer1(serializers.ModelSerializer):
+            class Meta:
+                model = TestModel
+                read_only_fields = ('field1',)
+                fields = ('field1', 'field2')
+
+        class TestSerializer2(serializers.ModelSerializer):
+            class Meta:
+                model = TestModel
+                read_only_fields = ('field1',)
+                fields = ('field1', 'field2')
+
+            def get_read_only_fields(self):
+                return ('field2',)
+
+        class TestSerializer3(serializers.ModelSerializer):
+            class Meta:
+                model = TestModel
+                read_only_fields = ('field1',)
+                fields = ('field1', 'field2')
+
+            def get_read_only_fields(self):
+                return None
+
+        test_expected1 = dedent("""
+            TestSerializer1():
+                field1 = CharField(read_only=True)
+                field2 = CharField(max_length=255)
+        """)
+
+        test_expected2 = dedent("""
+            TestSerializer2():
+                field1 = CharField(max_length=255)
+                field2 = CharField(read_only=True)
+        """)
+
+        test_expected3 = dedent("""
+            TestSerializer3():
+                field1 = CharField(max_length=255)
+                field2 = CharField(max_length=255)
+        """)
+
+        self.assertEqual(repr(TestSerializer1()), test_expected1)
+        self.assertEqual(repr(TestSerializer2()), test_expected2)
+        self.assertEqual(repr(TestSerializer3()), test_expected3)
+
 
 class TestRegularFieldMappings(TestCase):
     def test_regular_fields(self):


### PR DESCRIPTION
## Description
Add `get_read_only_fields` method to `Modelserializer`.
It helps to dynamically determine the `read_only_fields`.
