### PR TITLE
Schemas: Map renderers/parsers for request/response media-types.

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -465,6 +465,13 @@ class AutoSchema(ViewInspector):
 
     def _get_responses(self, path, method):
         # TODO: Handle multiple codes and pagination classes.
+        if method == 'DELETE':
+            return {
+                '204': {
+                    'description': ''
+                }
+            }
+
         item_schema = {}
         serializer = self._get_serializer(path, method)
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -9,7 +9,7 @@ from django.core.validators import (
 from django.db import models
 from django.utils.encoding import force_str
 
-from rest_framework import exceptions, serializers, renderers
+from rest_framework import exceptions, renderers, serializers
 from rest_framework.compat import uritemplate
 from rest_framework.fields import _UnvalidatedField, empty
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -93,7 +93,6 @@ class AutoSchema(ViewInspector):
     def get_operation(self, path, method):
         operation = {}
 
-
         operation['operationId'] = self._get_operation_id(path, method)
 
         parameters = []

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -264,6 +264,29 @@ class TestOperationIntrospection(TestCase):
             },
         }
 
+    def test_delete_response_body_generation(self):
+        """Test that a view's delete method generates a proper response body schema."""
+        path = '/{id}/'
+        method = 'DELETE'
+
+        class View(generics.DestroyAPIView):
+            serializer_class = views.ExampleSerializer
+
+        view = create_view(
+            View,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        responses = inspector._get_responses(path, method)
+        assert responses == {
+            '204': {
+                'description': '',
+            },
+        }
+
     def test_retrieve_response_body_generation(self):
         """Test that a list of properties is returned for retrieve item views."""
         path = '/{id}/'

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -287,6 +287,30 @@ class TestOperationIntrospection(TestCase):
             },
         }
 
+    def test_multipart_request_body_generation(self):
+        """Test that a view's delete method generates a proper response body schema."""
+        path = '/{id}/'
+        method = 'POST'
+
+        class ItemSerializer(serializers.Serializer):
+            attachment = serializers.FileField()
+
+        class View(generics.CreateAPIView):
+            serializer_class = ItemSerializer
+
+        view = create_view(
+            View,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        request_body = inspector._get_request_body(path, method)
+        assert 'multipart/form-data' in request_body['content']
+        attachment = request_body['content']['multipart/form-data']['schema']['properties']['attachment']
+        assert attachment['format'] == 'binary'
+
     def test_retrieve_response_body_generation(self):
         """Test that a list of properties is returned for retrieve item views."""
         path = '/{id}/'

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -5,6 +5,8 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import filters, generics, pagination, routers, serializers
 from rest_framework.compat import uritemplate
+from rest_framework.parsers import JSONParser, MultiPartParser
+from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
 from rest_framework.schemas.openapi import AutoSchema, SchemaGenerator
 
@@ -339,8 +341,55 @@ class TestOperationIntrospection(TestCase):
             },
         }
 
-    def test_multipart_request_body_generation(self):
-        """Test that a view's delete method generates a proper response body schema."""
+    def test_parser_mapping(self):
+        """Test that view's parsers are mapped to OA media types"""
+        path = '/{id}/'
+        method = 'POST'
+
+        class View(generics.CreateAPIView):
+            serializer_class = views.ExampleSerializer
+            parser_classes = [JSONParser, MultiPartParser]
+
+        view = create_view(
+            View,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        request_body = inspector._get_request_body(path, method)
+
+        assert len(request_body['content'].keys()) == 2
+        assert 'multipart/form-data' in request_body['content']
+        assert 'application/json' in request_body['content']
+
+    def test_renderer_mapping(self):
+        """Test that view's renderers are mapped to OA media types"""
+        path = '/{id}/'
+        method = 'GET'
+
+        class View(generics.CreateAPIView):
+            serializer_class = views.ExampleSerializer
+            renderer_classes = [JSONRenderer]
+
+        view = create_view(
+            View,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        responses = inspector._get_responses(path, method)
+        # TODO this should be changed once the multiple response
+        # schema support is there
+        success_response = responses['200']
+
+        assert len(success_response['content'].keys()) == 1
+        assert 'application/json' in success_response['content']
+
+    def test_serializer_filefield(self):
         path = '/{id}/'
         method = 'POST'
 
@@ -359,8 +408,8 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         request_body = inspector._get_request_body(path, method)
-        assert 'multipart/form-data' in request_body['content']
-        attachment = request_body['content']['multipart/form-data']['schema']['properties']['attachment']
+        mp_media = request_body['content']['multipart/form-data']
+        attachment = mp_media['schema']['properties']['attachment']
         assert attachment['format'] == 'binary'
 
     def test_retrieve_response_body_generation(self):


### PR DESCRIPTION
Issue #6863

**TL;DR** I ended up implementing an automatic parser/renderer mapping to corresponding request/response media type. The tests are passing.

So while testing this I discovered that every endpoint that supports request body, accepts multipart requests even if there are no file fields in serializers. This is correct since this is how DRF default parsers setting actually works. So there is no longer a need to handle endpoints that accept files in a special way. Anyway, this is just an idea let me know what you think @carltongibson @tomchristie 