### PR TITLE
Additional throttle rate configurability

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -41,7 +41,7 @@ The default throttling policy may be set globally, using the `DEFAULT_THROTTLE_C
         }
     }
 
-The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `second`, `minute`, `hour` or `day` as the throttle period. To set the rate to a fraction of a period, simply prepend the desired timespan. For example, a rate of `'100/30s'` will mean "limit requests to a maximum of 100 per every 30 seconds".
+The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `second`, `minute`, `hour` or `day` as the throttle period. The throttle period can optionally include a number, too. For example, a rate of `100 / 30 seconds` will mean "limit requests to a maximum of 100 per every 30 seconds".
 
 You can also set the throttling policy on a per-view or per-viewset basis,
 using the `APIView` class-based views.

--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -41,7 +41,7 @@ The default throttling policy may be set globally, using the `DEFAULT_THROTTLE_C
         }
     }
 
-The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `second`, `minute`, `hour` or `day` as the throttle period.
+The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `second`, `minute`, `hour` or `day` as the throttle period. To set the rate to a fraction of a period, simply prepend the desired timespan. For example, a rate of `'100/30s'` will mean "limit requests to a maximum of 100 per every 30 seconds".
 
 You can also set the throttling policy on a per-view or per-viewset basis,
 using the `APIView` class-based views.

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -106,15 +106,15 @@ class SimpleRateThrottle(BaseThrottle):
         try:
             num, period = rate.split('/')
             num_requests = int(num)
-            # Get rate multiplier value if available
-            period_mult, _ = re.split('[s|m|h|d]', period, maxsplit=1)
-            period_char = re.findall('[s|m|h|d]', period)[0]
-        except ValueError:
+            period_timescale = re.findall(r'^\d*[s|m|h|d]', period)[0]
+            period_char = period_timescale[-1]
+        except (ValueError, IndexError):
             msg = "Incorrect throttle rate set for '%s' scope" % self.scope
             raise ImproperlyConfigured(msg)
 
         try:
-            period_mult = int(period_mult)
+            # Get rate multiplier value if available
+            period_mult = int(period_timescale[:-1])
         except ValueError:
             period_mult = 1
 

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -106,7 +106,8 @@ class SimpleRateThrottle(BaseThrottle):
         try:
             num, period = rate.split('/')
             num_requests = int(num)
-            period_timescale = re.findall(r'^\d*[s|m|h|d]', period)[0]
+            period_timescale = re.findall(r'^\d*[s|m|h|d]',
+                                          ''.join(period.split()))[0]
             period_char = period_timescale[-1]
         except (ValueError, IndexError):
             msg = "Incorrect throttle rate set for '%s' scope" % self.scope

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -503,9 +503,15 @@ class SimpleRateThrottleTests(TestCase):
         rate = SimpleRateThrottle().parse_rate(rate_str)
         assert rate == (100, 30)
 
-        SimpleRateThrottle.rate = '100/10d'
-        rate = SimpleRateThrottle().parse_rate('100/10d')
+        rate_str = '100/10d'
+        SimpleRateThrottle.rate = rate_str
+        rate = SimpleRateThrottle().parse_rate(rate_str)
         assert rate == (100, 10 * 86400)
+
+        rate_str = '100 / 36 hours'
+        SimpleRateThrottle.rate = rate_str
+        rate = SimpleRateThrottle().parse_rate(rate_str)
+        assert rate == (100, 36 * 3600)
 
     def test_parse_rate_returns_tuple_with_none_if_rate_not_provided(self):
         rate = SimpleRateThrottle().parse_rate(None)

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -474,11 +474,11 @@ class SimpleRateThrottleTests(TestCase):
         with pytest.raises(ImproperlyConfigured):
             SimpleRateThrottle()
 
-        SimpleRateThrottle.rate = '100/century'
+        SimpleRateThrottle.rate = '100/foos'
         with pytest.raises(ImproperlyConfigured):
             SimpleRateThrottle()
 
-        SimpleRateThrottle.rate = '100/10century'
+        SimpleRateThrottle.rate = '100/10foos'
         with pytest.raises(ImproperlyConfigured):
             SimpleRateThrottle()
 


### PR DESCRIPTION
## Description

_NB: This is my first ever pull request to an open source library, so please do let me know if there is anything to fix / change / not do again in the future. I've made sure I've read the contributing guidelines prior to this, too._

This pull requests addresses a lack of configurability for throttling rate that I found while working with Django Rest Framework on a project. I've **added a way to specify more fine grained throttle rate**: in addition to being able to specify the throttle rate as `100/hour` or `10/minute`, we can now also specify `100/36hour` or `100/15minute`. Tests and documentation included.

I also found that the throttle rate parsing was not previously handled using ImproperlyConfigured exception. Not sure if that was intentional or just plain skipped. Added that, too.