### PR TITLE
Fix UniqueTogetherValidator with field sources

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -448,7 +448,7 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
                 default = field.get_default()
             except SkipField:
                 continue
-            defaults[field.field_name] = default
+            defaults[field.source] = default
 
         return defaults
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -335,6 +335,15 @@ class TestUniquenessTogetherValidation(TestCase):
         serializer = WriteableSerializer(data={'name': 'test', 'position': 1})
         assert serializer.is_valid(raise_exception=True)
 
+        # Validation error should use seriazlier field name, not source
+        serializer = WriteableSerializer(data={'position': 1})
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            'name': [
+                'This field is required.'
+            ]
+        }
+
     def test_allow_explict_override(self):
         """
         Ensure validators can be explicitly removed..

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -301,6 +301,40 @@ class TestUniquenessTogetherValidation(TestCase):
             ]
         }
 
+    def test_read_only_fields_with_default_and_source(self):
+        class ReadOnlySerializer(serializers.ModelSerializer):
+            name = serializers.CharField(source='race_name', default='test', read_only=True)
+
+            class Meta:
+                model = UniquenessTogetherModel
+                fields = ['name', 'position']
+                validators = [
+                    UniqueTogetherValidator(
+                        queryset=UniquenessTogetherModel.objects.all(),
+                        fields=['name', 'position']
+                    )
+                ]
+
+        serializer = ReadOnlySerializer(data={'position': 1})
+        assert serializer.is_valid(raise_exception=True)
+
+    def test_writeable_fields_with_source(self):
+        class WriteableSerializer(serializers.ModelSerializer):
+            name = serializers.CharField(source='race_name')
+
+            class Meta:
+                model = UniquenessTogetherModel
+                fields = ['name', 'position']
+                validators = [
+                    UniqueTogetherValidator(
+                        queryset=UniquenessTogetherModel.objects.all(),
+                        fields=['name', 'position']
+                    )
+                ]
+
+        serializer = WriteableSerializer(data={'name': 'test', 'position': 1})
+        assert serializer.is_valid(raise_exception=True)
+
     def test_allow_explict_override(self):
         """
         Ensure validators can be explicitly removed..

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -391,13 +391,9 @@ class TestUniquenessTogetherValidation(TestCase):
             def filter(self, **kwargs):
                 self.called_with = kwargs
 
-        class MockSerializer:
-            def __init__(self, instance):
-                self.instance = instance
-
         data = {'race_name': 'bar'}
         queryset = MockQueryset()
-        serializer = MockSerializer(instance=self.instance)
+        serializer = UniquenessTogetherSerializer(instance=self.instance)
         validator = UniqueTogetherValidator(queryset, fields=('race_name',
                                                               'position'))
         validator.filter_queryset(attrs=data, queryset=queryset, serializer=serializer)


### PR DESCRIPTION
This is an updated version of #7005 that I was helping @anveshagarwal put together. In short, there are two related bugs:
- As pointed out by @anveshagarwal in https://github.com/encode/django-rest-framework/pull/5922#discussion_r336450337, `_read_only_defaults` does not correctly account for the field `source`. The initial check does account for compatible sources, but when assigning the read only default, the `field_name` is used instead of `source`. 
- Generally, `UniqueTogetherValidator` doesn't handle field sources. Handling this is a little annoying, because the objective is to validate the serializer fields/data. However, the given `attrs` use the source/model field names, which are used in the actual validation check.

As to potential breaking changes, we may want to call out that validation against read-only fields that have defaults now obey their sources? ¯\\\_(ツ)_/¯

Fixes #7003