### PR TITLE
An attempt to convert ChoiceField into TypedChoiceField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1468,7 +1468,7 @@ class ChoiceField(Field):
     def to_representation(self, value):
         # Preserving old untyped behavior
         if not self.underlying_field:
-            return value
+            return self.choice_reprs_to_values.get(str(value), value)
         return self.underlying_field.to_representation(value)
 
     def iter_options(self):
@@ -1533,7 +1533,9 @@ class MultipleChoiceField(ChoiceField):
 
     def to_representation(self, value):
         return {
-            self.underlying_field.to_representation(item) if self.underlying_field else value for item in value
+            self.underlying_field.to_representation(item)
+            if self.underlying_field
+            else self.choice_reprs_to_values.get(str(item), item) for item in value
         }
 
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1462,7 +1462,7 @@ class ChoiceField(Field):
 
         try:
             return self.choice_reprs_to_values[self._choices_key(data)]
-        except (KeyError, TypeError) as e:
+        except (KeyError, TypeError):
             self.fail('invalid_choice', input=data)
 
     def to_representation(self, value):


### PR DESCRIPTION
The case inpired me to make this PR is the following.

Let's consider this snippet of code:

```python
class SomeModel:
    def __init__(self, decimal_choice):
        self.decimal_choice = decimal_choice


class SomeSerializer(serializers.Serializer):
    decimal_choice = ChoiceField(
        choices=(
            (Decimal("1.00"), "1.00"),
            (Decimal("1.30"), "1.30"),
            (Decimal("1.60"), "1.60"),
        )
    )
```

Now let's perform the serialization:

```
In [2]: SomeSerializer(instance=SomeModel(Decimal("1.00"))).data
Out[2]: {'decimal_choice': Decimal('1.00')}
```

Decimal field is serialized as is which is already quite weird: we have `DecimalSerializer` which serializes it as a string. If you add some Django model and `ModelSerializer` stuff here you can see that the `ChoiceField` is generated for `models.DecimalField` with choices. This behavior is different from `models.DecimalField` without choices which is even more strange.

If you attach this serializer to the view with the default settings (i. e. with `JsonRenderer`) you can see that `data` from the example above is serialized as follows:

```json
{"decimal_choice": 1.0}
```

and data with `DecimalField` is serialized as follows:

```json
{"decimal_choice": "1.0"}
```

(TBH, i am a bit lazy to provide a full working example with views, I hope you'll trust me here)

Even more bad things happen if you try to deserialize the following JSON back:

```
In [6]: ss = SomeSerializer(data={'decimal_choice': 1.0})

In [7]: ss.is_valid()
Out[7]: False

In [8]: ss.validated_data
Out[8]: {}

In [9]: ss.errors
Out[9]: {'decimal_choice': [ErrorDetail(string='"1.0" is not a valid choice.', code='invalid_choice')]}
```

The value which was just valid suddenly became invalid.

Turns out it's because `ChoiceField` uses `str` to create intermediate representations of the choices (but the values themselves as a representation). 

Currently there is no way to tell `ChoiceField` what is the type of choices and how to serialize/deserialize them. I've found some discussions about `TypedChoiceField` (like one in `django.forms`) here but it seems like still no one has implemented it.

I ended up generalizing `ChoiceField` to add optional typing for it by providing an `underlying_field` that tells `ChoiceField` how to serialize  the values. I've managed to preserve old untyped behavior by default.

Currently this is only a draft to show an approach to this problem. I'd be glad to receive some review: is it needed at all, is the approach suitable. However basic field stuff now works properly:

```python
class SomeSerializerTyped(serializers.Serializer):
    decimal_choice = ChoiceField(
        choices=(
            (Decimal("1.00"), "1.00"),
            (Decimal("1.30"), "1.30"),
            (Decimal("1.60"), "1.60"),
        ),
        underlying_field=DecimalField(decimal_places=2, max_digits=3)
    )
```

The next steps might be adding typing into `ModelSerializer` generation (seems not too hard) and adding tests and documentation.