### PR TITLE
Add dasherize_url option to action decorator.

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -120,7 +120,7 @@ def schema(view_inspector):
     return decorator
 
 
-def action(methods=None, detail=None, url_path=None, url_name=None, underscore2dash=None, **kwargs):
+def action(methods=None, detail=None, url_path=None, url_name=None, dasherize_url=None, **kwargs):
     """
     Mark a ViewSet method as a routable action.
 
@@ -145,7 +145,7 @@ def action(methods=None, detail=None, url_path=None, url_name=None, underscore2d
         if url_path:
             func.url_path = url_path
         else:
-            func.url_path = func.__name__.replace('_', '-') if underscore2dash else func.__name__
+            func.url_path = func.__name__.replace('_', '-') if dasherize_url else func.__name__
 
         func.url_name = url_name if url_name else func.__name__.replace('_', '-')
         func.kwargs = kwargs

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -120,7 +120,7 @@ def schema(view_inspector):
     return decorator
 
 
-def action(methods=None, detail=None, url_path=None, url_name=None, **kwargs):
+def action(methods=None, detail=None, url_path=None, url_name=None, underscore2dash=None, **kwargs):
     """
     Mark a ViewSet method as a routable action.
 
@@ -142,6 +142,11 @@ def action(methods=None, detail=None, url_path=None, url_name=None, **kwargs):
         func.mapping = MethodMapper(func, methods)
 
         func.detail = detail
+        if url_path:
+            func.url_path = url_path
+        else:
+            func.url_path = func.__name__.replace('_', '-') if underscore2dash else func.__name__
+
         func.url_path = url_path if url_path else func.__name__
         func.url_name = url_name if url_name else func.__name__.replace('_', '-')
         func.kwargs = kwargs

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -147,7 +147,6 @@ def action(methods=None, detail=None, url_path=None, url_name=None, underscore2d
         else:
             func.url_path = func.__name__.replace('_', '-') if underscore2dash else func.__name__
 
-        func.url_path = url_path if url_path else func.__name__
         func.url_name = url_name if url_name else func.__name__.replace('_', '-')
         func.kwargs = kwargs
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -183,6 +183,13 @@ class ActionDecoratorTestCase(TestCase):
             'description': 'Description',
         }
 
+    def test_underscore2dash(self):
+        @action(detail=True, underscore2dash=True)
+        def test_action(request):
+            """Description"""
+
+        assert test_action.url_path == 'test-action'
+
     def test_detail_required(self):
         with pytest.raises(AssertionError) as excinfo:
             @action()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -183,8 +183,8 @@ class ActionDecoratorTestCase(TestCase):
             'description': 'Description',
         }
 
-    def test_underscore2dash(self):
-        @action(detail=True, underscore2dash=True)
+    def test_dasherize_url(self):
+        @action(detail=True, dasherize_url=True)
         def test_action(request):
             """Description"""
 


### PR DESCRIPTION
## Description

According to [Google Webmaster Central](https://support.google.com/webmasters/answer/76329?hl=en), They recommend using hyphens (-) instead of underscores (_) in URLs.

But the python function convention uses underscores (_) to separate words. 
So I noticed that all python functions with underscores had like this code.

```
@detail_route(['post'], url_path='send-push')
def send_push(self, request, pk=None):
    pass
```

I don't think this is an elegant solution and a comfortable way.
Hence, I added underscore2dash option and test code into the action decorator.

Regards.
