### PR TITLE
[Doc] Remove the old reference to `JSONResponse`

### DIFF
--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -33,9 +33,7 @@ The wrappers also provide behaviour such as returning `405 Method Not Allowed` r
 
 ## Pulling it all together
 
-Okay, let's go ahead and start using these new components to write a few views.
-
-We don't need our `JSONResponse` class in `views.py` any more, so go ahead and delete that.  Once that's done we can start refactoring our views slightly.
+Okay, let's go ahead and start using these new components to refactor our views slightly.
 
     from rest_framework import status
     from rest_framework.decorators import api_view


### PR DESCRIPTION
## Description

This PR removes the reference to `JSONResponse` in the part 2 of the tutorial. It seems like this class was [used before in the part 1](https://github.com/encode/django-rest-framework/blame/149b00a070fcbfd44feee5b37096081e18356f93/docs/tutorial/1-serialization.md#L166) but it has been removed.