### PR TITLE
Doc/test SearchFilter m2m behavior

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -297,13 +297,8 @@ class Blog(models.Model):
     name = models.CharField(max_length=20)
 
 
-class Tag(models.Model):
-    name = models.CharField(max_length=20)
-
-
 class Entry(models.Model):
     blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
-    tags = models.ManyToManyField(Tag, related_name='entries', blank=True)
     headline = models.CharField(max_length=120)
     pub_date = models.DateField(null=True)
 
@@ -321,62 +316,25 @@ class SearchFilterToManyTests(TestCase):
         b1 = Blog.objects.create(name='Blog 1')
         b2 = Blog.objects.create(name='Blog 2')
 
-        t1 = Tag.objects.create(name='tag1')
-        t2 = Tag.objects.create(name='tag2')
-
         # Multiple entries on Lennon published in 1979 - distinct should deduplicate
-        e1 = Entry.objects.create(blog=b1, headline='Something about Lennon', pub_date=datetime.date(1979, 1, 1))
-        e1.tags.add(t1)
-        e1.save()
-
-        e2 = Entry.objects.create(blog=b1, headline='Another thing about Lennon', pub_date=datetime.date(1979, 6, 1))
-        e2.tags.add(t2)
-        e2.save()
+        Entry.objects.create(blog=b1, headline='Something about Lennon', pub_date=datetime.date(1979, 1, 1))
+        Entry.objects.create(blog=b1, headline='Another thing about Lennon', pub_date=datetime.date(1979, 6, 1))
 
         # Entry on Lennon *and* a separate entry in 1979 - should not match
-        e3 = Entry.objects.create(blog=b2, headline='Something unrelated', pub_date=datetime.date(1979, 1, 1))
+        Entry.objects.create(blog=b2, headline='Something unrelated', pub_date=datetime.date(1979, 1, 1))
+        Entry.objects.create(blog=b2, headline='Retrospective on Lennon', pub_date=datetime.date(1990, 6, 1))
 
-        e4 = Entry.objects.create(blog=b2, headline='Retrospective on Lennon', pub_date=datetime.date(1990, 6, 1))
-        e4.tags.add(t1)
-        e4.tags.add(t2)
-        e4.save()
-
-    def setUp(self):
+    def test_multiple_filter_conditions(self):
         class SearchListView(generics.ListAPIView):
             queryset = Blog.objects.all()
             serializer_class = BlogSerializer
             filter_backends = (filters.SearchFilter,)
-            search_fields = (
-                '=name',
-                'entry__headline',
-                '=entry__pub_date__year',
-                'entry__tags__name'
-            )
-        self.SearchListView = SearchListView
+            search_fields = ('=name', 'entry__headline', '=entry__pub_date__year')
 
-    def test_multiple_filter_conditions(self):
-        view = self.SearchListView.as_view()
+        view = SearchListView.as_view()
         request = factory.get('/', {'search': 'Lennon,1979'})
         response = view(request)
         assert len(response.data) == 1
-
-    def test_single_filter_condition_manytomany(self):
-        view = self.SearchListView.as_view()
-
-        request = factory.get('/', {'search': 'tag1'})
-        response = view(request)
-        assert len(response.data) == 2
-
-        request = factory.get('/', {'search': 'tag2'})
-        response = view(request)
-        assert len(response.data) == 2
-
-    def test_multiple_filter_conditions_manytomany(self):
-        view = self.SearchListView.as_view()
-        request = factory.get('/', {'search': 'tag1,tag2'})
-        response = view(request)
-        assert len(response.data) == 1
-
 
 
 class SearchFilterAnnotatedSerializer(serializers.ModelSerializer):

