### PR TITLE
Add django-restql to 3rd party packages in docs

### DIFF
--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -212,6 +212,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [drf-flex-fields][drf-flex-fields] - Serializer providing dynamic field expansion and sparse field sets via URL parameters.
 * [drf-action-serializer][drf-action-serializer] - Serializer providing per-action fields config for use with ViewSets to prevent having to write multiple serializers.
 * [djangorestframework-dataclasses][djangorestframework-dataclasses] - Serializer providing automatic field generation for Python dataclasses, like the built-in ModelSerializer does for models.
+* [django-restql][django-restql] - Turn your REST API into a GraphQL like API(It allows clients to control which fields will be sent in a response, uses GraphQL like syntax, supports read and write on both flat and nested fields).
 
 ### Serializer fields
 
@@ -350,5 +351,6 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [drf-flex-fields]: https://github.com/rsinger86/drf-flex-fields
 [drf-action-serializer]: https://github.com/gregschmit/drf-action-serializer
 [djangorestframework-dataclasses]: https://github.com/oxan/djangorestframework-dataclasses
+[django-restql]: https://github.com/yezyilomo/django-restql
 [djangorestframework-mvt]: https://github.com/corteva/djangorestframework-mvt
 [django-rest-framework-guardian]: https://github.com/rpkilby/django-rest-framework-guardian


### PR DESCRIPTION
I'd like to add my [django-restql](https://github.com/yezyilomo/django-restql) package to the list of 3rd party packages in the docs.