### PR TITLE
RFC: Only generate ModelSerializer fields once

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -587,7 +587,7 @@ For full details see the [serializer relations][relations] documentation.
 
 ## Customizing field mappings
 
-The ModelSerializer class also exposes a set of class attributes that you can override in order to alter how serializer fields are automatically determined when first instantiating the serializer.
+The ModelSerializer class also exposes a set of class attributes that you can override in order to alter how serializer fields are automatically determined when generating the fields.
 
 Normally if a `ModelSerializer` does not generate the fields you need by default then you should either add them to the class explicitly, or simply use a regular `Serializer` class instead. However in some cases you may want to create a new base class that defines how the serializer fields are created for any given model.
 

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -587,7 +587,7 @@ For full details see the [serializer relations][relations] documentation.
 
 ## Customizing field mappings
 
-The ModelSerializer class also exposes an API that you can override in order to alter how serializer fields are automatically determined when instantiating the serializer.
+The ModelSerializer class also exposes a set of class attributes that you can override in order to alter how serializer fields are automatically determined when first instantiating the serializer.
 
 Normally if a `ModelSerializer` does not generate the fields you need by default then you should either add them to the class explicitly, or simply use a regular `Serializer` class instead. However in some cases you may want to create a new base class that defines how the serializer fields are created for any given model.
 
@@ -617,15 +617,15 @@ Defaults to `serializers.ChoiceField`
 
 ### The field_class and field_kwargs API
 
-The following methods are called to determine the class and keyword arguments for each field that should be automatically included on the serializer. Each of these methods should return a two tuple of `(field_class, field_kwargs)`.
+The following class methods are called to determine the class and keyword arguments for each field that should be automatically included on the serializer. Each of these methods should return a two tuple of `(field_class, field_kwargs)`.
 
-### `.build_standard_field(self, field_name, model_field)`
+### `.build_standard_field(cls, field_name, model_field)`
 
 Called to generate a serializer field that maps to a standard model field.
 
 The default implementation returns a serializer class based on the `serializer_field_mapping` attribute.
 
-### `.build_relational_field(self, field_name, relation_info)`
+### `.build_relational_field(cls, field_name, relation_info)`
 
 Called to generate a serializer field that maps to a relational model field.
 
