### PR TITLE
Fixed decimal snan deserialization

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1062,9 +1062,7 @@ class DecimalField(Field):
         except decimal.DecimalException:
             self.fail('invalid')
 
-        # Check for NaN. It is the only value that isn't equal to itself,
-        # so we can use this to identify NaN values.
-        if value != value:
+        if value.is_nan():
             self.fail('invalid')
 
         # Check for infinity and negative infinity.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1080,6 +1080,7 @@ class TestDecimalField(FieldValues):
     invalid_inputs = (
         ('abc', ["A valid number is required."]),
         (Decimal('Nan'), ["A valid number is required."]),
+        (Decimal('Snan'), ["A valid number is required."]),
         (Decimal('Inf'), ["A valid number is required."]),
         ('12.345', ["Ensure that there are no more than 3 digits in total."]),
         (200000000000.0, ["Ensure that there are no more than 3 digits in total."]),


### PR DESCRIPTION
## Description
Added test case to reproduce the bug described here #7001 ('sNaN' string raises InvalidOperation exception instead of validation error ) and fixed the bug.

refs #7001
