### PR TITLE
Added required permission and authentication classes

### DIFF
--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -39,9 +39,11 @@ DEFAULTS = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication'
     ],
+    'REQUIRED_AUTHENTICATION_CLASSES': [],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.AllowAny',
     ],
+    'REQUIRED_PERMISSION_CLASSES': [],
     'DEFAULT_THROTTLE_CLASSES': [],
     'DEFAULT_CONTENT_NEGOTIATION_CLASS': 'rest_framework.negotiation.DefaultContentNegotiation',
     'DEFAULT_METADATA_CLASS': 'rest_framework.metadata.SimpleMetadata',
@@ -132,7 +134,9 @@ IMPORT_STRINGS = [
     'DEFAULT_RENDERER_CLASSES',
     'DEFAULT_PARSER_CLASSES',
     'DEFAULT_AUTHENTICATION_CLASSES',
+    'REQUIRED_AUTHENTICATION_CLASSES',
     'DEFAULT_PERMISSION_CLASSES',
+    'REQUIRED_PERMISSION_CLASSES',
     'DEFAULT_THROTTLE_CLASSES',
     'DEFAULT_CONTENT_NEGOTIATION_CLASS',
     'DEFAULT_METADATA_CLASS',

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -107,8 +107,10 @@ class APIView(View):
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES
     parser_classes = api_settings.DEFAULT_PARSER_CLASSES
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
+    required_authentication_classes = api_settings.REQUIRED_AUTHENTICATION_CLASSES
     throttle_classes = api_settings.DEFAULT_THROTTLE_CLASSES
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES
+    required_permission_classes = api_settings.REQUIRED_PERMISSION_CLASSES
     content_negotiation_class = api_settings.DEFAULT_CONTENT_NEGOTIATION_CLASS
     metadata_class = api_settings.DEFAULT_METADATA_CLASS
     versioning_class = api_settings.DEFAULT_VERSIONING_CLASS
@@ -269,13 +271,17 @@ class APIView(View):
         """
         Instantiates and returns the list of authenticators that this view can use.
         """
-        return [auth() for auth in self.authentication_classes]
+        required = [auth() for auth in self.required_authentication_classes]
+        required.extend([auth() for auth in self.authentication_classes])
+        return required
 
     def get_permissions(self):
         """
         Instantiates and returns the list of permissions that this view requires.
         """
-        return [permission() for permission in self.permission_classes]
+        required = [permission() for permission in self.required_permission_classes]
+        required.extend([permission() for permission in self.permission_classes])
+        return required
 
     def get_throttles(self):
         """


### PR DESCRIPTION
## Description
A quick proposal to add two new DRF settings called `REQUIRED_PERMISSION_CLASSES` and `REQUIRED_AUTHENTICATION_CLASSES`, which cannot be overwritten in the view.  This ensures that even if the view has custom classes, it cannot overwrite the ones specified as required, enabling the project owners to have required authentication and permission flows. It also allows the developers to add their custom authentication classes without having to copy in all the ones specified in the `DEFAULT_PERMISSION_CLASSES` for every view.

I have not looked into the tests, but would gladly do so if you think this is a good idea. Any other approach to how to solve this is also welcome, I have little to no knowledge of the DRF code base. 