### PR TITLE
Update linter requirements

### DIFF
--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,7 +1,7 @@
 # PEP8 code linting, which we run on all commits.
-flake8==3.5.0
-flake8-tidy-imports==1.1.0
-pycodestyle==2.3.1
+flake8==3.7.8
+flake8-tidy-imports==3.0.0
+pycodestyle==2.5.0
 
 # Sort and lint imports
-isort==4.3.3
+isort==4.3.21

--- a/rest_framework/schemas/__init__.py
+++ b/rest_framework/schemas/__init__.py
@@ -23,8 +23,8 @@ Other access should target the submodules directly
 from rest_framework.settings import api_settings
 
 from . import coreapi, openapi
-from .inspectors import DefaultSchema  # noqa
 from .coreapi import AutoSchema, ManualSchema, SchemaGenerator  # noqa
+from .inspectors import DefaultSchema  # noqa
 
 
 def get_schema_view(

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ addopts=--tb=short --strict -ra
 testspath = tests
 
 [flake8]
-ignore = E501
+ignore = E501,W504
 banned-modules = json = use from rest_framework.utils import json!
 
 [isort]

--- a/tests/schemas/test_coreapi.py
+++ b/tests/schemas/test_coreapi.py
@@ -24,8 +24,8 @@ from rest_framework.utils import formatting
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
-from . import views
 from ..models import BasicModel, ForeignKeySource, ManyToManySource
+from . import views
 
 factory = APIRequestFactory()
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -494,28 +494,28 @@ class CustomPermissionsTests(TestCase):
         self.custom_message = 'Custom: You cannot access this resource'
 
     def test_permission_denied(self):
-            response = denied_view(self.request, pk=1)
-            detail = response.data.get('detail')
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertNotEqual(detail, self.custom_message)
+        response = denied_view(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertNotEqual(detail, self.custom_message)
 
     def test_permission_denied_with_custom_detail(self):
-            response = denied_view_with_detail(self.request, pk=1)
-            detail = response.data.get('detail')
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertEqual(detail, self.custom_message)
+        response = denied_view_with_detail(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, self.custom_message)
 
     def test_permission_denied_for_object(self):
-            response = denied_object_view(self.request, pk=1)
-            detail = response.data.get('detail')
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertNotEqual(detail, self.custom_message)
+        response = denied_object_view(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertNotEqual(detail, self.custom_message)
 
     def test_permission_denied_for_object_with_custom_detail(self):
-            response = denied_object_view_with_detail(self.request, pk=1)
-            detail = response.data.get('detail')
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertEqual(detail, self.custom_message)
+        response = denied_object_view_with_detail(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, self.custom_message)
 
 
 class PermissionsCompositionTests(TestCase):


### PR DESCRIPTION
Update the linter requirements and fix new errors.

The addition of W504 is a little confusing. In short, pycodestyle somewhat recently added [W504](https://lintlyci.github.io/Flake8Rules/rules/W504.html), which contradicts the older W503. By default, both W503 and W504 are ignored, however we override the flake8 ignore list to just E501, so these contradictory rules are running in conflict with each other. 

For now, the fix is to add W504 to the ignore list, although conforming to W504 is the recommendation and we may want to follow it in the future.