### PR TITLE
Trying to introspect openapi security schemes

### DIFF
--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -95,6 +95,7 @@ class TestOperationIntrospection(TestCase):
                     },
                 },
             },
+            'security': [{'BasicAuth': []}],
         }
 
     def test_path_with_id_parameter(self):


### PR DESCRIPTION
Hello,

I noticed that the generation of openapi schema is not managing authentication. It seems also that openapi schema contains only the views that the current user is allowed to use. Why not list all the endpoints and add try to introspect the openapi `security` and 'securitySchemes'. Then an openapi client (for example Swagger) will give the opportunity to the user to login with the related security scheme.

What do you think?

(This PR was helping me to understand how it's work: it's not ready to merge!)