### PR TITLE
Fix ArrayField kwargs mapping with ListField

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -109,6 +109,9 @@ def get_field_kwargs(field_name, model_field):
     if model_field.blank and (isinstance(model_field, (models.CharField, models.TextField))):
         kwargs['allow_blank'] = True
 
+    if not model_field.blank and (postgres_fields and isinstance(model_field, postgres_fields.ArrayField)):
+        kwargs['allow_empty'] = False
+
     if isinstance(model_field, models.FilePathField):
         kwargs['path'] = model_field.path
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -440,15 +440,17 @@ class TestPosgresFieldsMapping(TestCase):
     def test_array_field(self):
         class ArrayFieldModel(models.Model):
             array_field = postgres_fields.ArrayField(base_field=models.CharField())
+            array_field_with_blank = postgres_fields.ArrayField(blank=True, base_field=models.CharField())
 
         class TestSerializer(serializers.ModelSerializer):
             class Meta:
                 model = ArrayFieldModel
-                fields = ['array_field']
+                fields = ['array_field', 'array_field_with_blank']
 
         expected = dedent("""
             TestSerializer():
-                array_field = ListField(child=CharField(label='Array field', validators=[<django.core.validators.MaxLengthValidator object>]))
+                array_field = ListField(allow_empty=False, child=CharField(label='Array field', validators=[<django.core.validators.MaxLengthValidator object>]))
+                array_field_with_blank = ListField(child=CharField(label='Array field with blank', validators=[<django.core.validators.MaxLengthValidator object>]), required=False)
         """)
         self.assertEqual(repr(TestSerializer()), expected)
 


### PR DESCRIPTION
## Description

Fixes #6597 Correctly map Postgres ArrayField `blank=False` attribute to `allow_empty=False` of ListField

The default mappings between Django and DRF are not clean here. Django, by default set `blank=False` on ArrayField(most fields), which should translate to DRF non-default `allow_empty=False`, and vice-versa.

Need feedback if this is good enough or we should add some comments here.

refs #6597
