### PR TITLE
Update DEFAULT_SCHEMA_CLASSES default value in Settings docs

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -101,7 +101,7 @@ Default: `'rest_framework.negotiation.DefaultContentNegotiation'`
 
 A view inspector class that will be used for schema generation.
 
-Default: `'rest_framework.schemas.AutoSchema'`
+Default: `'rest_framework.schemas.openapi.AutoSchema'`
 
 ---
 


### PR DESCRIPTION
I changed the docs to reflect that the default value for `DEFAULT_SCHEMA_CLASSES` now points to the OpenAPI `AutoSchema` class.  The docs were leading users to believe that `rest_framework.schemas.AutoSchema` was the default: as of this PR, the root AutoSchema is [still imported](https://github.com/encode/django-rest-framework/blob/3.10.0/rest_framework/schemas/__init__.py#L27) from the coreapi module.