### PR TITLE
Add docs validation to release process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
   test-docs:
     name: Test documentation links
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: pip install -r requirements/requirements-documentation.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,3 +56,27 @@ jobs:
     - name: Upload coverage
       run: |
         codecov -e TOXENV,DJANGO
+
+  test-docs:
+    name: Test documentation links
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: pip install -r requirements/requirements-documentation.txt
+    
+    # Start mkdocs server and wait for it to be ready
+    - run: mkdocs serve &
+    - run: WAIT_TIME=0 && until nc -vzw 2 localhost 8000 || [ $WAIT_TIME -eq 5 ]; do sleep $(( WAIT_TIME++ )); done
+    - run: if [ $WAIT_TIME == 5 ]; then echo cannot start mkdocs server on http://localhost:8000; exit 1; fi
+    
+    - name: Check links
+      continue-on-error: true
+      run: pylinkvalidate.py -P http://localhost:8000/
+  
+    - run: echo "Done"

--- a/docs/community/project-management.md
+++ b/docs/community/project-management.md
@@ -112,6 +112,9 @@ The following template should be used for the description of the issue, and serv
         - [ ] `docs` Python & Django versions
     - [ ] Update the translations from [transifex](https://www.django-rest-framework.org/topics/project-management/#translations).
     - [ ] Ensure the pull request increments the version to `*.*.*` in [`restframework/__init__.py`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/__init__.py).
+    - [ ] Ensure documentation validates
+        - Build and serve docs `mkdocs serve`
+        - Validate links `pylinkvalidate.py -P http://127.0.0.1:8000`
     - [ ] Confirm with @tomchristie that release is finalized and ready to go.
     - [ ] Ensure that release date is included in pull request.
     - [ ] Merge the release pull request.

--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -1,3 +1,6 @@
 # MkDocs to build our documentation.
 mkdocs>=1.1.2,<1.2
 jinja2>=2.10,<3.1.0 # contextfilter has been renamed
+
+# pylinkvalidator to check for broken links in documentation.
+pylinkvalidator==0.3


### PR DESCRIPTION
This is a way to automatically check if the documentation contains any broken links in order to avoid issues like #6928 

The task is currently on `allow_failures`, but it could be added to the regular tasks in order to avoid linking to non existent pages in future.

The current documentation contains 17 broken links:
```
  not found (404): http://localhost:8000/tutorial/#api-guide
    from http://localhost:8000/tutorial/quickstart/
  not found (404): http://localhost:8000/api-guide/pagination/github-link-pagination
    from http://localhost:8000/api-guide/pagination/
    from http://localhost:8000/api-guide/pagination/#setting-the-pagination-style
    from http://localhost:8000/api-guide/pagination/#modifying-the-pagination-style
  not found (404): http://localhost:8000/topics/api-guide/schemas/#examples
    from http://localhost:8000/topics/documenting-your-api/
  not found (404): http://localhost:8000/topics/api-guide/metadata/
    from http://localhost:8000/topics/documenting-your-api/
  not found (404): http://localhost:8000/community/topics/third-party-packages/#existing-third-party-packages
    from http://localhost:8000/community/third-party-packages/
  not found (404): http://localhost:8000/community/3.10-announcement/community/funding.md
    from http://localhost:8000/community/3.10-announcement/
  not found (404): http://localhost:8000/community/api-guide/schemas/#schemas-as-documentation
    from http://localhost:8000/community/3.5-announcement/
  not found (404): http://localhost:8000/community/api-guide/schemas/#the-get_schema_view-shortcut
    from http://localhost:8000/community/3.5-announcement/
  not found (404): http://localhost:8000/community/api-guide/schemas/#schemagenerator
    from http://localhost:8000/community/3.5-announcement/
  not found (404): http://localhost:8000/community/3.4-announcement/api-clients#command-line-client
    from http://localhost:8000/community/3.4-announcement/
  not found (404): http://localhost:8000/community/3.4-announcement/api-clients#python-client-library
    from http://localhost:8000/community/3.4-announcement/
  not found (404): http://localhost:8000/community/tutorial/7-schemas-and-client-libraries/
    from http://localhost:8000/community/3.4-announcement/
  not found (404): http://localhost:8000/community/api-guide/schemas/
    from http://localhost:8000/community/3.4-announcement/
  not found (404): http://localhost:8000/community/api-guide/metadata/#custom-metadata-classes
    from http://localhost:8000/community/3.4-announcement/
  not found (404): http://localhost:8000/community/3.4-announcement/release-notes#34
    from http://localhost:8000/community/3.4-announcement/
  not found (404): http://localhost:8000/community/api-guide/fields#jsonfield
    from http://localhost:8000/community/3.3-announcement/
  not found (404): http://localhost:8000/community/api-guide/pagination/#custom-pagination-styles
    from http://localhost:8000/community/3.1-announcement/
```