### PR TITLE
Add raw_id_fields to `authtoken` admin

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -7,6 +7,7 @@ class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
     ordering = ('-created',)
+    raw_id_fields = ('user',)
 
 
 admin.site.register(Token, TokenAdmin)


### PR DESCRIPTION
## Description

This fixes an issue where the admin pages hang when you have a large number of users.