### PR TITLE
OpenAPI: Use int64 format for large integers.

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -265,9 +265,13 @@ class AutoSchema(ViewInspector):
                 'items': {},
             }
             if not isinstance(field.child, _UnvalidatedField):
-                mapping['items'] = {
-                    "type": self._map_field(field.child).get('type')
+                map_field = self._map_field(field.child)
+                items = {
+                    "type": map_field.get('type')
                 }
+                if 'format' in map_field:
+                    items['format'] = map_field.get('format')
+                mapping['items'] = items
             return mapping
 
         # DateField and DateTimeField type is string
@@ -337,6 +341,9 @@ class AutoSchema(ViewInspector):
                 'type': 'integer'
             }
             self._map_min_max(field, content)
+            # 2147483647 is max for int32_size, so we use int64 for format
+            if int(content.get('maximum', 0)) > 2147483647 or int(content.get('minimum', 0)) > 2147483647:
+                content['format'] = 'int64'
             return content
 
         # Simplest cases, default to 'string' type:

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -48,6 +48,10 @@ class TestFieldMapping(TestCase):
             (serializers.ListField(child=serializers.BooleanField()), {'items': {'type': 'boolean'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.FloatField()), {'items': {'type': 'number'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.CharField()), {'items': {'type': 'string'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.IntegerField(max_value=4294967295)),
+             {'items': {'type': 'integer', 'format': 'int64'}, 'type': 'array'}),
+            (serializers.IntegerField(min_value=2147483648),
+             {'type': 'integer', 'minimum': 2147483648, 'format': 'int64'}),
         ]
         for field, mapping in cases:
             with self.subTest(field=field):


### PR DESCRIPTION
## Description

This fixes #7017 where we can produce a better openapi spec.