### PR TITLE
Fix a spelling error in openapi AutoSchema method

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -209,7 +209,7 @@ class AutoSchema(ViewInspector):
         if not is_list_view(path, method, view):
             return []
 
-        paginator = self._get_pagninator()
+        paginator = self._get_paginator()
         if not paginator:
             return []
 
@@ -429,7 +429,7 @@ class AutoSchema(ViewInspector):
                     schema['maximum'] = int(digits * '9') + 1
                     schema['minimum'] = -schema['maximum']
 
-    def _get_pagninator(self):
+    def _get_paginator(self):
         pagination_class = getattr(self.view, 'pagination_class', None)
         if pagination_class:
             return pagination_class()
@@ -502,7 +502,7 @@ class AutoSchema(ViewInspector):
                 'type': 'array',
                 'items': item_schema,
             }
-            paginator = self._get_pagninator()
+            paginator = self._get_paginator()
             if paginator:
                 response_schema = paginator.get_paginated_response_schema(response_schema)
         else:


### PR DESCRIPTION
Replace "pagninator" by "paginator".

This is a private method, so it does not affect API users.