### PR TITLE
Let AND and OR operators have multiple members

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -74,13 +74,13 @@ class AND(BasePermission):
 
     def has_permission(self, request, view):
         for permission in self.permissions:
-            if not permissions.has_permission(request, view):
+            if not permission.has_permission(request, view):
                 return False
         return True
 
     def has_object_permission(self, request, view, obj):
         for permission in self.permissions:
-            if not permissions.has_object_permission(request, view, obj):
+            if not permission.has_object_permission(request, view, obj):
                 return False
         return True
 

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -87,7 +87,7 @@ class AND(BasePermission):
 
 class OR(BasePermission):
     def __init__(self, *args):
-        self.permissions = op1
+        self.permissions = args
 
     def has_permission(self, request, view):
         for permission in self.permissions:

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -47,6 +47,51 @@ class OperandHolder(OperationHolderMixin):
         return self.operator_class(op1, op2)
 
 
+class AND:
+    def __init__(self, *args):
+        self.permissions = args
+
+    def has_permission(self, request, view):
+        for permission in self.permissions:
+            if not permission.has_permission(request, view):
+                return False
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        for permission in self.permissions:
+            if not permission.has_object_permission(request, view, obj):
+                return False
+        return True
+
+
+class OR:
+    def __init__(self, *args):
+        self.permissions = args
+
+    def has_permission(self, request, view):
+        for permission in self.permissions:
+            if permission.has_permission(request, view):
+                return True
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        for permission in self.permissions:
+            if permission.has_object_permission(request, view, obj):
+                return True
+        return False
+
+
+class NOT:
+    def __init__(self, op1):
+        self.op1 = op1
+
+    def has_permission(self, request, view):
+        return not self.op1.has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        return not self.op1.has_object_permission(request, view, obj)
+
+
 class BasePermissionMetaclass(OperationHolderMixin, type):
     pass
 
@@ -67,51 +112,6 @@ class BasePermission(metaclass=BasePermissionMetaclass):
         Return `True` if permission is granted, `False` otherwise.
         """
         return True
-
-
-class AND(BasePermission):
-    def __init__(self, *args):
-        self.permissions = args
-
-    def has_permission(self, request, view):
-        for permission in self.permissions:
-            if not permission.has_permission(request, view):
-                return False
-        return True
-
-    def has_object_permission(self, request, view, obj):
-        for permission in self.permissions:
-            if not permission.has_object_permission(request, view, obj):
-                return False
-        return True
-
-
-class OR(BasePermission):
-    def __init__(self, *args):
-        self.permissions = args
-
-    def has_permission(self, request, view):
-        for permission in self.permissions:
-            if permission.has_permission(request, view):
-                return True
-        return False
-
-    def has_object_permission(self, request, view, obj):
-        for permission in self.permissions:
-            if permission.has_object_permission(request, view, obj):
-                return True
-        return False
-
-
-class NOT(BasePermission):
-    def __init__(self, op1):
-        self.op1 = op1
-
-    def has_permission(self, request, view):
-        return not self.op1.has_permission(request, view)
-
-    def has_object_permission(self, request, view, obj):
-        return not self.op1.has_object_permission(request, view, obj)
 
 
 class AllowAny(BasePermission):

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -68,6 +68,7 @@ class BasePermission(metaclass=BasePermissionMetaclass):
         """
         return True
 
+
 class AND(BasePermission):
     def __init__(self, *args):
         self.permissions = args
@@ -111,7 +112,6 @@ class NOT(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return not self.op1.has_object_permission(request, view, obj)
-
 
 
 class AllowAny(BasePermission):


### PR DESCRIPTION
Hi, this is just a suggestion, note that this is my first pull request here, so sorry if a do not follow the rules as expected

## Description
Let AND and OR permission accept multiple members:
`AND(OR(a, b, c), d, e)` should resolve iff `(a or b or c) and d and e`

Also, let NOT, AND and OR be BasePermission
