### PR TITLE
Modify ModelSerializer to support per-action field configuration

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -498,6 +498,26 @@ Alternatively names in the `fields` options can map to properties or methods whi
 
 Since version 3.3.0, it is **mandatory** to provide one of the attributes `fields` or `exclude`.
 
+## Per-action fields
+
+For `ModelSerializer` instances that will be used with ViewSets, you can define per-action fields.
+
+For example:
+
+    class AccountSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = Account
+            fields = ['id', 'account_name', 'users', 'created']
+            action_fields = {
+                'list': {
+                    'fields': ['id', 'account_name']
+                }
+            }
+
+In the above example, for the `list` action, only the `id` and `account_name` will be serialized, however with any other action (such as `detail`), all of the fields in `Meta.fields` attribute will be serialized.
+
+The `action_fields` configuration works with custom actions, too. Additionally, you may use the `exclude` and `extra_kwargs` keys in the same way that `Meta.exclude` and `Meta.extra_kwargs` attributes are used.
+
 ## Specifying nested serialization
 
 The default `ModelSerializer` uses primary keys for relationships, but you can also easily generate nested representations using the `depth` option:

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -380,14 +380,16 @@ class TestRegularFieldMappings(TestCase):
                 fields = ('char_field')
                 action_fields = {
                     'list': {
-                        'exclude': ('big_integer_field', 'boolean_field',
+                        'exclude': (
+                            'big_integer_field', 'boolean_field',
                             'comma_separated_integer_field', 'date_field',
                             'datetime_field', 'email_field', 'float_field',
                             'integer_field', 'null_boolean_field',
                             'positive_small_integer_field', 'slug_field',
                             'small_integer_field', 'text_field', 'file_field',
                             'time_field', 'url_field', 'custom_field',
-                            'file_path_field')
+                            'file_path_field',
+                        )
                     }
                 }
 


### PR DESCRIPTION
## Description

This loosely Refs #4632 but they asked for per-action serializer configuration in ViewSets, however this PR implements a per-action serializer, so the ViewSet would just include one serializer. But this would resolve the underlying problem there.

The general idea is that this PR modifies the `ModelSerializer` to use a new attribute on the `Meta` class, `action_fields`. `action_fields` is a dictionary of strings that represent actions, and under the action is a dictionary of `fields`, `exclude`, and `extra_kwargs`, that work just like the `Meta` attributes, except they override the default serializer behavior for that particular action. The previous workaround was to override the `get_serializer_class` method and use the action to decide which serializer you want to use.

The nice thing about this is that it is backward compatible (everything works the same if you don't have the `action_fields` attribute), and it means you don't have to build multiple serializers. I noticed that when building multiple serializers for the same model, a lot of logic would be duplicated and it wasn't very DRY.

I did put all this functionality into a 3rd party package at https://github.com/gregschmit/drf-action-serializer, but since it ended up being such a small and backwards compatible change, I decided to see if the DRF community wanted to just pull it into the project.

Also, I did write tests and added a section to the documentation, however this is my first PR for this project and I'm very new to contributing to big open source projects, so please let me know if any of the code/tests/docs that I wrote are crap.