### PR TITLE
ChoiceField converts between `key` and `display_name`

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -953,12 +953,13 @@ class TestFilePathField(FieldValues):
     """
 
     valid_inputs = {
-        __file__: __file__,
+        os.path.basename(__file__): os.path.abspath(__file__),
     }
     invalid_inputs = {
         'wrong_path': ['"wrong_path" is not a valid path choice.']
     }
     outputs = {
+        os.path.abspath(__file__): os.path.basename(__file__),
     }
     field = serializers.FilePathField(
         path=os.path.abspath(os.path.dirname(__file__))
@@ -1559,15 +1560,15 @@ class TestChoiceField(FieldValues):
     Valid and invalid values for `ChoiceField`.
     """
     valid_inputs = {
-        'poor': 'poor',
-        'medium': 'medium',
-        'good': 'good',
+        'Poor quality': 'poor',
+        'Medium quality': 'medium',
+        'Good quality': 'good',
     }
     invalid_inputs = {
         'amazing': ['"amazing" is not a valid choice.']
     }
     outputs = {
-        'good': 'good',
+        'good': 'Good quality',
         '': '',
         'amazing': 'amazing',
     }
@@ -1658,16 +1659,16 @@ class TestChoiceFieldWithType(FieldValues):
     instead of a char type.
     """
     valid_inputs = {
-        '1': 1,
-        3: 3,
+        'Poor quality': 1,
+        'Good quality': 3,
     }
     invalid_inputs = {
         5: ['"5" is not a valid choice.'],
         'abc': ['"abc" is not a valid choice.']
     }
     outputs = {
-        '1': 1,
-        1: 1
+        '1': '1',
+        1: 'Poor quality',
     }
     field = serializers.ChoiceField(
         choices=[
@@ -1703,15 +1704,15 @@ class TestChoiceFieldWithGroupedChoices(FieldValues):
     choices, rather than a list of pairs of (`value`, `description`).
     """
     valid_inputs = {
-        'poor': 'poor',
-        'medium': 'medium',
-        'good': 'good',
+        'Poor quality': 'poor',
+        'Medium quality': 'medium',
+        'Good quality': 'good',
     }
     invalid_inputs = {
         'awful': ['"awful" is not a valid choice.']
     }
     outputs = {
-        'good': 'good'
+        'good': 'Good quality'
     }
     field = serializers.ChoiceField(
         choices=[
@@ -1733,15 +1734,15 @@ class TestChoiceFieldWithMixedChoices(FieldValues):
     grouped.
     """
     valid_inputs = {
-        'poor': 'poor',
+        'Poor quality': 'poor',
         'medium': 'medium',
-        'good': 'good',
+        'Good quality': 'good',
     }
     invalid_inputs = {
         'awful': ['"awful" is not a valid choice.']
     }
     outputs = {
-        'good': 'good'
+        'good': 'Good quality'
     }
     field = serializers.ChoiceField(
         choices=[
@@ -1763,12 +1764,12 @@ class TestMultipleChoiceField(FieldValues):
     """
     valid_inputs = {
         (): set(),
-        ('aircon',): {'aircon'},
-        ('aircon', 'manual'): {'aircon', 'manual'},
+        ('AirCon',): {'aircon'},
+        ('AirCon', 'Manual drive'): {'aircon', 'manual'},
     }
     invalid_inputs = {
         'abc': ['Expected a list of items but got type "str".'],
-        ('aircon', 'incorrect'): ['"incorrect" is not a valid choice.']
+        ('AirCon', 'incorrect'): ['"incorrect" is not a valid choice.']
     }
     outputs = [
         (['aircon', 'manual', 'incorrect'], {'aircon', 'manual', 'incorrect'})

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -107,7 +107,7 @@ class Issue3674ChildModel(models.Model):
 class UniqueChoiceModel(models.Model):
     CHOICES = (
         ('choice1', 'choice 1'),
-        ('choice2', 'choice 1'),
+        ('choice2', 'choice 2'),
     )
 
     name = models.CharField(max_length=254, unique=True, choices=CHOICES)
@@ -1196,7 +1196,7 @@ class Test5004UniqueChoiceField(TestCase):
                 fields = '__all__'
 
         UniqueChoiceModel.objects.create(name='choice1')
-        serializer = TestUniqueChoiceSerializer(data={'name': 'choice1'})
+        serializer = TestUniqueChoiceSerializer(data={'name': 'choice 1'})
         assert not serializer.is_valid()
         assert serializer.errors == {'name': ['unique choice model with this name already exists.']}
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -196,7 +196,7 @@ class TestChoiceFieldChoicesValidate(TestCase):
         Make sure a value for choices works as expected.
         """
         f = serializers.ChoiceField(choices=self.CHOICES)
-        value = self.CHOICES[0][0]
+        value = self.CHOICES[0][1]
         try:
             f.to_internal_value(value)
         except serializers.ValidationError:
@@ -218,7 +218,7 @@ class TestChoiceFieldChoicesValidate(TestCase):
         Make sure a nested value for choices works as expected.
         """
         f = serializers.ChoiceField(choices=self.CHOICES_NESTED)
-        value = self.CHOICES_NESTED[0][1][0][0]
+        value = self.CHOICES_NESTED[0][1][0][1]
         try:
             f.to_internal_value(value)
         except serializers.ValidationError:


### PR DESCRIPTION
Perhaps I misunderstand the intended serialization and deserialization behaviors of `fields.ChoiceField`, but I recently noticed that although every `ChoiceField` instance stores all of the choices, pairs of `key` and `display_name`, with which it is initialized, I couldn't figure out when it ever actually _uses_ a choice's `display_name`. Meanwhile, I found myself manually converting user input values, which match choice `display_name`s, to the underlying data values that match the choice `key`s.

This pull request modifies the behavior of the `ChoiceField` so that it automatically deserializes user input into the corresponding underlying data values and does the reverse for serialization.

[Here][1] is a link to a related post that I wrote in the Django REST Framework Google group.

[1]: https://groups.google.com/forum/#!topic/django-rest-framework/1NsaEGJR6bE