@@ -633,7 +633,7 @@ The default implementation returns a serializer class based on the `serializer_r
 
 The `relation_info` argument is a named tuple, that contains `model_field`, `related_model`, `to_many` and `has_through_model` properties.
 
-### `.build_nested_field(self, field_name, relation_info, nested_depth)`
+### `.build_nested_field(cls, field_name, relation_info, nested_depth)`
 
 Called to generate a serializer field that maps to a relational model field, when the `depth` option has been set.
 
@@ -643,17 +643,17 @@ The `nested_depth` will be the value of the `depth` option, minus one.
 
 The `relation_info` argument is a named tuple, that contains `model_field`, `related_model`, `to_many` and `has_through_model` properties.
 
-### `.build_property_field(self, field_name, model_class)`
+### `.build_property_field(cls, field_name, model_class)`
 
 Called to generate a serializer field that maps to a property or zero-argument method on the model class.
 
 The default implementation returns a `ReadOnlyField` class.
 
-### `.build_url_field(self, field_name, model_class)`
+### `.build_url_field(cls, field_name, model_class)`
 
 Called to generate a serializer field for the serializer's own `url` field. The default implementation returns a `HyperlinkedIdentityField` class.
 
-### `.build_unknown_field(self, field_name, model_class)`
+### `.build_unknown_field(cls, field_name, model_class)`
 
 Called when the field name did not map to any model field or model property.
 The default implementation raises an error, although subclasses may customize this behavior.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -862,15 +862,13 @@ class ModelSerializerMetaclass(SerializerMetaclass):
 
     @classmethod
     def _get_fields(cls, new_class):
-        # XXX
+        # ModelSerializer itself and customized subclasses like
+        # HyperlinkedModelSerializer are never instantiated directly,
+        # and don't have a Meta. For these, the base_fields is None,
+        # and an error is raised if it's attempted to be used.
         if not hasattr(new_class, 'Meta'):
-            return OrderedDict()
+            return None
 
-        assert hasattr(new_class, 'Meta'), (
-            'Class {serializer_class} missing "Meta" attribute'.format(
-                serializer_class=new_class.__name__
-            )
-        )
         assert hasattr(new_class.Meta, 'model'), (
             'Class {serializer_class} missing "Meta.model" attribute'.format(
                 serializer_class=new_class.__name__
@@ -1097,6 +1095,11 @@ class ModelSerializer(Serializer, metaclass=ModelSerializerMetaclass):
         Return the dict of field names -> field instances that should be
         used for `self.fields` when instantiating the serializer.
         """
+        assert self.base_fields is not None, (
+            'Class {serializer_class} missing "Meta" attribute'.format(
+                serializer_class=self.__class__.__name__
+            )
+        )
         return copy.deepcopy(self.base_fields)
 
     # Methods for determining the set of field names to include...

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -151,6 +151,14 @@ class TestModelSerializer(TestCase):
                     model = AbstractModel
                     fields = ('afield',)
 
+    def test_missing_meta(self):
+        class TestSerializer(serializers.ModelSerializer):
+            text = serializers.CharField()
+
+        msginitial = 'Class TestSerializer missing "Meta" attribute'
+        with self.assertRaisesMessage(AssertionError, msginitial):
+            TestSerializer().fields
+
 
 class TestRegularFieldMappings(TestCase):
     def test_regular_fields(self):


### PR DESCRIPTION
### Problem

References #2504, #5614.

We have several large projects which use DRF serializers. ModelSerializers are a great feature which saves a lot of time and mistakes. However, as the projects grow and the models grow, the slowness of ModelSerializer starts to show. The usual solution for this problem is "use something else", but we prefer to try and improve ModelSerializer's performance first, if possible.

The following is a somewhat realistic benchmark, comparing serialization of one of our models using a ModelSerializer, a regular serializer (it's just the `str(ModelSerializer())`), and a custom serializer.

<details>
<summary>Benchmark</summary>

```py
#!/usr/bin/env python
import cProfile
import datetime
from time import perf_counter

import django
from django.db import models
from django.conf import settings
from django.utils.translation import gettext_lazy as _
from rest_framework import serializers


settings.configure(INSTALLED_APPS=['rest_framework'])
django.setup()


class SomeOtherModel(models.Model):
    class Meta:
        app_label = 'some_app'
        verbose_name = _('SomeOtherModel')
        verbose_name_plural = _('SomeOtherModels')

    id = models.AutoField(
        primary_key=True,
        verbose_name=_('ID')
    )


