### PR TITLE
Fix serializer multiple inheritance bug

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -299,18 +299,22 @@ class SerializerMetaclass(type):
                   if isinstance(obj, Field)]
         fields.sort(key=lambda x: x[1]._creation_counter)
 
-        # If this class is subclassing another Serializer, add that Serializer's
-        # fields.  Note that we loop over the bases in *reverse*. This is necessary
-        # in order to maintain the correct order of fields.
-        for base in reversed(bases):
-            if hasattr(base, '_declared_fields'):
-                fields = [
-                    (field_name, obj) for field_name, obj
-                    in base._declared_fields.items()
-                    if field_name not in attrs
-                ] + fields
+        # Ensures a base class field doesn't override cls attrs, and maintains
+        # field precedence when inheriting multiple parents. e.g. if there is a
+        # class C(A, B), and A and B both define 'field', use 'field' from A.
+        known = set(attrs)
 
-        return OrderedDict(fields)
+        def visit(name):
+            known.add(name)
+            return name
+
+        base_fields = [
+            (visit(name), f)
+            for base in bases if hasattr(base, '_declared_fields')
+            for name, f in base._declared_fields.items() if name not in known
+        ]
+
+        return OrderedDict(base_fields + fields)
 
     def __new__(cls, name, bases, attrs):
         attrs['_declared_fields'] = cls._get_declared_fields(bases, attrs)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -682,3 +682,39 @@ class TestDeclaredFieldInheritance:
         assert len(Parent().get_fields()) == 2
         assert len(Child().get_fields()) == 2
         assert len(Grandchild().get_fields()) == 2
+
+    def test_multiple_inheritance(self):
+        class A(serializers.Serializer):
+            field = serializers.CharField()
+
+        class B(serializers.Serializer):
+            field = serializers.IntegerField()
+
+        class TestSerializer(A, B):
+            pass
+
+        fields = {
+            name: type(f) for name, f
+            in TestSerializer()._declared_fields.items()
+        }
+        assert fields == {
+            'field': serializers.CharField
+        }
+
+    def test_field_ordering(self):
+        class Base(serializers.Serializer):
+            f1 = serializers.CharField()
+            f2 = serializers.CharField()
+
+        class A(Base):
+            f3 = serializers.CharField()
+
+        class B(serializers.Serializer):
+            f4 = serializers.CharField()
+
+        class TestSerializer(A, B):
+            f2 = serializers.CharField()
+            f5 = serializers.CharField()
+
+        field_names = list(TestSerializer()._declared_fields)
+        assert field_names == ['f1', 'f2', 'f3', 'f4', 'f5']

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -698,7 +698,7 @@ class TestDeclaredFieldInheritance:
             in TestSerializer()._declared_fields.items()
         }
         assert fields == {
-            'field': serializers.CharField
+            'field': serializers.CharField,
         }
 
     def test_field_ordering(self):
@@ -707,14 +707,28 @@ class TestDeclaredFieldInheritance:
             f2 = serializers.CharField()
 
         class A(Base):
-            f3 = serializers.CharField()
+            f3 = serializers.IntegerField()
 
         class B(serializers.Serializer):
+            f3 = serializers.CharField()
             f4 = serializers.CharField()
 
         class TestSerializer(A, B):
-            f2 = serializers.CharField()
+            f2 = serializers.IntegerField()
             f5 = serializers.CharField()
 
-        field_names = list(TestSerializer()._declared_fields)
-        assert field_names == ['f1', 'f2', 'f3', 'f4', 'f5']
+        fields = {
+            name: type(f) for name, f
+            in TestSerializer()._declared_fields.items()
+        }
+
+        # `IntegerField`s should be the 'winners' in field name conflicts
+        # - `TestSerializer.f2` should override `Base.F2`
+        # - `A.f3` should override `B.f3`
+        assert fields == {
+            'f1': serializers.CharField,
+            'f2': serializers.IntegerField,
+            'f3': serializers.IntegerField,
+            'f4': serializers.CharField,
+            'f5': serializers.CharField,
+        }


### PR DESCRIPTION
Fixes #5798. As pointed out by @svilendobrev, the current code reverses the field order twice, defeating the point of reversing the first place. Thanks to @mwhansen for providing a minimal test case.

Note that I ran the test locally to verify the failure. Also, even though this is a relatively minor bugfix, I'm adding to the 3.11 milestone since it's technically a change in behavior to the public API.