### PR TITLE
Fix link to Django docs in responses documentation

### DIFF
--- a/docs/api-guide/responses.md
+++ b/docs/api-guide/responses.md
@@ -94,5 +94,5 @@ As with any other `TemplateResponse`, this method is called to render the serial
 
 You won't typically need to call `.render()` yourself, as it's handled by Django's standard response cycle.
 
-[cite]: https://docs.djangoproject.com/en/stable/stable/template-response/
+[cite]: https://docs.djangoproject.com/en/stable/ref/template-response/
 [statuscodes]: status-codes.md


### PR DESCRIPTION
It's all in the title; the link to the Django documentation quoted in [this page](https://www.django-rest-framework.org/api-guide/responses/) was dead. The link was probably written by hand and nobody ever clicked on it!