### PR TITLE
Extracted` page_size` logic into `get_page_number` to allow overloading

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -195,9 +195,7 @@ class PageNumberPagination(BasePagination):
             return None
 
         paginator = self.django_paginator_class(queryset, page_size)
-        page_number = request.query_params.get(self.page_query_param, 1)
-        if page_number in self.last_page_strings:
-            page_number = paginator.num_pages
+        page_number = self.get_page_number(request, paginator)
 
         try:
             self.page = paginator.page(page_number)
@@ -234,6 +232,12 @@ class PageNumberPagination(BasePagination):
                 pass
 
         return self.page_size
+
+    def get_page_number(self, request, paginator):
+        page_number = request.query_params.get(self.page_query_param, 1)
+        if page_number in self.last_page_strings:
+            return paginator.num_pages
+        return page_number
 
     def get_next_link(self):
         if not self.page.has_next():


### PR DESCRIPTION
## Description

Allow to override the logic to get `page_number` in the same way as `get_page_size`.

Then one could create a class that simply overrides this method instead of copy-pasting whole `paginate_queryset` method.

Also provide `view` into `get_page_size` and `get_page_number`