### PR TITLE
Rename view_func.cls/initkwargs to view_class/view_initkwargs

### DIFF
--- a/rest_framework/utils/breadcrumbs.py
+++ b/rest_framework/utils/breadcrumbs.py
@@ -21,13 +21,13 @@ def get_breadcrumbs(url, request=None):
         else:
             # Check if this is a REST framework view,
             # and if so add it to the breadcrumbs
-            cls = getattr(view, 'cls', None)
-            initkwargs = getattr(view, 'initkwargs', {})
-            if cls is not None and issubclass(cls, APIView):
+            view_class = getattr(view, 'view_class', None)
+            initkwargs = getattr(view, 'view_initkwargs', {})
+            if view_class is not None and issubclass(view_class, APIView):
                 # Don't list the same view twice in a row.
                 # Probably an optional trailing slash.
                 if not seen or seen[-1] != view:
-                    c = cls(**initkwargs)
+                    c = view_class(**initkwargs)
                     name = c.get_view_name()
                     insert_url = preserve_builtin_query_params(prefix + url, request)
                     breadcrumbs_list.insert(0, (name, insert_url))

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -136,8 +136,8 @@ class APIView(View):
             cls.queryset._fetch_all = force_evaluation
 
         view = super().as_view(**initkwargs)
-        view.cls = cls
-        view.initkwargs = initkwargs
+        view.view_class = cls
+        view.view_initkwargs = initkwargs
 
         # Note: session based authentication is explicitly CSRF validated,
         # all other authentication is CSRF exempt.

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -123,8 +123,8 @@ class ViewSetMixin:
         # We need to set these on the view function, so that breadcrumb
         # generation can pick out these bits of information from a
         # resolved URL.
-        view.cls = cls
-        view.initkwargs = initkwargs
+        view.view_class = cls
+        view.view_initkwargs = initkwargs
         view.actions = actions
         return csrf_exempt(view)
 

--- a/tests/schemas/test_get_schema_view.py
+++ b/tests/schemas/test_get_schema_view.py
@@ -9,12 +9,12 @@ class GetSchemaViewTests(TestCase):
     """For the get_schema_view() helper."""
     def test_openapi(self):
         schema_view = get_schema_view(title="With OpenAPI")
-        assert isinstance(schema_view.initkwargs['schema_generator'], openapi.SchemaGenerator)
-        assert renderers.OpenAPIRenderer in schema_view.cls().renderer_classes
+        assert isinstance(schema_view.view_initkwargs['schema_generator'], openapi.SchemaGenerator)
+        assert renderers.OpenAPIRenderer in schema_view.view_class().renderer_classes
 
     @pytest.mark.skipif(not coreapi.coreapi, reason='coreapi is not installed')
     def test_coreapi(self):
         with override_settings(REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.AutoSchema'}):
             schema_view = get_schema_view(title="With CoreAPI")
-            assert isinstance(schema_view.initkwargs['schema_generator'], coreapi.SchemaGenerator)
-            assert renderers.CoreAPIOpenAPIRenderer in schema_view.cls().renderer_classes
+            assert isinstance(schema_view.view_initkwargs['schema_generator'], coreapi.SchemaGenerator)
+            assert renderers.CoreAPIOpenAPIRenderer in schema_view.view_class().renderer_classes

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -164,7 +164,7 @@ class DecoratorTestCase(TestCase):
         def view(request):
             return Response({})
 
-        assert isinstance(view.cls.schema, CustomSchema)
+        assert isinstance(view.view_class.schema, CustomSchema)
 
 
 class ActionDecoratorTestCase(TestCase):

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -470,18 +470,18 @@ class TestViewInitkwargs(URLPatternsTestCase, TestCase):
 
     def test_suffix(self):
         match = resolve('/example/notes/')
-        initkwargs = match.func.initkwargs
+        initkwargs = match.func.view_initkwargs
 
         assert initkwargs['suffix'] == 'List'
 
     def test_detail(self):
         match = resolve('/example/notes/')
-        initkwargs = match.func.initkwargs
+        initkwargs = match.func.view_initkwargs
 
         assert not initkwargs['detail']
 
     def test_basename(self):
         match = resolve('/example/notes/')
-        initkwargs = match.func.initkwargs
+        initkwargs = match.func.view_initkwargs
 
         assert initkwargs['basename'] == 'routertestmodel'


### PR DESCRIPTION
Fixes #7036

Renamed two attributes:
 - `view_func.cls` to `view_func.view_class`
 - `view_func.initkwargs` to `view_func.view_initkwargs`
