### PR TITLE
Version 3.10.1

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '3.10.0'
+__version__ = '3.10.1'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2019 Encode OSS Ltd'

--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -7,7 +7,6 @@ class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
     ordering = ('-created',)
-    autocomplete_fields = ('user',)
 
 
 admin.site.register(Token, TokenAdmin)

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -93,12 +93,16 @@ except ImportError:
     postgres_fields = None
 
 
-# coreapi is optional (Note that uritemplate is a dependency of coreapi)
+# coreapi is required for CoreAPI schema generation
 try:
     import coreapi
-    import uritemplate
 except ImportError:
     coreapi = None
+
+# uritemplate is required for OpenAPI schema generation
+try:
+    import uritemplate
+except ImportError:
     uritemplate = None
 
 

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -99,7 +99,7 @@ try:
 except ImportError:
     coreapi = None
 
-# uritemplate is required for OpenAPI schema generation
+# uritemplate is required for OpenAPI and CoreAPI schema generation
 try:
     import uritemplate
 except ImportError:


### PR DESCRIPTION
## Ensure that requiring uritemplate, doe not also require coreapi

Refs #6814

## Don't include autocomplete fields on TokenAuth admin

Closes #6808
Refs https://github.com/encode/django-rest-framework/pull/6762

I think we should instead document how to customize the TokenAuth admin, using an `autocomplete` field as an example case. (Looking into it I can see that expanding on #3831 slightly is what we'd want)


Also closes #6811