### PR TITLE
TokenAdmin: add 'user' to autocomplete_fields

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -7,6 +7,7 @@ class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
     ordering = ('-created',)
+    autocomplete_fields = ('user',)
 
 
 admin.site.register(Token, TokenAdmin)


### PR DESCRIPTION
TokenAdmin is unusable with a big number of user records (in this case ~150k). Django 2.0 added the [ModelAdmin.autocomplete_fields](https://docs.djangoproject.com/en/stable/ref/contrib/admin/#django.contrib.admin.ModelAdmin.autocomplete_fields) option to use select2 to provide a better user experience.

If support for django 1.11 is dropped, this change would make the `TokenAdmin` usable again.
