### PR TITLE
Uppercases method before method check for openapi schema generation.

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -452,7 +452,7 @@ class AutoSchema(ViewInspector):
             return None
 
     def _get_request_body(self, path, method):
-        if method not in ('PUT', 'PATCH', 'POST'):
+        if method.upper() not in ('PUT', 'PATCH', 'POST'):
             return {}
 
         serializer = self._get_serializer(path, method)

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -143,6 +143,29 @@ class TestOperationIntrospection(TestCase):
         assert request_body['content']['application/json']['schema']['required'] == ['text']
         assert list(request_body['content']['application/json']['schema']['properties'].keys()) == ['text']
 
+    def test_request_body_lower_cased_method(self):
+        path = '/'
+        method = 'post'
+
+        class Serializer(serializers.Serializer):
+            text = serializers.CharField()
+            read_only = serializers.CharField(read_only=True)
+
+        class View(generics.GenericAPIView):
+            serializer_class = Serializer
+
+        view = create_view(
+            View,
+            method,
+            create_request(path)
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        request_body = inspector._get_request_body(path, method)
+        assert request_body['content']['application/json']['schema']['required'] == ['text']
+        assert list(request_body['content']['application/json']['schema']['properties'].keys()) == ['text']
+
     def test_empty_required(self):
         path = '/'
         method = 'POST'


### PR DESCRIPTION
## Description

Adds test to verify content still works for upper and lower case http method names. Closes #6881.