### PR TITLE
Fixes #6875 - OpenAPI Schema inconsistent operationId casing

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -111,7 +111,7 @@ class AutoSchema(ViewInspector):
         """
         method_name = getattr(self.view, 'action', method.lower())
         if is_list_view(path, method, self.view):
-            action = 'List'
+            action = 'list'
         elif method_name not in self.method_mapping:
             action = method_name
         else:
@@ -135,10 +135,13 @@ class AutoSchema(ViewInspector):
                 name = name[:-7]
             elif name.endswith('View'):
                 name = name[:-4]
-            if name.endswith(action):  # ListView, UpdateAPIView, ThingDelete ...
+
+            # Due to camel-casing of classes and `action` being lowercase, apply title in order to find if action truly
+            # comes at the end of the name
+            if name.endswith(action.title()):  # ListView, UpdateAPIView, ThingDelete ...
                 name = name[:-len(action)]
 
-        if action == 'List' and not name.endswith('s'):  # ListThings instead of ListThing
+        if action == 'list' and not name.endswith('s'):  # listThings instead of listThing
             name += 's'
 
         return action + name

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -80,7 +80,7 @@ class TestOperationIntrospection(TestCase):
 
         operation = inspector.get_operation(path, method)
         assert operation == {
-            'operationId': 'ListExamples',
+            'operationId': 'listExamples',
             'parameters': [],
             'responses': {
                 '200': {
@@ -402,7 +402,7 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         operationId = inspector._get_operation_id(path, method)
-        assert operationId == 'ListExamples'
+        assert operationId == 'listExamples'
 
     def test_repeat_operation_ids(self):
         router = routers.SimpleRouter()


### PR DESCRIPTION
## Description

Fixes incorrect casing of `operationId` in OpenAPI generation - refs #6875. Specifically fixing `ListThings` to `listThings` which standardizes on `lowerInitialCamelCase` like the other method types.

Updated tests as well.

