### PR TITLE
Update Django Filter dependency for OpenAPI schema support.

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -3,7 +3,7 @@ psycopg2-binary>=2.8.2, <2.9
 markdown==3.1.1
 pygments==2.4.2
 django-guardian==1.5.0
-django-filter>=2.1.0, <2.2
+django-filter>=2.2.0, <2.3
 coreapi==2.3.1
 coreschema==0.0.4
 pyyaml>=5.1


### PR DESCRIPTION
Bumps to 2.2, which adds the relevant bits. 