### PR TITLE
Fixed docstring typo

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -266,7 +266,7 @@ class Request:
 
     def _load_data_and_files(self):
         """
-        Parses the request content into `self.data`.
+        Parses the request content into `self._data`.
         """
         if not _hasattr(self, '_data'):
             self._data, self._files = self._parse()


### PR DESCRIPTION
## Description

The docstring for `rest_framework.requests._load_data_and_files()` says that it parses the request content into `self.data`. It doesn't; it parses it into `self._data`. (`data` in that class is a property.)

This PR fixes that docstring.