### PR TITLE
Allow to extend serializer context using kwargs of `get_serializer` method

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -106,7 +106,9 @@ class GenericAPIView(views.APIView):
         deserializing input, and for serializing output.
         """
         serializer_class = self.get_serializer_class()
-        kwargs['context'] = self.get_serializer_context()
+        serializer_context = self.get_serializer_context()
+        serializer_context.update(kwargs.get("context", {}))
+        kwargs['context'] = serializer_context
         return serializer_class(*args, **kwargs)
 
     def get_serializer_class(self):


### PR DESCRIPTION
Fixes #6955 

## Description

As I mentioned in the #6955 it is impossible to pass any extra context to the serializer from the generic Viewset as it will be overwritten with the default value in the `get_serializer` method. 

My pull request fixes this allowing the default context to be extended with the provided one.
