### PR TITLE
Support PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
       - { python: "3.7", env: DJANGO=2.2 }
       - { python: "3.7", env: DJANGO=master }
 
+      - { python: "pypy3", env: DJANGO=2.1 }
+      - { python: "pypy3", env: DJANGO=2.2 }
+
       - { python: "3.7", env: TOXENV=base }
       - { python: "3.7", env: TOXENV=lint }
       - { python: "3.7", env: TOXENV=docs }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 
 # Requirements
 
-* Python (3.5, 3.6, 3.7)
+* Python (3.5, 3.6, 3.7) and PyPy3
 * Django (1.11, 2.0, 2.1, 2.2)
 
 We **highly recommend** and only officially support the latest patch release of

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',
     ],
     project_urls={


### PR DESCRIPTION
## Description

The latest PyPy3 currently supports Python 3.6. We've witnessed large speed ups of `Serializer`'s using PyPy3 over CPython.

This PR adds testing for PyPy3 so that support for PyPy3 does not regress.

The PR is conservative as it only adds builds for supported Django 2.X builds (at the time of writing, 2.1 and 2.2).