class SomeModel(models.Model):
    class Meta:
        app_label = 'some_app'
        verbose_name = _('SomeModel')
        verbose_name_plural = _('SomeModels')

    id = models.AutoField(
        primary_key=True,
        verbose_name=_('ID')
    )
    field1 = models.DateTimeField(
        editable=False,
        db_index=True,
        verbose_name=_('Field1'),
    )
    field2 = models.DateTimeField(
        verbose_name=_('Field2'),
    )
    field3 = models.ForeignKey(
        to=SomeOtherModel,
        on_delete=models.PROTECT,
        verbose_name=_('Field3'),
    )
    field4 = models.ForeignKey(
        to=SomeOtherModel,
        on_delete=models.PROTECT,
        verbose_name=_('Field4'),
    )
    field5 = models.DateTimeField(
        blank=True,
        null=True,
        verbose_name=_('Field5'),
    )
    field6 = models.FloatField(
        blank=True,
        null=True,
        verbose_name=_('Field6'),
    )
    field7 = models.FloatField(
        blank=True,
        null=True,
        verbose_name=_('Field7'),
    )
    field8 = models.DateTimeField(
        blank=True,
        null=True,
        verbose_name=_('Field8'),
    )
    field9 = models.FloatField(
        blank=True,
        null=True,
        verbose_name=_('Field9'),
    )
    field10 = models.CharField(
        max_length=50,
        blank=True,
        null=True,
        verbose_name=_('Field10'),
    )
    field11 = models.IntegerField(
        choices=(
            (1, _('Choice1')),
            (2, _('Choice2')),
        ),
        verbose_name=_('Field11'),
    )
    field12 = models.BigIntegerField(
        verbose_name=_('Field12'),
    )
    field13 = models.ForeignKey(
        to=SomeOtherModel,
        blank=True,
        null=True,
        db_index=False,
        on_delete=models.PROTECT,
        verbose_name=_('Field13'),
    )
    field14 = models.BooleanField(
        blank=True,
        null=True,
        verbose_name=_('Field14'),
    )
    field15 = models.BooleanField(
        verbose_name=_('Field15'),
        null=True,
    )
    field16 = models.BooleanField(
        verbose_name=_('Field16'),
        help_text=_('Help'),
        null=True,
    )
    field17 = models.ForeignKey(
        to=SomeOtherModel,
        null=True,
        blank=True,
        db_index=False,
        on_delete=models.PROTECT,
        verbose_name=_('Field17'),
    )
    field18 = models.GenericIPAddressField(
        verbose_name=_('Field18'),
    )
    field19 = models.ForeignKey(
        to=SomeOtherModel,
        blank=True,
        null=True,
        db_index=False,
        on_delete=models.PROTECT,
        verbose_name=_('Field19'),
    )
    field20 = models.ImageField(
        blank=True,
        null=True,
        verbose_name=_('Field20'),
    )
    field21 = models.ForeignKey(
        to=SomeOtherModel,
        blank=True,
        null=True,
        on_delete=models.PROTECT,
        verbose_name=_('Field21'),
    )
    field22 = models.PositiveSmallIntegerField(
        blank=True,
        null=True,
        verbose_name=_('Field22'),
        help_text=_('Help'),
    )


class ModelSerializer(serializers.ModelSerializer):
    class Meta:
        model = SomeModel
        fields = (
            'id',
            'field1',
            'field2',
            'field3',
            'field4',
            'field5',
            'field6',
            'field7',
            'field8',
            'field9',
            'field10',
            'field11',
            'field12',
            'field13',
            'field14',
            'field15',
            'field16',
            'field17',
            'field18',
            'field19',
            'field20',
            'field21',
            'field22',
        )


class RegularSerializer(serializers.Serializer):
    id = serializers.IntegerField(label='ID', read_only=True)
    field1 = serializers.DateTimeField(read_only=True)
    field2 = serializers.DateTimeField()
    field3 = serializers.PrimaryKeyRelatedField(queryset=SomeOtherModel.objects.all())
    field4 = serializers.PrimaryKeyRelatedField(queryset=SomeOtherModel.objects.all())
    field5 = serializers.DateTimeField(allow_null=True, required=False)
    field6 = serializers.FloatField(allow_null=True, required=False)
    field7 = serializers.FloatField(allow_null=True, required=False)
    field8 = serializers.DateTimeField(allow_null=True, required=False)
    field9 = serializers.FloatField(allow_null=True, required=False)
    field10 = serializers.CharField(allow_blank=True, allow_null=True, max_length=50, required=False)
    field11 = serializers.ChoiceField(choices=((1, 'Choice1'), (2, 'Choice2')), validators=[django.core.validators.MinValueValidator(1), django.core.validators.MaxValueValidator(2)])
    field12 = serializers.IntegerField(max_value=9223372036854775807, min_value=-9223372036854775808)
    field13 = serializers.PrimaryKeyRelatedField(allow_null=True, queryset=SomeOtherModel.objects.all(), required=False)
    field14 = serializers.BooleanField(allow_null=True, required=False)
    field15 = serializers.BooleanField(allow_null=True, required=False)
    field16 = serializers.BooleanField(allow_null=True, help_text='Help', required=False)
    field17 = serializers.PrimaryKeyRelatedField(allow_null=True, queryset=SomeOtherModel.objects.all(), required=False)
    field18 = serializers.IPAddressField()
    field19 = serializers.PrimaryKeyRelatedField(allow_null=True, queryset=SomeOtherModel.objects.all(), required=False)
    field20 = serializers.ImageField(allow_null=True, max_length=100, required=False)
    field21 = serializers.PrimaryKeyRelatedField(allow_null=True, queryset=SomeOtherModel.objects.all(), required=False)
    field22 = serializers.IntegerField(allow_null=True, help_text='Help', max_value=32767, min_value=0, required=False)