--- a/tests/test_filters_multiple.py
+++ b/tests/test_filters_multiple.py
@@ -1,0 +1,115 @@
+import datetime
+
+from django.db import models
+from django.test import TestCase
+
+from rest_framework import filters, generics, serializers
+from rest_framework.test import APIRequestFactory
+
+factory = APIRequestFactory()
+
+
+class Post(models.Model):
+    name = models.CharField(max_length=20)
+
+
+class Author(models.Model):
+    name = models.CharField(max_length=20)
+
+
+class EntryRecord(models.Model):
+    blog = models.ForeignKey(Post, on_delete=models.CASCADE)
+    authors = models.ManyToManyField(Author, related_name='entries', blank=True)
+    headline = models.CharField(max_length=120)
+    pub_date = models.DateField(null=True)
+
+
+class PostSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Post
+        fields = '__all__'
+
+
+class EntryRecordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EntryRecord
+        fields = '__all__'
+
+
+class SearchFilterToManyTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        b1 = Post.objects.create(name='Post 1')
+        b2 = Post.objects.create(name='Post 2')
+
+        a1 = Author.objects.create(name='alice')
+        a2 = Author.objects.create(name='bob')
+
+        # Multiple entries on Lennon published in 1979 - distinct should deduplicate
+        e1 = EntryRecord.objects.create(blog=b1, headline='Something about Lennon', pub_date=datetime.date(1979, 1, 1))
+        e1.authors.add(a1)
+        e1.save()
+
+        e2 = EntryRecord.objects.create(blog=b1, headline='Another thing about Lennon', pub_date=datetime.date(1979, 6, 1))
+        e2.authors.add(a2)
+        e2.save()
+
+        # EntryRecord on Lennon *and* a separate entryrecord in 1979 - should not match
+        e3 = EntryRecord.objects.create(blog=b2, headline='Something unrelated', pub_date=datetime.date(1979, 1, 1))
+
+        e4 = EntryRecord.objects.create(blog=b2, headline='Retrospective on Lennon', pub_date=datetime.date(1990, 6, 1))
+        e4.authors.add(a1)
+        e4.authors.add(a2)
+        e4.save()
+
+    def setUp(self):
+        class SearchPostListView(generics.ListAPIView):
+            queryset = Post.objects.all()
+            serializer_class = PostSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = (
+                '=name',
+                'entryrecord__headline',
+                '=entryrecord__pub_date__year',
+                'entryrecord__authors__name'
+            )
+
+        self.SearchPostListView = SearchPostListView
+
+        class SearchEntryRecordListView(generics.ListAPIView):
+            queryset = EntryRecord.objects.all()
+            serializer_class = EntryRecordSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = (
+                'authors__name',
+            )
+
+        self.SearchEntryRecordListView = SearchEntryRecordListView
+
+    def test_multiple_filter_conditions(self):
+        view = self.SearchPostListView.as_view()
+        request = factory.get('/', {'search': 'Lennon, 1979'})
+        response = view(request)
+        assert len(response.data) == 1
+
+    def test_single_filter_condition_manytomany(self):
+        view = self.SearchPostListView.as_view()
+
+        request = factory.get('/', {'search': 'alice'})
+        response = view(request)
+        assert len(response.data) == 2
+
+        request = factory.get('/', {'search': 'bob'})
+        response = view(request)
+        assert len(response.data) == 2
+
+    def test_multiple_filter_conditions_manytomany(self):
+        view = self.SearchEntryRecordListView.as_view()
+        request = factory.get('/', {'search': 'alice, bob'})
+        response = view(request)
+        assert len(response.data) == 1
+
+        dual_entry = EntryRecord.objects.get(headline='Retrospective on Lennon')
+        response_id = response.data[0].get('id')
+        assert response_id == dual_entry.id


### PR DESCRIPTION
A change to rest_framework's filters.py, introduced in https://github.com/encode/django-rest-framework/pull/5264 and pushed out as part of v3.6.4, appears to have changed how searching with multiple filter conditions works when the fields involved are `ManyToMany` relations rather than plain model fields or `ForeignKey` relations.

This PR adds a failing test to test_filters.py that highlights a search involving `ManyToMany`.

(Note that the single-tag tests are in the same file mostly to verify that it really is only multiple filter conditions that are affected)

I tried to verify this against the commit preceding #5264 (f02b7f1329012aafca3851df3340b719c28d4586) but I was unable to get the tests to run succesfully, even without any new code - even with django pegged to 1.11 the result of `runtests --fast` is 54 errors, so I'm quite sure how to even check which historical versions of that various dependencies are necessary to make all the pre-existing tests pass.