### PR TITLE
Changed url() to re_path() for newest updates

### DIFF
--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -3,19 +3,20 @@ Login and logout views for the browsable API.
 
 Add these to your root URLconf if you're using the browsable API and
 your API requires authentication:
+    from django.urls import re_path
 
     urlpatterns = [
         ...
-        url(r'^auth/', include('rest_framework.urls'))
+        re_path(r'^auth/', include('rest_framework.urls'))
     ]
 
 You should make sure your authentication settings include `SessionAuthentication`.
 """
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib.auth import views
 
 app_name = 'rest_framework'
 urlpatterns = [
-    url(r'^login/$', views.LoginView.as_view(template_name='rest_framework/login.html'), name='login'),
-    url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
+    re_path(r'^login/$', views.LoginView.as_view(template_name='rest_framework/login.html'), name='login'),
+    re_path(r'^logout/$', views.LogoutView.as_view(), name='logout'),
 ]


### PR DESCRIPTION
I have changed url() function to re_path() function for Django 2.2 version updates because it is better. I have also updated imported modules from django.conf.urls import django.urls

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
