### PR TITLE
OpenAPI Schema Generation Fixes.

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -18,18 +18,6 @@ from rest_framework.settings import api_settings
 from rest_framework.utils.model_meta import _get_pk
 
 
-def common_path(paths):
-    split_paths = [path.strip('/').split('/') for path in paths]
-    s1 = min(split_paths)
-    s2 = max(split_paths)
-    common = s1
-    for i, c in enumerate(s1):
-        if c != s2[i]:
-            common = s1[:i]
-            break
-    return '/' + '/'.join(common)
-
-
 def get_pk_name(model):
     meta = model._meta.concrete_model._meta
     return _get_pk(meta).name
@@ -235,37 +223,6 @@ class BaseSchemaGenerator(object):
 
     def get_schema(self, request=None, public=False):
         raise NotImplementedError(".get_schema() must be implemented in subclasses.")
-
-    def determine_path_prefix(self, paths):
-        """
-        Given a list of all paths, return the common prefix which should be
-        discounted when generating a schema structure.
-
-        This will be the longest common string that does not include that last
-        component of the URL, or the last component before a path parameter.
-
-        For example:
-
-        /api/v1/users/
-        /api/v1/users/{pk}/
-
-        The path prefix is '/api/v1'
-        """
-        prefixes = []
-        for path in paths:
-            components = path.strip('/').split('/')
-            initial_components = []
-            for component in components:
-                if '{' in component:
-                    break
-                initial_components.append(component)
-            prefix = '/'.join(initial_components[:-1])
-            if not prefix:
-                # We can just break early in the case that there's at least
-                # one URL that doesn't have a path prefix.
-                return '/'
-            prefixes.append('/' + prefix + '/')
-        return common_path(prefixes)
 
     def has_view_permissions(self, path, method, view):
         """

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -190,6 +190,75 @@ class TestOperationIntrospection(TestCase):
         assert schema_str.count("newExample") == 1
         assert schema_str.count("oldExample") == 1
 
+    def test_serializer_datefield(self):
+        path = '/'
+        method = 'GET'
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        responses = inspector._get_responses(path, method)
+        response_schema = responses['200']['content']['application/json']['schema']['properties']
+        assert response_schema['date']['type'] == response_schema['datetime']['type'] == 'string'
+        assert response_schema['date']['format'] == 'date'
+        assert response_schema['datetime']['format'] == 'date-time'
+
+    def test_serializer_validators(self):
+        path = '/'
+        method = 'GET'
+        view = create_view(
+            views.ExampleValdidatedAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        responses = inspector._get_responses(path, method)
+        response_schema = responses['200']['content']['application/json']['schema']['properties']
+
+        assert response_schema['integer']['type'] == 'integer'
+        assert response_schema['integer']['maximum'] == 99
+        assert response_schema['integer']['minimum'] == -11
+
+        assert response_schema['string']['minLength'] == 2
+        assert response_schema['string']['maxLength'] == 10
+
+        assert response_schema['regex']['pattern'] == r'[ABC]12{3}'
+        assert response_schema['regex']['description'] == 'must have an A, B, or C followed by 1222'
+
+        assert response_schema['decimal1']['type'] == 'number'
+        assert response_schema['decimal1']['multipleOf'] == .01
+        assert response_schema['decimal1']['maximum'] == 10000
+        assert response_schema['decimal1']['minimum'] == -10000
+
+        assert response_schema['decimal2']['type'] == 'number'
+        assert response_schema['decimal2']['multipleOf'] == .0001
+
+        assert response_schema['email']['type'] == 'string'
+        assert response_schema['email']['format'] == 'email'
+        assert response_schema['email']['default'] == 'foo@bar.com'
+
+        assert response_schema['url']['type'] == 'string'
+        assert response_schema['url']['nullable'] is True
+        assert response_schema['url']['default'] == 'http://www.example.com'
+
+        assert response_schema['uuid']['type'] == 'string'
+        assert response_schema['uuid']['format'] == 'uuid'
+
+        assert response_schema['ip4']['type'] == 'string'
+        assert response_schema['ip4']['format'] == 'ipv4'
+
+        assert response_schema['ip6']['type'] == 'string'
+        assert response_schema['ip6']['format'] == 'ipv6'
+
+        assert response_schema['ip']['type'] == 'string'
+        assert 'format' not in response_schema['ip']
+
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')
 @override_settings(REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.openapi.AutoSchema'})
@@ -253,70 +322,3 @@ class TestGenerator(TestCase):
 
         assert 'openapi' in schema
         assert 'paths' in schema
-
-    def test_serializer_datefield(self):
-        patterns = [
-            url(r'^example/?$', views.ExampleGenericViewSet.as_view({"get": "get"})),
-        ]
-        generator = SchemaGenerator(patterns=patterns)
-
-        request = create_request('/')
-        schema = generator.get_schema(request=request)
-
-        response = schema['paths']['/example/']['get']['responses']
-        response_schema = response['200']['content']['application/json']['schema']['properties']
-
-        assert response_schema['date']['type'] == response_schema['datetime']['type'] == 'string'
-
-        assert response_schema['date']['format'] == 'date'
-        assert response_schema['datetime']['format'] == 'date-time'
-
-    def test_serializer_validators(self):
-        patterns = [
-            url(r'^example/?$', views.ExampleValdidatedAPIView.as_view()),
-        ]
-        generator = SchemaGenerator(patterns=patterns)
-
-        request = create_request('/')
-        schema = generator.get_schema(request=request)
-
-        response = schema['paths']['/example/']['get']['responses']
-        response_schema = response['200']['content']['application/json']['schema']['properties']
-
-        assert response_schema['integer']['type'] == 'integer'
-        assert response_schema['integer']['maximum'] == 99
-        assert response_schema['integer']['minimum'] == -11
-
-        assert response_schema['string']['minLength'] == 2
-        assert response_schema['string']['maxLength'] == 10
-
-        assert response_schema['regex']['pattern'] == r'[ABC]12{3}'
-        assert response_schema['regex']['description'] == 'must have an A, B, or C followed by 1222'
-
-        assert response_schema['decimal1']['type'] == 'number'
-        assert response_schema['decimal1']['multipleOf'] == .01
-        assert response_schema['decimal1']['maximum'] == 10000
-        assert response_schema['decimal1']['minimum'] == -10000
-
-        assert response_schema['decimal2']['type'] == 'number'
-        assert response_schema['decimal2']['multipleOf'] == .0001
-
-        assert response_schema['email']['type'] == 'string'
-        assert response_schema['email']['format'] == 'email'
-        assert response_schema['email']['default'] == 'foo@bar.com'
-
-        assert response_schema['url']['type'] == 'string'
-        assert response_schema['url']['nullable'] is True
-        assert response_schema['url']['default'] == 'http://www.example.com'
-
-        assert response_schema['uuid']['type'] == 'string'
-        assert response_schema['uuid']['format'] == 'uuid'
-
-        assert response_schema['ip4']['type'] == 'string'
-        assert response_schema['ip4']['format'] == 'ipv4'
-
-        assert response_schema['ip6']['type'] == 'string'
-        assert response_schema['ip6']['format'] == 'ipv6'
-
-        assert response_schema['ip']['type'] == 'string'
-        assert 'format' not in response_schema['ip']

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -215,18 +215,18 @@ class TestGenerator(TestCase):
         assert 'post' in example_operations
 
     def test_prefixed_paths_construction(self):
-        """Construction of the `paths` key with a common prefix."""
+        """Construction of the `paths` key maintains a common prefix."""
         patterns = [
-            url(r'^api/v1/example/?$', views.ExampleListView.as_view()),
-            url(r'^api/v1/example/{pk}/?$', views.ExampleDetailView.as_view()),
+            url(r'^v1/example/?$', views.ExampleListView.as_view()),
+            url(r'^v1/example/{pk}/?$', views.ExampleDetailView.as_view()),
         ]
         generator = SchemaGenerator(patterns=patterns)
         generator._initialise_endpoints()
 
         paths = generator.get_paths()
 
-        assert '/example/' in paths
-        assert '/example/{id}/' in paths
+        assert '/v1/example/' in paths
+        assert '/v1/example/{id}/' in paths
 
     def test_schema_construction(self):
         """Construction of the top level dictionary."""

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -233,7 +233,7 @@ class TestGenerator(TestCase):
             url(r'^example/?$', views.ExampleListView.as_view()),
             url(r'^example/{pk}/?$', views.ExampleDetailView.as_view()),
         ]
-        generator = SchemaGenerator(patterns=patterns, url='/api/')
+        generator = SchemaGenerator(patterns=patterns, url='/api')
         generator._initialise_endpoints()
 
         paths = generator.get_paths()

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -211,7 +211,7 @@ class TestOperationIntrospection(TestCase):
         path = '/'
         method = 'GET'
         view = create_view(
-            views.ExampleValdidatedAPIView,
+            views.ExampleValidatedAPIView,
             method,
             create_request(path),
         )

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -228,6 +228,19 @@ class TestGenerator(TestCase):
         assert '/v1/example/' in paths
         assert '/v1/example/{id}/' in paths
 
+    def test_mount_url_prefixed_to_paths(self):
+        patterns = [
+            url(r'^example/?$', views.ExampleListView.as_view()),
+            url(r'^example/{pk}/?$', views.ExampleDetailView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=patterns, url='/api/')
+        generator._initialise_endpoints()
+
+        paths = generator.get_paths()
+
+        assert '/api/example/' in paths
+        assert '/api/example/{id}/' in paths
+
     def test_schema_construction(self):
         """Construction of the top level dictionary."""
         patterns = [

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -96,7 +96,7 @@ class ExampleValidatedSerializer(serializers.Serializer):
     ip = serializers.IPAddressField()
 
 
-class ExampleValdidatedAPIView(generics.GenericAPIView):
+class ExampleValidatedAPIView(generics.GenericAPIView):
     serializer_class = ExampleValidatedSerializer
 
     def get(self, *args, **kwargs):


### PR DESCRIPTION
Specifically: Closes #6675. Closes #6823.

* Corrected one test, which was ultimately a logic error on my part, for common prefixes. 
* Adds another to check the `url` parameter functions as a mount point. 
* Fixes the above. 
* A couple of tidy-ups. 
