### PR TITLE
Check if coreapi is installed before using uritemplate or raise exception

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.utils.encoding import force_text
 
 from rest_framework import exceptions, serializers
-from rest_framework.compat import uritemplate
+from rest_framework.compat import coreapi, uritemplate
 from rest_framework.fields import empty
 
 from .generators import BaseSchemaGenerator
@@ -145,6 +145,7 @@ class AutoSchema(ViewInspector):
         """
         Return a list of parameters from templated path variables.
         """
+        assert coreapi, '`coreapi` must be installed for OpenAPI schema support.'
         assert uritemplate, '`uritemplate` must be installed for OpenAPI schema support.'
 
         model = getattr(getattr(self.view, 'queryset', None), 'model', None)


### PR DESCRIPTION
Hello,

this just adds extra information for the developer when coreapi is not installed.

I was struggling because I was receiving the exception

```
`uritemplate` must be installed for OpenAPI schema support.
```

I installed it and tested that ```import uritemplate``` was working. 
Reading the source code I noticed that even if you have uritemplate is not going to work without coreapi.
