### PR TITLE
Update docs for pagination settings

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -109,58 +109,25 @@ Default: `'rest_framework.schemas.AutoSchema'`
 
 *The following settings control the behavior of the generic class-based views.*
 
-#### DEFAULT_PAGINATION_SERIALIZER_CLASS
-
----
-
-**This setting has been removed.**
-
-The pagination API does not use serializers to determine the output format, and
-you'll need to instead override the `get_paginated_response method on a
-pagination class in order to specify how the output format is controlled.
-
----
-
 #### DEFAULT_FILTER_BACKENDS
 
 A list of filter backend classes that should be used for generic filtering.
 If set to `None` then generic filtering is disabled.
 
-#### PAGINATE_BY
+#### DEFAULT_PAGINATION_CLASS
 
----
+The default class to use for queryset pagination. If set to `None`, pagination
+is disabled by default. See the pagination documentation for further guidance on
+[setting](pagination.md#setting-the-pagination-style) and
+[modifying](pagination.md#modifying-the-pagination-style) the pagination style.
 
-**This setting has been removed.**
-
-See the pagination documentation for further guidance on [setting the pagination style](pagination.md#modifying-the-pagination-style).
-
----
+Default: `None`
 
 #### PAGE_SIZE
 
 The default page size to use for pagination.  If set to `None`, pagination is disabled by default.
 
 Default: `None`
-
-#### PAGINATE_BY_PARAM
-
----
-
-**This setting has been removed.**
-
-See the pagination documentation for further guidance on [setting the pagination style](pagination.md#modifying-the-pagination-style).
-
----
-
-#### MAX_PAGINATE_BY
-
----
-
-**This setting has been removed.**
-
-See the pagination documentation for further guidance on [setting the pagination style](pagination.md#modifying-the-pagination-style).
-
----
 
 ### SEARCH_PARAM
 


### PR DESCRIPTION
Documents `DEFAULT_PAGINATION_CLASS` and removes other, outdated pagination settings.

Resolves #6185 