### PR TITLE
Use an uppercase List action in OpenAPI

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -111,7 +111,7 @@ class AutoSchema(ViewInspector):
         """
         method_name = getattr(self.view, 'action', method.lower())
         if is_list_view(path, method, self.view):
-            action = 'list'
+            action = 'List'
         elif method_name not in self.method_mapping:
             action = method_name
         else:
@@ -141,7 +141,7 @@ class AutoSchema(ViewInspector):
             if name.endswith(action.title()):  # ListView, UpdateAPIView, ThingDelete ...
                 name = name[:-len(action)]
 
-        if action == 'list' and not name.endswith('s'):  # listThings instead of listThing
+        if action == 'List' and not name.endswith('s'):  # ListThings instead of ListThing
             name += 's'
 
         return action + name

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -80,7 +80,7 @@ class TestOperationIntrospection(TestCase):
 
         operation = inspector.get_operation(path, method)
         assert operation == {
-            'operationId': 'listExamples',
+            'operationId': 'ListExamples',
             'parameters': [],
             'responses': {
                 '200': {
@@ -402,7 +402,7 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         operationId = inspector._get_operation_id(path, method)
-        assert operationId == 'listExamples'
+        assert operationId == 'ListExamples'
 
     def test_repeat_operation_ids(self):
         router = routers.SimpleRouter()


### PR DESCRIPTION
Here's another one on OpenAPI, @carltongibson!

This fixes a small issue with endpoint names inside OpenAPI schemas, where list endpoints are named `listThings` instead of `ListThings` like all other endpoints.