### PR TITLE
Ability to specify urlconf in include_docs_urls added

### DIFF
--- a/rest_framework/documentation.py
+++ b/rest_framework/documentation.py
@@ -8,8 +8,8 @@ from rest_framework.settings import api_settings
 
 
 def get_docs_view(
-        title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator,
+        title=None, description=None, schema_url=None, urlconf=None,
+        public=True, patterns=None, generator_class=SchemaGenerator,
         authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
         permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES,
         renderer_classes=None):
@@ -20,6 +20,7 @@ def get_docs_view(
     return get_schema_view(
         title=title,
         url=schema_url,
+        urlconf=urlconf,
         description=description,
         renderer_classes=renderer_classes,
         public=public,
@@ -31,8 +32,8 @@ def get_docs_view(
 
 
 def get_schemajs_view(
-        title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator,
+        title=None, description=None, schema_url=None, urlconf=None,
+        public=True, patterns=None, generator_class=SchemaGenerator,
         authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
         permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
     renderer_classes = [SchemaJSRenderer]
@@ -40,6 +41,7 @@ def get_schemajs_view(
     return get_schema_view(
         title=title,
         url=schema_url,
+        urlconf=urlconf,
         description=description,
         renderer_classes=renderer_classes,
         public=public,
@@ -51,8 +53,8 @@ def get_schemajs_view(
 
 
 def include_docs_urls(
-        title=None, description=None, schema_url=None, public=True,
-        patterns=None, generator_class=SchemaGenerator,
+        title=None, description=None, schema_url=None, urlconf=None,
+        public=True, patterns=None, generator_class=SchemaGenerator,
         authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
         permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES,
         renderer_classes=None):
@@ -60,6 +62,7 @@ def include_docs_urls(
         title=title,
         description=description,
         schema_url=schema_url,
+        urlconf=urlconf,
         public=public,
         patterns=patterns,
         generator_class=generator_class,
@@ -71,6 +74,7 @@ def include_docs_urls(
         title=title,
         description=description,
         schema_url=schema_url,
+        urlconf=urlconf,
         public=public,
         patterns=patterns,
         generator_class=generator_class,


### PR DESCRIPTION
## Description
There is a problem in the current implementation that if one exports docs via `include_docs_urls` he will be using `ROOT_URLCONF` (https://github.com/encode/django-rest-framework/blob/master/rest_framework/schemas/generators.py#L73), which is a big problem, if one is working with subdomains and he has sets of disjoint URLs.
This simple fix allows to pass through forgotten `urlconf` parameter.

refs #6801 