def custom_serializer(obj):
    return {
        'field1': obj.field1.isoformat(),
        'field2': obj.field2.isoformat(),
        'field3': obj.field3_id,
        'field4': obj.field4_id,
        'field5': obj.field5.isoformat(),
        'field6': obj.field6,
        'field7': obj.field7,
        'field8': obj.field8.isoformat(),
        'field9': obj.field9,
        'field10': obj.field10,
        'field11': obj.field11,
        'field12': obj.field12,
        'field13': obj.field13_id,
        'field14': obj.field14,
        'field15': obj.field15,
        'field16': obj.field16,
        'field17': obj.field17_id,
        'field18': obj.field18,
        'field19': obj.field19_id,
        'field20': obj.field20,
        'field21': obj.field21_id,
        'field22': obj.field22,
    }


dt = datetime.datetime(2019, 12, 16, 11, 30, 0, 0, datetime.timezone.utc)
instance = SomeModel(
    field1 = dt,
    field2 = dt,
    field3_id = 1000,
    field4_id = 1000,
    field5 = dt,
    field6 = 10.20,
    field7 = 10.20,
    field8 = dt,
    field9 = 10.20,
    field10 = 'abcde',
    field11 = 1,
    field12 = 10000,
    field13_id = 1000,
    field14 = True,
    field15 = False,
    field16 = True,
    field17_id = 1000,
    field18 = '10.20.30.40',
    field19_id = 1000,
    field20 = None,
    field21_id = 1000,
    field22 = 10,
)


def run_model():
    ModelSerializer(instance).data


def run_regular():
    RegularSerializer(instance).data


def run_custom():
    custom_serializer(instance)


# cProfile.run('''''', sort='tottime')
start = perf_counter()
for i in range(5000): run_model()
print('model:', perf_counter() - start)
start = perf_counter()
for i in range(5000): run_regular()
print('regular:', perf_counter() - start)
start = perf_counter()
for i in range(5000): run_custom()
print('custom:', perf_counter() - start)
```
</details>

The results (before this PR):

```
model:   8.9562s
regular: 3.8447s
custom:  0.0409s
```

From the profile, it is clear that the difference between `model` and `regular` is due to ModelSerializer re-generating the model fields each time it is instantiated.

### Solution

This PR only generates the fields once, when the class is defined, using a metaclass. With this change, the benchmark results are

```
model:   3.0143s
regular: 3.8290s
custom:  0.0403s
```

The PR contains breaking changes, in that all of the codes participating in generating the fields now becomes classmethods/class attributes instead of self attributes/methods. This is necessary in order to indicate that the code only runs one, and must not use anything from `self` because it is incidental. Specifically, the fields must be defined on the class now (they almost always are, already):

```
url_field_name
serializer_field_mapping
serializer_related_field
serializer_choice_field
serializer_url_field
```

and the following methods become classmethods (breaking for `ModelSerializer` subclasses which override them):

```
get_field_names
get_default_field_names
build_field
build_standard_field
build_relational_field
build_nested_field
build_property_field
build_url_field
build_unknown_field
include_extra_kwargs
get_extra_kwargs
get_uniqueness_extra_kwargs
```

Additionally, errors in the ModelSerializer definition (like e.g. not setting `fields = [...]`) are now raised on definition time, not on first instantiation.

The DRF tests pass without any changes, except for adapting to when the errors are raised.

### Possible further work

On the deserialization side, I believe the validators are generated every time. They can be cached too.

From profiling the benchmark after the changes, the major remaining slowdown is the `copy.deepcopy` of the fields on each instantiation. For reference, changing to a shallow copy (of each field) instead of a deepcopy brings the `model` time to `1.3842s` (was attempted already before, #4587). The optimal solution would be to make the fields immutable, thus not requiring copy at all -- but that is a larger breaking change presumably.