### PR TITLE
JSONEncoder: ensure empty listlikes remain lists, not dicts

### DIFF
--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -57,8 +57,9 @@ class JSONEncoder(json.JSONEncoder):
                 'You should be using a schema renderer instead for this view.'
             )
         elif hasattr(obj, '__getitem__'):
+            cls = (list if isinstance(obj, (list, tuple)) else dict)
             try:
-                return dict(obj)
+                return cls(obj)
             except Exception:
                 pass
         elif hasattr(obj, '__iter__'):

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -8,6 +8,7 @@ from django.utils.timezone import utc
 
 from rest_framework.compat import coreapi
 from rest_framework.utils.encoders import JSONEncoder
+from rest_framework.utils.serializer_helpers import ReturnList
 
 
 class MockList:
@@ -93,3 +94,10 @@ class JSONEncoderTests(TestCase):
         """
         foo = MockList()
         assert self.encoder.default(foo) == [1, 2, 3]
+
+    def test_encode_empty_returnlist(self):
+        """
+        Tests encoding an empty ReturnList
+        """
+        foo = ReturnList(serializer=None)
+        assert self.encoder.default(foo) == []


### PR DESCRIPTION
I found out that when using JSONEncoder's `default()` method with JSON serializer libraries that do not internally handle list subclasses (such as [`orjson`](https://github.com/ijl/orjson)), empty indexable collections (such as `ReturnList`s, as used by paginators etc.) get turned into dicts, leading into interesting situations á la 

```json
{"count":0,"next":null,"previous":null,"results":{}}
```
(where `"results"` should naturally be a list).

The patch is happily short enough.