### PR TITLE
Fixed incorrect min/max attributes for serializers.ListField

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -378,7 +378,7 @@ class AutoSchema(ViewInspector):
                 schema['default'] = field.default
             if field.help_text:
                 schema['description'] = str(field.help_text)
-            self._map_field_validators(field.validators, schema)
+            self._map_field_validators(field, field.validators, schema)
 
             properties[field.field_name] = schema
 
@@ -390,7 +390,7 @@ class AutoSchema(ViewInspector):
 
         return result
 
-    def _map_field_validators(self, validators, schema):
+    def _map_field_validators(self, field, validators, schema):
         """
         map field validators
         :param list:validators: list of field validators
@@ -406,9 +406,15 @@ class AutoSchema(ViewInspector):
             if isinstance(v, RegexValidator):
                 schema['pattern'] = v.regex.pattern
             elif isinstance(v, MaxLengthValidator):
-                schema['maxLength'] = v.limit_value
+                attr_name = 'maxLength'
+                if isinstance(field, serializers.ListField):
+                    attr_name = 'maxItems'
+                schema[attr_name] = v.limit_value
             elif isinstance(v, MinLengthValidator):
-                schema['minLength'] = v.limit_value
+                attr_name = 'minLength'
+                if isinstance(field, serializers.ListField):
+                    attr_name = 'minItems'
+                schema[attr_name] = v.limit_value
             elif isinstance(v, MaxValueValidator):
                 schema['maximum'] = v.limit_value
             elif isinstance(v, MinValueValidator):

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -378,7 +378,7 @@ class AutoSchema(ViewInspector):
                 schema['default'] = field.default
             if field.help_text:
                 schema['description'] = str(field.help_text)
-            self._map_field_validators(field, field.validators, schema)
+            self._map_field_validators(field, schema)
 
             properties[field.field_name] = schema
 
@@ -390,13 +390,11 @@ class AutoSchema(ViewInspector):
 
         return result
 
-    def _map_field_validators(self, field, validators, schema):
+    def _map_field_validators(self, field, schema):
         """
         map field validators
-        :param list:validators: list of field validators
-        :param dict:schema: schema that the validators get added to
         """
-        for v in validators:
+        for v in field.validators:
             # "Formats such as "email", "uuid", and so on, MAY be used even though undefined by this specification."
             # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#data-types
             if isinstance(v, EmailValidator):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -395,6 +395,9 @@ class TestOperationIntrospection(TestCase):
         assert properties['string']['minLength'] == 2
         assert properties['string']['maxLength'] == 10
 
+        assert properties['lst']['minItems'] == 2
+        assert properties['lst']['maxItems'] == 10
+
         assert properties['regex']['pattern'] == r'[ABC]12{3}'
         assert properties['regex']['description'] == 'must have an A, B, or C followed by 1222'
 

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -85,6 +85,12 @@ class ExampleValidatedSerializer(serializers.Serializer):
         ),
         help_text='must have an A, B, or C followed by 1222'
     )
+    lst = serializers.ListField(
+        validators=(
+            MaxLengthValidator(limit_value=10),
+            MinLengthValidator(limit_value=2),
+        )
+    )
     decimal1 = serializers.DecimalField(max_digits=6, decimal_places=2)
     decimal2 = serializers.DecimalField(max_digits=5, decimal_places=0,
                                         validators=(DecimalValidator(max_digits=17, decimal_places=4),))


### PR DESCRIPTION
Fixes #6862 

Had to replace `validators` with a `field` argument in `_map_field_validators` because otherwise there is no way to test whether the field is a `ListField` or a `CharField` and we need to know this since they have different length attributes in OpenAPI spec.