### PR TITLE
Fix markdown code indent in schemas doc

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -90,6 +90,7 @@ The `get_schema_view()` helper takes the following keyword arguments:
             url='https://www.example.org/api/',
             urlconf='myproject.urls'
         )
+
 * `patterns`: List of url patterns to limit the schema introspection to. If you
   only want the `myproject.api` urls to be exposed in the schema:
 


### PR DESCRIPTION
Hello guys,

Just fixing an incredibly minor rendering issue that makes the paragraph more complicated to understand

### Before
![Screenshot from 2019-10-22 14-56-23](https://user-images.githubusercontent.com/4201782/67287864-2b6c2180-f4dc-11e9-9d22-28efac7fb99d.png)


### After
![Screenshot from 2019-10-22 14-55-35](https://user-images.githubusercontent.com/4201782/67287806-1099ad00-f4dc-11e9-9694-25a208afaa83.png)


Cheers