### PR TITLE
OpenAPI: Added description to responses.

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -490,6 +490,10 @@ class AutoSchema(ViewInspector):
                 'content': {
                     ct: {'schema': response_schema}
                     for ct in self.content_types
-                }
+                },
+                # description is a mandatory property,
+                # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject
+                # TODO: put something meaningful into it
+                'description': ""
             }
         }

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -84,6 +84,7 @@ class TestOperationIntrospection(TestCase):
             'parameters': [],
             'responses': {
                 '200': {
+                    'description': '',
                     'content': {
                         'application/json': {
                             'schema': {
@@ -190,6 +191,7 @@ class TestOperationIntrospection(TestCase):
         responses = inspector._get_responses(path, method)
         assert responses['200']['content']['application/json']['schema']['required'] == ['text']
         assert list(responses['200']['content']['application/json']['schema']['properties'].keys()) == ['text']
+        assert 'description' in responses['200']
 
     def test_response_body_nested_serializer(self):
         path = '/'
@@ -243,6 +245,7 @@ class TestOperationIntrospection(TestCase):
         responses = inspector._get_responses(path, method)
         assert responses == {
             '200': {
+                'description': '',
                 'content': {
                     'application/json': {
                         'schema': {
@@ -283,6 +286,7 @@ class TestOperationIntrospection(TestCase):
         responses = inspector._get_responses(path, method)
         assert responses == {
             '200': {
+                'description': '',
                 'content': {
                     'application/json': {
                         'schema': {


### PR DESCRIPTION
As discussed in #6833, just add an empty description to satisfy editor.swagger.io

Closes #6833.