### PR TITLE
Default OpenAPI version to the empty string

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -151,7 +151,7 @@ class BaseSchemaGenerator(object):
     # Set by 'SCHEMA_COERCE_PATH_PK'.
     coerce_path_pk = None
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version='0.1.0'):
+    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=''):
         if url and not url.endswith('/'):
             url += '/'
 


### PR DESCRIPTION
The OpenAPI `['info']['version']` property now defaults to the empty string, unless explicitly set.

Discussed at https://github.com/encode/django-rest-framework/commit/e57c1505fc4ed957332ae547a35c8713acfdf30c#r34944838