### PR TITLE
Handle 'None' return value of wait() properly during throttling.

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -356,7 +356,17 @@ class APIView(View):
                 throttle_durations.append(throttle.wait())
 
         if throttle_durations:
-            self.throttled(request, max(throttle_durations))
+            # Filter out `None` values which may happen in case of config / rate
+            # changes, see #1438
+            durations = [
+                duration for duration in throttle_durations
+                if duration is not None
+            ]
+
+            if durations:
+                self.throttled(request, max(durations))
+            else:
+                self.throttled(request, None)
 
     def determine_version(self, request, *args, **kwargs):
         """

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -363,7 +363,7 @@ class APIView(View):
                 if duration is not None
             ]
 
-            duration = max(durations) if durations else None
+            duration = max(durations, default=None)
             self.throttled(request, duration)
 
     def determine_version(self, request, *args, **kwargs):

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -363,10 +363,8 @@ class APIView(View):
                 if duration is not None
             ]
 
-            if durations:
-                self.throttled(request, max(durations))
-            else:
-                self.throttled(request, None)
+            duration = max(durations) if durations else None
+            self.throttled(request, duration)
 
     def determine_version(self, request, *args, **kwargs):
         """

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -168,16 +168,17 @@ class ThrottlingTests(TestCase):
         assert int(response['retry-after']) == 60
 
         previous_rate = User3SecRateThrottle.rate
-        User3SecRateThrottle.rate = '1/sec'
+        try:
+            User3SecRateThrottle.rate = '1/sec'
 
-        for dummy in range(24):
-            response = MockView_DoubleThrottling.as_view()(request)
+            for dummy in range(24):
+                response = MockView_DoubleThrottling.as_view()(request)
 
-        assert response.status_code == 429
-        assert int(response['retry-after']) == 60
-
-        # reset
-        User3SecRateThrottle.rate = previous_rate
+            assert response.status_code == 429
+            assert int(response['retry-after']) == 60
+        finally:
+            # reset
+            User3SecRateThrottle.rate = previous_rate
 
     def ensure_response_header_contains_proper_throttle_field(self, view, expected_headers):
         """

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -159,7 +159,7 @@ class ThrottlingTests(TestCase):
         assert response.status_code == 429
         assert int(response['retry-after']) == 58
 
-    def test_handle_negative_throttle_value(self):
+    def test_throttle_rate_change_negative(self):
         self.set_throttle_timer(MockView_DoubleThrottling, 0)
         request = self.factory.get('/')
         for dummy in range(24):

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -159,6 +159,26 @@ class ThrottlingTests(TestCase):
         assert response.status_code == 429
         assert int(response['retry-after']) == 58
 
+    def test_handle_negative_throttle_value(self):
+        self.set_throttle_timer(MockView_DoubleThrottling, 0)
+        request = self.factory.get('/')
+        for dummy in range(24):
+            response = MockView_DoubleThrottling.as_view()(request)
+        assert response.status_code == 429
+        assert int(response['retry-after']) == 60
+
+        previous_rate = User3SecRateThrottle.rate
+        User3SecRateThrottle.rate = '1/sec'
+
+        for dummy in range(24):
+            response = MockView_DoubleThrottling.as_view()(request)
+
+        assert response.status_code == 429
+        assert int(response['retry-after']) == 60
+
+        # reset
+        User3SecRateThrottle.rate = previous_rate
+
     def ensure_response_header_contains_proper_throttle_field(self, view, expected_headers):
         """
         Ensure the response returns an Retry-After field with status and next attributes


### PR DESCRIPTION
Fixes #6836
