### PR TITLE
Handles ListField mapping for OpenAPI

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -9,7 +9,7 @@ from django.utils.encoding import force_text
 
 from rest_framework import exceptions, serializers
 from rest_framework.compat import uritemplate
-from rest_framework.fields import empty
+from rest_framework.fields import _UnvalidatedField, empty
 
 from .generators import BaseSchemaGenerator
 from .inspectors import ViewInspector
@@ -256,9 +256,15 @@ class AutoSchema(ViewInspector):
 
         # ListField.
         if isinstance(field, serializers.ListField):
-            return {
+            mapping = {
                 'type': 'array',
+                'items': {},
             }
+            if not isinstance(field.child, _UnvalidatedField):
+                mapping['items'] = {
+                    "type": self._map_field(field.child).get('type')
+                }
+            return mapping
 
         # DateField and DateTimeField type is string
         if isinstance(field, serializers.DateField):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -39,6 +39,20 @@ class TestBasics(TestCase):
             assert f.get_schema_operation_parameters(self.dummy_view)
 
 
+class TestFieldMapping(TestCase):
+    def test_list_field_mapping(self):
+        inspector = AutoSchema()
+        cases = [
+            (serializers.ListField(), {'items': {}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.BooleanField()), {'items': {'type': 'boolean'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.FloatField()), {'items': {'type': 'number'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.CharField()), {'items': {'type': 'string'}, 'type': 'array'}),
+        ]
+        for field, mapping in cases:
+            with self.subTest(field=field):
+                assert inspector._map_field(field) == mapping
+
+
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')
 class TestOperationIntrospection(TestCase):
 


### PR DESCRIPTION
## Description

Fixes #6815  

The `array` type in OpenAPI should come with corresponding `items`. Currently, if a `serializers.ListField` is used, the documentation will display the message 'Could not render this component'. In this commit I just add the `items` with the proper type of the child so it renders correctly.
