### PR TITLE
docs: update http method override middleware example

### DIFF
--- a/docs/topics/browser-enhancements.md
+++ b/docs/topics/browser-enhancements.md
@@ -51,13 +51,15 @@ For example:
 
     METHOD_OVERRIDE_HEADER = 'HTTP_X_HTTP_METHOD_OVERRIDE'
 
-    class MethodOverrideMiddleware(object):
-        def process_view(self, request, callback, callback_args, callback_kwargs):
-            if request.method != 'POST':
-                return
-            if METHOD_OVERRIDE_HEADER not in request.META:
-                return
-            request.method = request.META[METHOD_OVERRIDE_HEADER]
+    class MethodOverrideMiddleware:
+
+        def __init__(self, get_response):
+            self.get_response = get_response
+
+        def __call__(self, request):
+            if request.method == 'POST' and METHOD_OVERRIDE_HEADER in request.META:
+                request.method = request.META[METHOD_OVERRIDE_HEADER]
+            return self.get_response(request)
 
 ## URL based accept headers
 


### PR DESCRIPTION
## Description

Hello,

In the browser enhancement docs, the example middleware class for HTTP method overriding doesn't work with recent Django versions because  of the middleware API [changed in 1.10](https://docs.djangoproject.com/en/1.11/topics/http/middleware/#middleware).

This PR replaces the example with one that works with recent Django versions (tested in 2.2.3).
