### PR TITLE
Fixes import in the schemas documentation

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -51,7 +51,7 @@ To route a `SchemaView`, use the `get_schema_view()` helper.
 In `urls.py`:
 
 ```python
-from rest_framework.schemas import get_schema_view()
+from rest_framework.schemas import get_schema_view
 
 urlpatterns = [
     # ...

--- a/docs/community/3.10-announcement.md
+++ b/docs/community/3.10-announcement.md
@@ -67,7 +67,7 @@ shortcut.
 In your `urls.py`:
 
 ```python
-from rest_framework.schemas import get_schema_view()
+from rest_framework.schemas import get_schema_view
 
 urlpatterns = [
     # ...


### PR DESCRIPTION
## Description
Fixes the `get_schema_view` import in the documentation for `schemas` and `3.10 announcement ` pages
