### PR TITLE
change FileField.to_representation to EAFP style to better work with `django-storages`

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1546,16 +1546,15 @@ class FileField(Field):
             return None
 
         use_url = getattr(self, 'use_url', api_settings.UPLOADED_FILES_USE_URL)
-
         if use_url:
-            if not getattr(value, 'url', None):
-                # If the file has not been saved it may not have a URL.
+            try:
+                url = value.url
+                request = self.context.get('request', None)
+                if request is not None:
+                    return request.build_absolute_uri(url)
+                return url
+            except AttributeError:
                 return None
-            url = value.url
-            request = self.context.get('request', None)
-            if request is not None:
-                return request.build_absolute_uri(url)
-            return url
         return value.name
 
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1549,12 +1549,13 @@ class FileField(Field):
         if use_url:
             try:
                 url = value.url
-                request = self.context.get('request', None)
-                if request is not None:
-                    return request.build_absolute_uri(url)
-                return url
             except AttributeError:
                 return None
+            request = self.context.get('request', None)
+            if request is not None:
+                return request.build_absolute_uri(url)
+            return url
+
         return value.name
 
 


### PR DESCRIPTION
Hello :)

This PR is used for enhance performance when use with [`django-storages`](https://github.com/jschneier/django-storages).

When serializer encode data with `FileField`, the original way will cause `S3Boto3Storage.url` called twice. This method calls [`generate_presigned_url`](https://github.com/jschneier/django-storages/blob/44fe7698ece8bdf125d5529194e5277952bc6193/storages/backends/s3boto3.py#L622), which uses many computing times.

