### PR TITLE
Allow to specify JSONField and HStoreField lookup paths in search_fields

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -90,6 +90,9 @@ class SearchFilter(BaseFilterBackend):
             parts = search_field.split(LOOKUP_SEP)
             for part in parts:
                 field = opts.get_field(part)
+                if field.get_internal_type() in ('JSONField', 'HStoreField'):
+                    # These fields support arbitrary key lookups
+                    break
                 if hasattr(field, 'get_path_info'):
                     # This field is a relation, update opts to follow the relation
                     path_info = field.get_path_info()


### PR DESCRIPTION
## Description

This small change allows to specify key lookup paths for PostgreSQL specific `JSONField` and `HStoreField` in a `search_fields` view attribute which configures `SearchFilter` behaviour:

```python
class SearchFilterModelPostgres(models.Model):
    json_field = postgres_fields.JSONField()


class SearchFilterPostgresSerializer(serializers.ModelSerializer):
    class Meta:
        model = SearchFilterModelPostgres
        fields = '__all__'


@pytest.mark.skipif('connection.vendor != "postgresql"')
class SearchFilterPostgresTests(TestCase):

    def setUp(self):
        for idx in range(10):
            title = 'z' * (idx + 1)
            text = (
                chr(idx + ord('a')) +
                chr(idx + ord('b')) +
                chr(idx + ord('c'))
            )
            SearchFilterModelPostgres(
                json_field={'title': title, 'text': text}
            ).save()
            
    def test_exact_json_search(self):
        class SearchListView(generics.ListAPIView):
            queryset = SearchFilterModelPostgres.objects.all()
            serializer_class = SearchFilterPostgresSerializer
            filter_backends = (filters.SearchFilter,)
            search_fields = ('json_field__title', 'json_field__text')

        view = SearchListView.as_view()
        request = factory.get('/', {'search': 'b'})
        response = view(request)
        assert response.data == [
            {'id': 1, 'json_field': {'title': 'z', 'text': 'abc'}},
            {'id': 2, 'json_field': {'title': 'zz', 'text': 'bcd'}},
        ]
```

I do not include tests in the commit because a lot of existing Django REST Framework tests seem to fail with `postgresql` database backend anyway (or I just don't know how to configure them properly: many of the tests rely on exact primary key values, as in my test above).

Also, I'm not sure whether it's intended behaviour to immediately return `False` from `must_call_distinct()` in case when one of the `search_fields` is an annotation. I suspect it's a bug but leave it as is here.