### PR TITLE
Add django-restql to third party packages

### DIFF
--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -211,6 +211,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [djangorestframework-queryfields][djangorestframework-queryfields] - Serializer mixin allowing clients to control which fields will be sent in the API response.
 * [drf-flex-fields][drf-flex-fields] - Serializer providing dynamic field expansion and sparse field sets via URL parameters.
 * [drf-action-serializer][drf-action-serializer] - Serializer providing per-action fields config for use with ViewSets to prevent having to write multiple serializers.
+* [django-restql][django-restql] - Turn your REST API into a GraphQL like API(It allows clients to control which fields will be sent in a response, supports both flat and nested fields, uses GraphQL like syntax).
 
 ### Serializer fields
 
@@ -346,6 +347,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [django-rest-framework-condition]: https://github.com/jozo/django-rest-framework-condition
 [django-rest-witchcraft]: https://github.com/shosca/django-rest-witchcraft
 [drf-access-policy]: https://github.com/rsinger86/drf-access-policy
+[django-restql]: https://github.com/yezyilomo/django-restql
 [drf-flex-fields]: https://github.com/rsinger86/drf-flex-fields
 [drf-action-serializer]: https://github.com/gregschmit/drf-action-serializer
 [djangorestframework-mvt]: https://github.com/corteva/djangorestframework-mvt


### PR DESCRIPTION
I would like to add [django-restql ](https://github.com/yezyilomo/django-restql) to the docs, please let me know if I've added it to the wrong place in the docs or skipped any important step.