### PR TITLE
Add X-CSRFToken HTTP header in swagger-ui example

### DIFF
--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -45,7 +45,11 @@ this:
           SwaggerUIBundle.presets.apis,
           SwaggerUIBundle.SwaggerUIStandalonePreset
         ],
-        layout: "BaseLayout"
+        layout: "BaseLayout",
+        requestInterceptor: (request) => {
+          request.headers['X-CSRFToken'] = "{{ csrf_token }}"
+          return request;
+        }
       })
     </script>
   </body>


### PR DESCRIPTION
This pull request fixes swagger-ui example placed in the docs, allowing usage of "Try it out" functionality with POST method.

Closes #6859.