### PR TITLE
Allow setting trim_whitespace globally through API settings

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -158,12 +158,12 @@ A text representation. Optionally validates the text to be shorter than `max_len
 
 Corresponds to `django.db.models.fields.CharField` or `django.db.models.fields.TextField`.
 
-**Signature:** `CharField(max_length=None, min_length=None, allow_blank=False, trim_whitespace=True)`
+**Signature:** `CharField(max_length=None, min_length=None, allow_blank=False, trim_whitespace=api_settings.TRIM_WHITESPACE)`
 
 - `max_length` - Validates that the input contains no more than this number of characters.
 - `min_length` - Validates that the input contains no fewer than this number of characters.
 - `allow_blank` - If set to `True` then the empty string should be considered a valid value. If set to `False` then the empty string is considered invalid and will raise a validation error. Defaults to `False`.
-- `trim_whitespace` - If set to `True` then leading and trailing whitespace is trimmed. Defaults to `True`.
+- `trim_whitespace` - If set to `True` then leading and trailing whitespace is trimmed. Defaults to the `TRIM_WHITESPACE` settings key which is `True` by default.
 
 The `allow_null` option is also available for string fields, although its usage is discouraged in favor of `allow_blank`. It is valid to set both `allow_blank=True` and `allow_null=True`, but doing so means that there will be two differing types of empty value permissible for string representations, which can lead to data inconsistencies and subtle application bugs.
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -768,7 +768,7 @@ class CharField(Field):
 
     def __init__(self, **kwargs):
         self.allow_blank = kwargs.pop('allow_blank', False)
-        self.trim_whitespace = kwargs.pop('trim_whitespace', True)
+        self.trim_whitespace = kwargs.pop('trim_whitespace', api_settings.TRIM_WHITESPACE)
         self.max_length = kwargs.pop('max_length', None)
         self.min_length = kwargs.pop('min_length', None)
         super().__init__(**kwargs)

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -113,6 +113,7 @@ DEFAULTS = {
     'STRICT_JSON': True,
     'COERCE_DECIMAL_TO_STRING': True,
     'UPLOADED_FILES_USE_URL': True,
+    'TRIM_WHITESPACE': True,
 
     # Browseable API
     'HTML_SELECT_CUTOFF': 1000,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -741,6 +741,13 @@ class TestCharField(FieldValues):
         field = serializers.CharField(trim_whitespace=False)
         assert field.to_internal_value(' abc ') == ' abc '
 
+    def test_trim_whitespace_setting(self):
+        with override_settings(REST_FRAMEWORK={"TRIM_WHITESPACE": True}):
+            assert serializers.CharField().trim_whitespace is True
+
+        with override_settings(REST_FRAMEWORK={"TRIM_WHITESPACE": False}):
+            assert serializers.CharField().trim_whitespace is False
+
     def test_disallow_blank_with_trim_whitespace(self):
         field = serializers.CharField(allow_blank=False, trim_whitespace=True)
 


### PR DESCRIPTION
Allow setting the default value of `CharField`'s `trim_whitespace` from DRF's settings file.

Background: Generally speaking, `trim_whitespace` should not be defaulted to `True`, as it is a destructive operation, i.e. changing user data where it might not be expected.

Real-world issue that happened today: A model has a `unique_together` over 2 columns, where one is a `CharField`. Blanks are perfectly fine for the data in this case, and several places use and store it just like that. Now the user receives the JSON payload _with_ a blank, and sends it back _with_ a blank. The unique constraint fails because DRF dropped the whitespace. This is unexpected and even dangerous — at least as the default behavior.

Having a setting key for the default allows people like me to change the global behavior to be not destructive. And the default of `True` makes all users happy that rely on the current behavior. Of course I'd vote for changing the default behavior.