### PR TITLE
Strip null characters from search param

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -64,7 +64,9 @@ class SearchFilter(BaseFilterBackend):
         and may be comma and/or whitespace delimited.
         """
         params = request.query_params.get(self.search_param, '')
-        return params.replace(',', ' ').split()
+        params = params.replace('\x00', '')  # strip null characters
+        params = params.replace(',', ' ')
+        return params.split()
 
     def construct_search(self, field_name):
         lookup = self.lookup_prefixes.get(field_name[0])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -180,6 +180,15 @@ class SearchFilterTests(TestCase):
             {'id': 3, 'title': 'zzz', 'text': 'cde'}
         ]
 
+    def test_search_field_with_null_characters(self):
+        view = generics.GenericAPIView()
+        request = factory.get('/?search=\0as%00d\x00f')
+        request = view.initialize_request(request)
+
+        terms = filters.SearchFilter().get_search_terms(request)
+
+        assert terms == ['asdf']
+
 
 class AttributeModel(models.Model):
     label = models.CharField(max_length=32)


### PR DESCRIPTION
Fixes 6453 by stripping null characters from the search parameter. 
In the future, we may want to use validators for more complex validation. 