### PR TITLE
Fix broken schema examples link.

### DIFF
--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -268,7 +268,7 @@ To implement a hypermedia API you'll need to decide on an appropriate media type
 [image-self-describing-api]: ../img/self-describing.png
 [metadata-docs]: ../api-guide/metadata/
 
-[schemas-examples]: ../api-guide/schemas/#examples
+[schemas-examples]: ../coreapi/schemas/#examples
 [swagger-ui]: https://swagger.io/tools/swagger-ui/
 [redoc]: https://github.com/Rebilly/ReDoc
 


### PR DESCRIPTION
## Description

The page has moved from `api-guide` to `coreapi`.