### PR TITLE
Fixed import of FieldDoesNotExist exception.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -16,12 +16,11 @@ import traceback
 from collections import OrderedDict
 from collections.abc import Mapping
 
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models
 from django.db.models import DurationField as ModelDurationField
 from django.db.models.fields import Field as DjangoModelField
-from django.db.models.fields import FieldDoesNotExist
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
`FieldDoesNotExist` was moved to `django.core.exceptions` in https://github.com/django/django/commit/8958170755b37ce346ae5257c1000bd936faa3b0 and removed from `django.db.models.fields` in https://github.com/django/django/commit/129583a0d3cf69b08d058cd751d777588801b7ad.