### PR TITLE
Fix minor grammatical errors in Docs

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -52,7 +52,7 @@ The `default` is not applied during partial update operations. In the partial up
 
 May be set to a function or other callable, in which case the value will be evaluated each time it is used. When called, it will receive no arguments. If the callable has a `set_context` method, that will be called each time before getting the value with the field instance as only argument. This works the same way as for [validators](validators.md#using-set_context).
 
-When serializing the instance, default will be used if the the object attribute or dictionary key is not present in the instance.
+When serializing the instance, default will be used if the object attribute or dictionary key is not present in the instance.
 
 Note that setting a `default` value implies that the field is not required. Including both the `default` and `required` keyword arguments is invalid and will raise an error.
 

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -1014,7 +1014,7 @@ The signatures for these methods are as follows:
 
 Takes the object instance that requires serialization, and should return a primitive representation. Typically this means returning a structure of built-in Python datatypes. The exact types that can be handled will depend on the render classes you have configured for your API.
 
-May be overridden in order modify the representation style. For example:
+May be overridden in order to modify the representation style. For example:
 
     def to_representation(self, instance):
         """Convert `username` to lowercase."""


### PR DESCRIPTION
## Description

Fixes minor grammatical errors in the Docs.
