### PR TITLE
Set the proper JSON schema type for HStoreFields in OpenAPI schemas

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -344,6 +344,7 @@ class AutoSchema(ViewInspector):
             serializers.BooleanField: 'boolean',
             serializers.JSONField: 'object',
             serializers.DictField: 'object',
+            serializers.HStoreField: 'object',
         }
         return {'type': FIELD_CLASS_SCHEMA_TYPE.get(field.__class__, 'string')}
 

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -437,6 +437,22 @@ class TestOperationIntrospection(TestCase):
         assert properties['date']['format'] == 'date'
         assert properties['datetime']['format'] == 'date-time'
 
+    def test_serializer_hstorefield(self):
+        path = '/'
+        method = 'GET'
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        responses = inspector._get_responses(path, method)
+        response_schema = responses['200']['content']['application/json']['schema']
+        properties = response_schema['items']['properties']
+        assert properties['hstore']['type'] == 'object'
+
     def test_serializer_validators(self):
         path = '/'
         method = 'GET'

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -33,6 +33,7 @@ class ExampleDetailView(APIView):
 class ExampleSerializer(serializers.Serializer):
     date = serializers.DateField()
     datetime = serializers.DateTimeField()
+    hstore = serializers.HStoreField()
 
 
 class ExampleGenericAPIView(generics.GenericAPIView):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

HStoreFields were described as `{"type": "string"}` inside OpenAPI schemas, while they should actually be `{"type": "object"}`, because the generator did not recognize them. This PR fixes this issue and adds a test case for this particular field.

Fixes #6913
