### PR TITLE
Add failing test-case for choice field

### DIFF
--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -571,6 +571,22 @@ class TestOperationIntrospection(TestCase):
         properties = response_schema['items']['properties']
         assert properties['hstore']['type'] == 'object'
 
+    def test_serializer_choice_field(self):
+        path = '/'
+        method = 'GET'
+        view = create_view(
+            views.ExampleChoiceFieldAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        responses = inspector._get_responses(path, method)
+        response_schema = responses['200']['content']['application/json']['schema']
+        properties = response_schema['items']['properties']
+        assert 'type' in properties['gender']
+
     def test_serializer_validators(self):
         path = '/'
         method = 'GET'

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -136,3 +136,24 @@ class ExampleValidatedAPIView(generics.GenericAPIView):
                                          url='http://localhost', uuid=uuid.uuid4(), ip4='127.0.0.1', ip6='::1',
                                          ip='192.168.1.1')
         return Response(serializer.data)
+
+
+MALE = 'male'
+FEMALE = 'female'
+
+EXAMPLE_GENDER_CHOICES = (
+    (MALE, 'male'),
+    (FEMALE, 'female')
+)
+
+
+class ExampleChoiceFieldSerializer(serializers.Serializer):
+    gender = serializers.ChoiceField(choices=EXAMPLE_GENDER_CHOICES)
+
+
+class ExampleChoiceFieldAPIView(generics.GenericAPIView):
+    serializer_class = ExampleChoiceFieldSerializer
+
+    def get(self, *args, **kwargs):
+        serializer = self.get_serializer(gender='male')
+        return Response(serializer.data)


### PR DESCRIPTION
**Notes:**
As per OpenAPI specs, `type` is required. While generating schema, `type` is not provided for choice field. This leads to wrong schema in swagger and javascript error in redoc. 