### PR TITLE
fix dynamic route can't match url rightly

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -38,8 +38,12 @@ def escape_curly_brackets(url_path):
     """
     Double brackets in regex of url_path for escape string formatting
     """
-    if ('{' and '}') in url_path:
-        url_path = url_path.replace('{', '{{').replace('}', '}}')
+    if '{' in url_path:
+        url_path = url_path.replace('{', '{{')
+
+    if '}' in url_path:
+        url_path = url_path.replace('}', '}}')
+
     return url_path
 
 


### PR DESCRIPTION
## Description

The `('{' and '}')` code return ` '}' `,  so it make an error.
A bug can be triggered by odd `'{'`.