### PR TITLE
Removed Eric S. Raymond quote from the release notes

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -1,9 +1,5 @@
 # Release Notes
 
-> Release Early, Release Often
->
-> &mdash; Eric S. Raymond, [The Cathedral and the Bazaar][cite].
-
 ## Versioning
 
 Minor version numbers (0.0.x) are used for changes that are API compatible.  You should be able to upgrade between minor point releases without any other code changes.


### PR DESCRIPTION
## Description

Forgive the political nature of this pull request because it's the last thing people want to deal with when maintaining an open-source package. To qualify this, I am a long-time and heavy Django REST Framework user and not a drive-by activist looking to cause controversy. I think the vast majority of people are sensible and will not turn this into a divisive issue.

There is a quote from Eric S. Raymond at the top of the release notes document. This quote is largely inconsequential to achieving the intent of the document, as is the style in DRF documentation generally. ESR has had an [extremely long, public, and ongoing fall from grace](https://rationalwiki.org/wiki/Eric_S._Raymond), including ongoing comments of a racist, sexist, islamophobic.etc nature. I put forward the position that—given the inconsequential nature of the quote within the context of the release notes document—the better thing to do is to just remove the quote and let ESR sink further into irrelevancy.

Those that can separate the artist from their art can surely recognise ESR's large role in popularising Open Source, and the positives that has provided. However, I see no reason to give ESR any ongoing visibility. 
