### PR TITLE
Remove unmaintained django-rest-framework-bulk from docs

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -378,10 +378,6 @@ If you need to generic PUT-as-create behavior you may want to include something 
 
 The following third party packages provide additional generic view implementations.
 
-## Django REST Framework bulk
-
-The [django-rest-framework-bulk package][django-rest-framework-bulk] implements generic view mixins as well as some common concrete generic views to allow to apply bulk operations via API requests.
-
 ## Django Rest Multiple Models
 
 [Django Rest Multiple Models][django-rest-multiple-models] provides a generic view (and mixin) for sending multiple serialized models and/or querysets via a single API request.
@@ -394,5 +390,4 @@ The [django-rest-framework-bulk package][django-rest-framework-bulk] implements 
 [RetrieveModelMixin]: #retrievemodelmixin
 [UpdateModelMixin]: #updatemodelmixin
 [DestroyModelMixin]: #destroymodelmixin
-[django-rest-framework-bulk]: https://github.com/miki725/django-rest-framework-bulk
 [django-rest-multiple-models]: https://github.com/MattBroach/DjangoRestMultipleModels

--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -222,7 +222,6 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 
 ### Views
 
-* [djangorestframework-bulk][djangorestframework-bulk] - Implements generic view mixins as well as some common concrete generic views to allow to apply bulk operations via API requests.
 * [django-rest-multiple-models][django-rest-multiple-models] - Provides a generic view (and mixin) for sending multiple serialized models and/or querysets via a single API request.
 
 ### Routers
@@ -305,7 +304,6 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [djangorestframework-hstore]: https://github.com/djangonauts/django-rest-framework-hstore
 [drf-compound-fields]: https://github.com/estebistec/drf-compound-fields
 [django-extra-fields]: https://github.com/Hipo/drf-extra-fields
-[djangorestframework-bulk]: https://github.com/miki725/django-rest-framework-bulk
 [django-rest-multiple-models]: https://github.com/MattBroach/DjangoRestMultipleModels
 [drf-nested-routers]: https://github.com/alanjds/drf-nested-routers
 [wq.db.rest]: https://wq.io/docs/about-rest


### PR DESCRIPTION
The project seems to be obsolete per https://github.com/miki725/django-rest-framework-bulk/issues/77 .