### PR TITLE
OpenAPI: Fixed generation when title or version not provided.

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -73,7 +73,7 @@ The `get_schema_view()` helper takes the following keyword arguments:
 
 * `title`: May be used to provide a descriptive title for the schema definition.
 * `description`: Longer descriptive text.
-* `version`: The version of the API. Defaults to `0.1.0`.
+* `version`: The version of the API.
 * `url`: May be used to pass a canonical base URL for the schema.
 
         schema_view = get_schema_view(

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -151,7 +151,7 @@ class BaseSchemaGenerator(object):
     # Set by 'SCHEMA_COERCE_PATH_PK'.
     coerce_path_pk = None
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=''):
+    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
         if url and not url.endswith('/'):
             url += '/'
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -21,18 +21,11 @@ from .utils import get_pk_description, is_list_view
 
 class SchemaGenerator(BaseSchemaGenerator):
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
-        # Title and version are required by openapi specification 3.x
-        if title is None:
-            title = ''
-        if version is None:
-            version = ''
-        super().__init__(title, url, description, patterns, urlconf, version)
-
     def get_info(self):
+        # Title and version are required by openapi specification 3.x
         info = {
-            'title': self.title,
-            'version': self.version,
+            'title': self.title or '',
+            'version': self.version or ''
         }
 
         if self.description is not None:

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -21,6 +21,14 @@ from .utils import get_pk_description, is_list_view
 
 class SchemaGenerator(BaseSchemaGenerator):
 
+    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
+        # Title and version are required by openapi specification 3.x
+        if title is None:
+            title = ''
+        if version is None:
+            version = ''
+        super().__init__(title, url, description, patterns, urlconf, version)
+
     def get_info(self):
         info = {
             'title': self.title,

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -570,3 +570,16 @@ class TestGenerator(TestCase):
         assert schema['info']['title'] == 'My title'
         assert schema['info']['version'] == '1.2.3'
         assert schema['info']['description'] == 'My description'
+
+    def test_schema_information_empty(self):
+        """Construction of the top level dictionary."""
+        patterns = [
+            url(r'^example/?$', views.ExampleListView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=patterns)
+
+        request = create_request('/')
+        schema = generator.get_schema(request=request)
+
+        assert schema['info']['title'] == ''
+        assert schema['info']['version'] == ''


### PR DESCRIPTION
## Description

Generated openapi definition is not valid if title or version are not provided.

- title and version are required by openapi specification 3.x
- fixed my mistake with default parameter introduced here: #6899 
- reverted my documentation change after #6907 