### PR TITLE
Update mkdocs to 1.x

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -1,4 +1,7 @@
-source: authentication.py
+---
+source:
+    - authentication.py
+---
 
 # Authentication
 

--- a/docs/api-guide/content-negotiation.md
+++ b/docs/api-guide/content-negotiation.md
@@ -1,4 +1,7 @@
-source: negotiation.py
+---
+source:
+    - negotiation.py
+---
 
 # Content negotiation
 

--- a/docs/api-guide/exceptions.md
+++ b/docs/api-guide/exceptions.md
@@ -1,4 +1,7 @@
-source: exceptions.py
+---
+source:
+    - exceptions.py
+---
 
 # Exceptions
 

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -1,4 +1,7 @@
-source: fields.py
+---
+source:
+    - fields.py
+---
 
 # Serializer fields
 

--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -1,4 +1,7 @@
-source: filters.py
+---
+source:
+    - filters.py
+---
 
 # Filtering
 

--- a/docs/api-guide/format-suffixes.md
+++ b/docs/api-guide/format-suffixes.md
@@ -1,4 +1,7 @@
-source: urlpatterns.py
+---
+source:
+    - urlpatterns.py
+---
 
 # Format suffixes
 

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -1,5 +1,8 @@
-source: mixins.py
-        generics.py
+---
+source:
+    - mixins.py
+    - generics.py
+---
 
 # Generic views
 

--- a/docs/api-guide/metadata.md
+++ b/docs/api-guide/metadata.md
@@ -1,4 +1,7 @@
-source: metadata.py
+---
+source:
+    - metadata.py
+---
 
 # Metadata
 

--- a/docs/api-guide/parsers.md
+++ b/docs/api-guide/parsers.md
@@ -1,4 +1,7 @@
-source: parsers.py
+---
+source:
+    - parsers.py
+---
 
 # Parsers
 

--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -1,4 +1,7 @@
-source: permissions.py
+---
+source:
+    - permissions.py
+---
 
 # Permissions
 

--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -1,4 +1,7 @@
-source: relations.py
+---
+source:
+    - relations.py
+---
 
 # Serializer relations
 

--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -1,4 +1,7 @@
-source: renderers.py
+---
+source:
+    - renderers.py
+---
 
 # Renderers
 

--- a/docs/api-guide/requests.md
+++ b/docs/api-guide/requests.md
@@ -1,4 +1,7 @@
-source: request.py
+---
+source:
+    - request.py
+---
 
 # Requests
 

--- a/docs/api-guide/responses.md
+++ b/docs/api-guide/responses.md
@@ -1,4 +1,7 @@
-source: response.py
+---
+source:
+    - response.py
+---
 
 # Responses
 

--- a/docs/api-guide/reverse.md
+++ b/docs/api-guide/reverse.md
@@ -1,4 +1,7 @@
-source: reverse.py
+---
+source:
+    - reverse.py
+---
 
 # Returning URLs
 

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -1,4 +1,7 @@
-source: routers.py
+---
+source:
+    - routers.py
+---
 
 # Routers
 

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -1,4 +1,7 @@
-source: schemas.py
+---
+source:
+    - schemas.py
+---
 
 # Schemas
 

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -1,4 +1,7 @@
-source: serializers.py
+---
+source:
+    - serializers.py
+---
 
 # Serializers
 

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -1,4 +1,7 @@
-source: settings.py
+---
+source:
+    - settings.py
+---
 
 # Settings
 

--- a/docs/api-guide/status-codes.md
+++ b/docs/api-guide/status-codes.md
@@ -1,4 +1,7 @@
-source: status.py
+---
+source:
+    - status.py
+---
 
 # Status Codes
 

--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -1,4 +1,7 @@
-source: test.py
+---
+source:
+    - test.py
+---
 
 # Testing
 

--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -1,4 +1,7 @@
-source: throttling.py
+---
+source:
+    - throttling.py
+---
 
 # Throttling
 

--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -1,4 +1,7 @@
-source: validators.py
+---
+source:
+    - validators.py
+---
 
 # Validators
 

--- a/docs/api-guide/versioning.md
+++ b/docs/api-guide/versioning.md
@@ -1,4 +1,7 @@
-source: versioning.py
+---
+source:
+    - versioning.py
+---
 
 # Versioning
 

--- a/docs/api-guide/views.md
+++ b/docs/api-guide/views.md
@@ -1,5 +1,8 @@
-source: decorators.py
-        views.py
+---
+source:
+    - decorators.py
+    - views.py
+---
 
 # Class-based Views
 

--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -1,4 +1,7 @@
-source: viewsets.py
+---
+source:
+    - viewsets.py
+---
 
 # ViewSets
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,13 +4,15 @@ site_description: Django REST framework - Web APIs for Django
 
 repo_url: https://github.com/encode/django-rest-framework
 
-theme_dir: docs_theme
+theme:
+    name: mkdocs
+    custom_dir: docs_theme
 
 markdown_extensions:
  - toc:
     anchorlink: True
 
-pages:
+nav:
  - Home: 'index.md'
  - Tutorial:
     - 'Quickstart': 'tutorial/quickstart.md'

--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -1,2 +1,2 @@
 # MkDocs to build our documentation.
-mkdocs==0.16.3
+mkdocs==1.0.4

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ deps =
         -rrequirements/requirements-testing.txt
 
 [testenv:docs]
-basepython = python2.7
+basepython = python3.7
 skip_install = true
 commands = mkdocs build
 deps =


### PR DESCRIPTION
Updates mkdocs to the 1.0.4, which allows us to move the build to Python 3. Aside from some minor configuration changes, page metadata is now YAML-based so we can use lists. Fixes #6623.