### PR TITLE
Fix sorting by related fields with cursor pagination

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -873,7 +873,9 @@ class CursorPagination(BasePagination):
         if isinstance(instance, dict):
             attr = instance[field_name]
         else:
-            attr = getattr(instance, field_name)
+            attr = instance
+            for field in field_name.split('__'):
+                attr = getattr(attr, field)
         return str(attr)
 
     def get_paginated_response(self, data):


### PR DESCRIPTION
Allow sorting by `related_field__field_name` using django notation with `__` as separator.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

CursorPagination throws AttributeError when ordering is done on related fields (e.g. `related_field__field_name`). `getattr` obviously fails on such field name. splitting by `__` and calling `getattr` multiple times fixes this.