### PR TITLE
Fix KeyError when delete required property from schema with patch method

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -387,7 +387,7 @@ class AutoSchema(ViewInspector):
         result = {
             'properties': properties
         }
-        if len(required) > 0:
+        if required:
             result['required'] = required
 
         return result
@@ -463,7 +463,7 @@ class AutoSchema(ViewInspector):
         content = self._map_serializer(serializer)
         # No required fields for PATCH
         if method == 'PATCH':
-            del content['required']
+            content.pop('required', None)
         # No read_only fields for request.
         for name, schema in content['properties'].copy().items():
             if 'readOnly' in schema:

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -169,6 +169,31 @@ class TestOperationIntrospection(TestCase):
         for response in inspector._get_responses(path, method).values():
             assert 'required' not in response['content']['application/json']['schema']
 
+    def test_empty_required_with_patch_method(self):
+        path = '/'
+        method = 'PATCH'
+
+        class Serializer(serializers.Serializer):
+            read_only = serializers.CharField(read_only=True)
+            write_only = serializers.CharField(write_only=True, required=False)
+
+        class View(generics.GenericAPIView):
+            serializer_class = Serializer
+
+        view = create_view(
+            View,
+            method,
+            create_request(path)
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        request_body = inspector._get_request_body(path, method)
+        # there should be no empty 'required' property, see #6834
+        assert 'required' not in request_body['content']['application/json']['schema']
+        for response in inspector._get_responses(path, method).values():
+            assert 'required' not in response['content']['application/json']['schema']
+
     def test_response_body_generation(self):
         path = '/'
         method = 'POST'


### PR DESCRIPTION
## Description

Improve delete of required property from OpenAPI schema avoiding `KeyError` exception.

### Traceback:

```
ERROR    django.request:log.py:228 Internal Server Error: /
Traceback (most recent call last):
  File "/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/lib/python3.7/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/lib/python3.7/site-packages/rest_framework/views.py", line 505, in dispatch
    response = self.handle_exception(exc)
  File "/lib/python3.7/site-packages/rest_framework/schemas/views.py", line 48, in handle_exception
    return super().handle_exception(exc)
  File "/lib/python3.7/site-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/lib/python3.7/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/lib/python3.7/site-packages/rest_framework/views.py", line 502, in dispatch
    response = handler(request, *args, **kwargs)
  File "/lib/python3.7/site-packages/rest_framework/schemas/views.py", line 37, in get
    schema = self.schema_generator.get_schema(request, self.public)
  File "/lib/python3.7/site-packages/rest_framework/schemas/openapi.py", line 64, in get_schema
    paths = self.get_paths(None if public else request)
  File "/lib/python3.7/site-packages/rest_framework/schemas/openapi.py", line 47, in get_paths
    operation = view.schema.get_operation(path, method)
  File "/lib/python3.7/site-packages/rest_framework/schemas/openapi.py", line 101, in get_operation
    request_body = self._get_request_body(path, method)
  File "/lib/python3.7/site-packages/rest_framework/schemas/openapi.py", line 466, in _get_request_body
    del content['required']
KeyError: 'required'
```