### PR TITLE
`field` set `read_only` and `default` have bug

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -363,7 +363,7 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
     @property
     def _writable_fields(self):
         for field in self.fields.values():
-            if not field.read_only:
+            if (not field.read_only) or (field.default is not empty):
                 yield field
 
     @property


### PR DESCRIPTION
When i set `read_only` and `default`  arguments together. The `default` argument do not work.
