### PR TITLE
fixed no-cls-argument

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1764,8 +1764,8 @@ class JSONField(Field):
             # When HTML form input is used, mark up the input
             # as being a JSON string, rather than a JSON primitive.
             class JSONString(str):
-                def __new__(self, value):
-                    ret = str.__new__(self, value)
+                def __new__(cls, value):
+                    ret = str.__new__(cls, value)
                     ret.is_json_string = True
                     return ret
             return JSONString(dictionary[self.field_name])

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -46,8 +46,8 @@ class Hyperlink(str):
     We use this for hyperlinked URLs that may render as a named link
     in some contexts, or render as a plain URL in others.
     """
-    def __new__(self, url, obj):
-        ret = str.__new__(self, url)
+    def __new__(cls, url, obj):
+        ret = str.__new__(cls, url)
         ret.obj = obj
         return ret
 


### PR DESCRIPTION
## Description

fixed no-cls-argument on staticmethod `__new__` .
Class method `__new__` should have `cls` as first argument.