### PR TITLE
Remove a few no longer needed compat checks and references

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -597,8 +597,6 @@ The `.to_representation()` method is called to convert the initial datatype into
 
 The `to_internal_value()` method is called to restore a primitive datatype into its internal python representation. This method should raise a `serializers.ValidationError` if the data is invalid.
 
-Note that the `WritableField` class that was present in version 2.x no longer exists. You should subclass `Field` and override `to_internal_value()` if the field supports data input.
-
 ## Examples
 
 ### A Basic Custom Field

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -175,8 +175,6 @@ You can also use these hooks to provide additional validation, by raising a `Val
             raise ValidationError('You have already signed up')
         serializer.save(user=self.request.user)
 
-**Note**: These methods replace the old-style version 2.x `pre_save`, `post_save`, `pre_delete` and `post_delete` methods, which are no longer available.
-
 **Other methods**:
 
 You won't typically need to override the following methods, although you might need to call into them if you're writing custom views using `GenericAPIView`.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -894,6 +894,10 @@ class ModelSerializer(Serializer):
         models.GenericIPAddressField: IPAddressField,
         models.FilePathField: FilePathField,
     }
+    if postgres_fields:
+        serializer_field_mapping[postgres_fields.HStoreField] = HStoreField
+        serializer_field_mapping[postgres_fields.ArrayField] = ListField
+        serializer_field_mapping[postgres_fields.JSONField] = JSONField
     serializer_related_field = PrimaryKeyRelatedField
     serializer_related_to_field = SlugRelatedField
     serializer_url_field = HyperlinkedIdentityField
@@ -1582,12 +1586,6 @@ class ModelSerializer(Serializer):
                 validators.append(validator)
 
         return validators
-
-
-if postgres_fields:
-    ModelSerializer.serializer_field_mapping[postgres_fields.HStoreField] = HStoreField
-    ModelSerializer.serializer_field_mapping[postgres_fields.ArrayField] = ListField
-    ModelSerializer.serializer_field_mapping[postgres_fields.JSONField] = JSONField
 
 
 class HyperlinkedModelSerializer(ModelSerializer):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -166,13 +166,6 @@ class BaseSerializer(Field):
         raise NotImplementedError('`create()` must be implemented.')
 
     def save(self, **kwargs):
-        assert not hasattr(self, 'save_object'), (
-            'Serializer `%s.%s` has old-style version 2 `.save_object()` '
-            'that is no longer compatible with REST framework 3. '
-            'Use the new-style `.create()` and `.update()` methods instead.' %
-            (self.__class__.__module__, self.__class__.__name__)
-        )
-
         assert hasattr(self, '_errors'), (
             'You must call `.is_valid()` before calling `.save()`.'
         )
@@ -216,13 +209,6 @@ class BaseSerializer(Field):
         return self.instance
 
     def is_valid(self, raise_exception=False):
-        assert not hasattr(self, 'restore_object'), (
-            'Serializer `%s.%s` has old-style version 2 `.restore_object()` '
-            'that is no longer compatible with REST framework 3. '
-            'Use the new-style `.create()` and `.update()` methods instead.' %
-            (self.__class__.__module__, self.__class__.__name__)
-        )
-
         assert hasattr(self, 'initial_data'), (
             'Cannot call `.is_valid()` as no `data=` keyword argument was '
             'passed when instantiating the serializer instance.'

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -19,7 +19,6 @@ from collections.abc import Mapping
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models
-from django.db.models import DurationField as ModelDurationField
 from django.db.models.fields import Field as DjangoModelField
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -876,6 +875,7 @@ class ModelSerializer(Serializer):
         models.DateField: DateField,
         models.DateTimeField: DateTimeField,
         models.DecimalField: DecimalField,
+        models.DurationField: DurationField,
         models.EmailField: EmailField,
         models.Field: ModelField,
         models.FileField: FileField,
@@ -890,11 +890,10 @@ class ModelSerializer(Serializer):
         models.TextField: CharField,
         models.TimeField: TimeField,
         models.URLField: URLField,
+        models.UUIDField: UUIDField,
         models.GenericIPAddressField: IPAddressField,
         models.FilePathField: FilePathField,
     }
-    if ModelDurationField is not None:
-        serializer_field_mapping[ModelDurationField] = DurationField
     serializer_related_field = PrimaryKeyRelatedField
     serializer_related_to_field = SlugRelatedField
     serializer_url_field = HyperlinkedIdentityField
@@ -1584,13 +1583,6 @@ class ModelSerializer(Serializer):
 
         return validators
 
-
-if hasattr(models, 'UUIDField'):
-    ModelSerializer.serializer_field_mapping[models.UUIDField] = UUIDField
-
-# IPAddressField is deprecated in Django
-if hasattr(models, 'IPAddressField'):
-    ModelSerializer.serializer_field_mapping[models.IPAddressField] = IPAddressField
 
 if postgres_fields:
     ModelSerializer.serializer_field_mapping[postgres_fields.HStoreField] = HStoreField


### PR DESCRIPTION
These are a few trivial things I noticed while browsing serializers.py. Please see the commits.