### PR TITLE
Add additional_permission_classes attribute on APIView

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -109,6 +109,7 @@ class APIView(View):
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
     throttle_classes = api_settings.DEFAULT_THROTTLE_CLASSES
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES
+    additional_permission_classes = []
     content_negotiation_class = api_settings.DEFAULT_CONTENT_NEGOTIATION_CLASS
     metadata_class = api_settings.DEFAULT_METADATA_CLASS
     versioning_class = api_settings.DEFAULT_VERSIONING_CLASS
@@ -275,7 +276,8 @@ class APIView(View):
         """
         Instantiates and returns the list of permissions that this view requires.
         """
-        return [permission() for permission in self.permission_classes]
+        permissions = self.permission_classes + self.additional_permission_classes
+        return [permission() for permission in permissions]
 
     def get_throttles(self):
         """


### PR DESCRIPTION
This attributes allows adding specific permissions to a view without overriding the default permissions in the settings

## Description

If you want to have a specific permission on a viewset, you have to append the default permissions declared in the settings to the new permissions.

With this attribute, you simple have to declare your new permissions that will be appended to the default ones. It avoids errors in the code were developers would simply add the new permission without checking the default ones.

It is also possible to add a attribute for specific permissions for unsafe HTTP methods.

I know this is far from being ready, I just wanted to have your thoughts about it.

#### TODO:

- Add tests
- Add documentation
