### PR TITLE
Missing List Comprehension in Tutorial 1: Serialization | snippets/models.py

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -60,7 +60,7 @@ For the purposes of this tutorial we're going to start by creating a simple `Sni
 
     LEXERS = [item for item in get_all_lexers() if item[1]]
     LANGUAGE_CHOICES = sorted([(item[1][0], item[0]) for item in LEXERS])
-    STYLE_CHOICES = sorted((item, item) for item in get_all_styles())
+    STYLE_CHOICES = sorted([(item, item) for item in get_all_styles()])
 
 
     class Snippet(models.Model):


### PR DESCRIPTION
## Description

In Tutorial 1: Serialization, when creating the Snippets model in snippets/models.py, the variable STYLE_CHOICES is assigned:

`STYLE_CHOICES = sorted( (item, item) for item in get_all_styles() )`

The global function sorted() expects a list, or an iterable. However this is not being given. STYLE_CHOICES should be generated by using a list comprehension just like the LANGUAGE_CHOICES variable defined immediately before it.

`STYLE_CHOICES = sorted([(item, item) for item in get_all_styles()])`