### PR TITLE
Add more flexible rate attribute.

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -103,7 +103,10 @@ class SimpleRateThrottle(BaseThrottle):
             return (None, None)
         num, period = rate.split('/')
         num_requests = int(num)
-        duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[period[0]]
+        if not period.isdigit():
+            duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[period[0]]
+        else:
+            duration = int(period)
         return (num_requests, duration)
 
     def allow_request(self, request, view):


### PR DESCRIPTION
## Description

`rate` attribute in throttling classes allow use custom seconds, example: `rate = "1/300"` — 1 request per 5 minutes.