### PR TITLE
ease sublcassing related fields

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -526,7 +526,7 @@ class ManyRelatedField(Field):
         if hasattr(instance, 'pk') and instance.pk is None:
             return []
 
-        relationship = get_attribute(instance, self.source_attrs)
+        relationship = self.child_relation.get_attribute(instance)
         return relationship.all() if hasattr(relationship, 'all') else relationship
 
     def to_representation(self, iterable):


### PR DESCRIPTION
ManyRelatedField is automatically invoked by related fields given `many=True` option.

However, subclassing a related field might require `get_attribute` to be overridden. Current implementation does not support this, unless `many_init` is overridden as well. This seems to be cumbersome and I couldn't find an issue with directly calling `get_attribute` from the child_relation.

FYI: This is the only method I had an issue with, so there might be similar cases where subclassing gets difficult once `many=True` is given.