### PR TITLE
Allow redundant SerializerMethodField method names

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1835,12 +1835,6 @@ class SerializerMethodField(Field):
         # 'method_name' argument has been used. For example:
         # my_field = serializer.SerializerMethodField(method_name='get_my_field')
         default_method_name = 'get_{field_name}'.format(field_name=field_name)
-        assert self.method_name != default_method_name, (
-            "It is redundant to specify `%s` on SerializerMethodField '%s' in "
-            "serializer '%s', because it is the same as the default method name. "
-            "Remove the `method_name` argument." %
-            (self.method_name, field_name, parent.__class__.__name__)
-        )
 
         # The method name should default to `get_{field_name}`.
         if self.method_name is None:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2212,17 +2212,13 @@ class TestSerializerMethodField:
         }
 
     def test_redundant_method_name(self):
+        # Prior to v3.10, redundant method names were not allowed.
+        # This restriction has since been removed.
         class ExampleSerializer(serializers.Serializer):
             example_field = serializers.SerializerMethodField('get_example_field')
 
-        with pytest.raises(AssertionError) as exc_info:
-            ExampleSerializer().fields
-        assert str(exc_info.value) == (
-            "It is redundant to specify `get_example_field` on "
-            "SerializerMethodField 'example_field' in serializer "
-            "'ExampleSerializer', because it is the same as the default "
-            "method name. Remove the `method_name` argument."
-        )
+        field = ExampleSerializer().fields['example_field']
+        assert field.method_name == 'get_example_field'
 
 
 class TestValidationErrorCode:


### PR DESCRIPTION
Resolves #2420 by removing the redundant `SerializerMethodField.method_name` restriction.

cc @tomchristie?