### PR TITLE
Update description and link to djangorestframework-api-key

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -303,7 +303,7 @@ The [Django Rest Framework Roles][django-rest-framework-roles] package makes it 
 
 ## Django REST Framework API Key
 
-The [Django REST Framework API Key][djangorestframework-api-key] package provides the ability to authorize clients based on customizable API key headers. This package is targeted at situations in which regular user-based authentication (e.g. `TokenAuthentication`) is not suitable, e.g. allowing non-human clients to safely use your API. API keys are generated and validated through cryptographic methods and can be created and revoked from the Django admin interface at anytime.
+The [Django REST Framework API Key][djangorestframework-api-key] package provides permissions classes, models and helpers to add API key authorization to your API. It can be used to authorize internal or third-party backends and services (i.e. _machines_) which do not have a user account. API keys are stored securely using Django's password hashing infrastructure, and they can be viewed, edited and revoked at anytime in the Django admin.
 
 ## Django Rest Framework Role Filters
 
@@ -321,7 +321,7 @@ The [Django Rest Framework Role Filters][django-rest-framework-role-filters] pac
 [rest-condition]: https://github.com/caxap/rest_condition
 [dry-rest-permissions]: https://github.com/Helioscene/dry-rest-permissions
 [django-rest-framework-roles]: https://github.com/computer-lab/django-rest-framework-roles
-[djangorestframework-api-key]: https://github.com/florimondmanca/djangorestframework-api-key
+[djangorestframework-api-key]: https://florimondmanca.github.io/djangorestframework-api-key/
 [django-rest-framework-role-filters]: https://github.com/allisson/django-rest-framework-role-filters
 [django-rest-framework-guardian]: https://github.com/rpkilby/django-rest-framework-guardian
 [drf-access-policy]: https://github.com/rsinger86/drf-access-policy


### PR DESCRIPTION
## Description

Hi, the Django REST Framework API Key package listed in the Permissions third-party packages has a new documentation site. I also went ahead and updated the project description.

Fixes https://github.com/florimondmanca/djangorestframework-api-key/issues/56