### PR TITLE
Add debouncing to rate throttle

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -195,8 +195,36 @@ The following is an example of a rate throttle, that will randomly throttle 1 in
         def allow_request(self, request, view):
             return random.randint(1, 10) != 1
 
+
+# Debouncing
+
+[Debouncing][debounce] refers to disallowing rapid invocations of the throttled view regardless of its actual throttling rate.
+
+When deriving a custom throttle from `throttling.SimpleRateThrottle` (or one of its concrete subclasses described above), you may override the `get_debounce_interval()` function, or set the
+class-level `debounce_interval` to a value in seconds.
+
+For instance,
+
+    class FiveSecondDebounce(throttling.UserRateThrottle):
+        debounce_interval = 5
+        rate = '10/min'
+
+would allow each user/IP address (as described above) to invoke the view 10 times in a minute, but only after 5 seconds have
+passed from the previous successful invocation.
+
+Using `get_debounce_interval()`, one can e.g. ensure superusers can always invoke the view regardless of debouncing.
+
+    class FiveSecondDebounce(throttling.UserRateThrottle):
+        rate = '10/min'
+
+        def get_debounce_interval(self, request, view):
+            if request.user.is_superuser:
+                return 0
+            return 5
+
 [cite]: https://developer.twitter.com/en/docs/basics/rate-limiting
 [permissions]: permissions.md
 [identifying-clients]: http://oxpedia.org/wiki/index.php?title=AppSuite:Grizzly#Multiple_Proxies_in_front_of_the_cluster
 [cache-setting]: https://docs.djangoproject.com/en/stable/ref/settings/#caches
 [cache-docs]: https://docs.djangoproject.com/en/stable/topics/cache/#setting-up-the-cache
+[debounce]: https://en.wikipedia.org/wiki/Switch#Contact_bounce

--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -222,6 +222,8 @@ Using `get_debounce_interval()`, one can e.g. ensure superusers can always invok
                 return 0
             return 5
 
+Note that due to the current implementation, debouncing _requires_ a throttling rate to be set as well.
+
 [cite]: https://developer.twitter.com/en/docs/basics/rate-limiting
 [permissions]: permissions.md
 [identifying-clients]: http://oxpedia.org/wiki/index.php?title=AppSuite:Grizzly#Multiple_Proxies_in_front_of_the_cluster

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -67,6 +67,9 @@ class SimpleRateThrottle(BaseThrottle):
     debounce_interval = None
 
     def __init__(self):
+        # TODO: this should probably be deferred to `allow_request`,
+        #       to simplify `ScopedRateThrottle` as well as to allow debouncing
+        #       without rate limiting.
         if not getattr(self, 'rate', None):
             self.rate = self.get_rate()
         self.num_requests, self.duration = self.parse_rate(self.rate)


### PR DESCRIPTION
This PR adds an option for debouncing requests, i.e. disallowing requests that rapidly follow each other, to `SimpleRateThrottle` and its subclasses.

## Notes

* Using debouncing requires a custom Throttle subclass in the user project – there is no scoped 
`DEFAULT_DEBOUNCE_INTERVALS` setting.
* In order not to change the API of the current throttle classes, using debounces requires a `rate` to be acquirable for the throttle. This is noted in the third commit.  
  (In general, I think the throttle classes should and could be made more composable, and acquisition of the user's IP address, even through proxies etc., should be relegated to a more general utility (or it could just require `django-ipware`). That felt out of scope for this PR.)