### PR TITLE
Replaced 'TODO' hardcoded version info by a parameter with default '0…

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -60,7 +60,8 @@ urlpatterns = [
     #   * Provide view name for use with `reverse()`.
     path('openapi', get_schema_view(
         title="Your Project",
-        description="API for all things …"
+        description="API for all things …",
+        version="1.0.0"
     ), name='openapi-schema'),
     # ...
 ]
@@ -72,6 +73,7 @@ The `get_schema_view()` helper takes the following keyword arguments:
 
 * `title`: May be used to provide a descriptive title for the schema definition.
 * `description`: Longer descriptive text.
+* `version`: The version of the API. Defaults to `0.1.0`.
 * `url`: May be used to pass a canonical base URL for the schema.
 
         schema_view = get_schema_view(
@@ -137,6 +139,7 @@ Arguments:
 
 * `title` **required**: The name of the API.
 * `description`: Longer descriptive text.
+* `version`: The version of the API. Defaults to `0.1.0`.
 * `url`: The root URL of the API schema. This option is not required unless the schema is included under path prefix.
 * `patterns`: A list of URLs to inspect when generating the schema. Defaults to the project's URL conf.
 * `urlconf`: A URL conf module name to use when generating the schema. Defaults to `settings.ROOT_URLCONF`.

--- a/rest_framework/schemas/__init__.py
+++ b/rest_framework/schemas/__init__.py
@@ -31,7 +31,8 @@ def get_schema_view(
         title=None, url=None, description=None, urlconf=None, renderer_classes=None,
         public=False, patterns=None, generator_class=None,
         authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
-        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES):
+        permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES,
+        version=None):
     """
     Return a schema view.
     """
@@ -43,7 +44,7 @@ def get_schema_view(
 
     generator = generator_class(
         title=title, url=url, description=description,
-        urlconf=urlconf, patterns=patterns,
+        urlconf=urlconf, patterns=patterns, version=version
     )
 
     # Avoid import cycle on APIView

--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -124,7 +124,7 @@ class SchemaGenerator(BaseSchemaGenerator):
     # Set by 'SCHEMA_COERCE_METHOD_NAMES'.
     coerce_method_names = None
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None):
+    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
         assert coreapi, '`coreapi` must be installed for schema support.'
         assert coreschema, '`coreschema` must be installed for schema support.'
 

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -151,7 +151,7 @@ class BaseSchemaGenerator(object):
     # Set by 'SCHEMA_COERCE_PATH_PK'.
     coerce_path_pk = None
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None):
+    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version='0.1.0'):
         if url and not url.endswith('/'):
             url += '/'
 
@@ -161,6 +161,7 @@ class BaseSchemaGenerator(object):
         self.urlconf = urlconf
         self.title = title
         self.description = description
+        self.version = version
         self.url = url
         self.endpoints = None
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -24,7 +24,7 @@ class SchemaGenerator(BaseSchemaGenerator):
     def get_info(self):
         info = {
             'title': self.title,
-            'version': 'TODO',
+            'version': self.version,
         }
 
         if self.description is not None:

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -489,3 +489,17 @@ class TestGenerator(TestCase):
 
         assert 'openapi' in schema
         assert 'paths' in schema
+
+    def test_schema_information(self):
+        """Construction of the top level dictionary."""
+        patterns = [
+            url(r'^example/?$', views.ExampleListView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=patterns, title='My title', version='1.2.3', description='My description')
+
+        request = create_request('/')
+        schema = generator.get_schema(request=request)
+
+        assert schema['info']['title'] == 'My title'
+        assert schema['info']['version'] == '1.2.3'
+        assert schema['info']['description'] == 'My description'


### PR DESCRIPTION
Openapi SchemaGenerator was setting 'TODO' as version info. Replaced by a parameter with default value '0.1.0'