### PR TITLE
Fix docs typos

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -713,7 +713,7 @@ the coordinate pair:
             fields = ['label', 'coordinates']
 
 Note that this example doesn't handle validation. Partly for that reason, in a
-real project, the coordinate nesting might be better handled with a nested serialiser
+real project, the coordinate nesting might be better handled with a nested serializer
 using `source='*'`, with two `IntegerField` instances, each with their own `source`
 pointing to the relevant field.
 
@@ -746,7 +746,7 @@ suitable for updating our target object. With `source='*'`, the return from
                      ('y_coordinate', 4),
                      ('x_coordinate', 3)])
 
-For completeness lets do the same thing again but with the nested serialiser
+For completeness lets do the same thing again but with the nested serializer
 approach suggested above:
 
     class NestedCoordinateSerializer(serializers.Serializer):
@@ -768,14 +768,14 @@ declarations. It's our `NestedCoordinateSerializer` that takes `source='*'`.
 Our new `DataPointSerializer` exhibits the same behaviour as the custom field
 approach.
 
-Serialising:
+Serializing:
 
     >>> out_serializer = DataPointSerializer(instance)
     >>> out_serializer.data
     ReturnDict([('label', 'testing'),
                 ('coordinates', OrderedDict([('x', 1), ('y', 2)]))])
 
-Deserialising:
+Deserializing:
 
     >>> in_serializer = DataPointSerializer(data=data)
     >>> in_serializer.is_valid()
@@ -802,8 +802,8 @@ But we also get the built-in validation for free:
                  {'x': ['A valid integer is required.'],
                   'y': ['A valid integer is required.']})])
 
-For this reason, the nested serialiser approach would be the first to try. You
-would use the custom field approach when the nested serialiser becomes infeasible
+For this reason, the nested serializer approach would be the first to try. You
+would use the custom field approach when the nested serializer becomes infeasible
 or overly complex.
 
 

--- a/docs/api-guide/requests.md
+++ b/docs/api-guide/requests.md
@@ -49,7 +49,7 @@ If a client sends a request with a content-type that cannot be parsed then a `Un
 
 # Content negotiation
 
-The request exposes some properties that allow you to determine the result of the content negotiation stage. This allows you to implement behaviour such as selecting a different serialisation schemes for different media types.
+The request exposes some properties that allow you to determine the result of the content negotiation stage. This allows you to implement behaviour such as selecting a different serialization schemes for different media types.
 
 ## .accepted_renderer
 

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -176,7 +176,7 @@ for each view, allowed method, and path.
 **Note**: For basic `APIView` subclasses, default introspection is essentially
 limited to the URL kwarg path parameters. For `GenericAPIView`
 subclasses, which includes all the provided class based views, `AutoSchema` will
-attempt to introspect serialiser, pagination and filter fields, as well as
+attempt to introspect serializer, pagination and filter fields, as well as
 provide richer path field descriptions. (The key hooks here are the relevant
 `GenericAPIView` attributes and methods: `get_serializer`, `pagination_class`,
 `filter_backends` and so on.)

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -222,11 +222,11 @@ Be sure to upgrade to Python 3 before upgrading to Django REST Framework 3.10.
         def perform_create(self, serializer):
             serializer.save(owner=self.request.user)
 
-    Alternatively you may override `save()` or `create()` or `update()` on the serialiser as appropriate.
+    Alternatively you may override `save()` or `create()` or `update()` on the serializer as appropriate.
 
 * Correct allow_null behaviour when required=False [#5888][gh5888]
 
-    Without an explicit `default`, `allow_null` implies a default of `null` for outgoing serialisation. Previously such
+    Without an explicit `default`, `allow_null` implies a default of `null` for outgoing serialization. Previously such
     fields were being skipped when read-only or otherwise not required.
 
     **Possible backwards compatibility break** if you were relying on such fields being excluded from the outgoing
@@ -464,7 +464,7 @@ Be sure to upgrade to Python 3 before upgrading to Django REST Framework 3.10.
 * Deprecated `exclude_from_schema` on `APIView` and `api_view` decorator. Set `schema = None` or `@schema(None)` as appropriate. [#5422][gh5422]
 * Timezone-aware `DateTimeField`s now respect active or default `timezone` during serialization, instead of always using UTC. [#5435][gh5435]
 
-    Resolves inconsistency whereby instances were serialised with supplied datetime for `create` but UTC for `retrieve`. [#3732][gh3732]
+    Resolves inconsistency whereby instances were serialized with supplied datetime for `create` but UTC for `retrieve`. [#3732][gh3732]
 
     **Possible backwards compatibility break** if you were relying on datetime strings being UTC. Have client interpret datetimes or [set default or active timezone (docs)][djangodocs-set-timezone] to UTC if needed.
 

--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -254,7 +254,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 ### Misc
 
 * [cookiecutter-django-rest][cookiecutter-django-rest] - A cookiecutter template that takes care of the setup and configuration so you can focus on making your REST apis awesome.
-* [djangorestrelationalhyperlink][djangorestrelationalhyperlink] - A hyperlinked serialiser that can can be used to alter relationships via hyperlinks, but otherwise like a hyperlink model serializer.
+* [djangorestrelationalhyperlink][djangorestrelationalhyperlink] - A hyperlinked serializer that can can be used to alter relationships via hyperlinks, but otherwise like a hyperlink model serializer.
 * [django-rest-swagger][django-rest-swagger] - An API documentation generator for Swagger UI.
 * [django-rest-framework-proxy][django-rest-framework-proxy] - Proxy to redirect incoming request to another API server.
 * [gaiarestframework][gaiarestframework] - Utils for django-rest-framework

--- a/docs/coreapi/schemas.md
+++ b/docs/coreapi/schemas.md
@@ -191,7 +191,7 @@ each view, allowed method and path.)
 **Note**: For basic `APIView` subclasses, default introspection is essentially
 limited to the URL kwarg path parameters. For `GenericAPIView`
 subclasses, which includes all the provided class based views, `AutoSchema` will
-attempt to introspect serialiser, pagination and filter fields, as well as
+attempt to introspect serializer, pagination and filter fields, as well as
 provide richer path field descriptions. (The key hooks here are the relevant
 `GenericAPIView` attributes and methods: `get_serializer`, `pagination_class`,
 `filter_backends` and so on.)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -555,7 +555,7 @@ class TestDefaultOutput:
             bar = serializers.CharField(source='foo.bar', allow_null=True)
             optional = serializers.CharField(required=False, allow_null=True)
 
-        # allow_null=True should imply default=None when serialising:
+        # allow_null=True should imply default=None when serializing:
         assert Serializer({'foo': None}).data == {'foo': None, 'bar': None, 'optional': None, }
 
 


### PR DESCRIPTION
I'm not sure it is allowed to use `serialis*`(like `serialiser`) ，or it should be replaced as `serializ*`.