### PR TITLE
OpenAPI3 proposal: Components

### DIFF
--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -18,6 +18,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--title', dest="title", default='', type=str)
         parser.add_argument('--url', dest="url", default=None, type=str)
+        parser.add_argument('--api-version', dest="api_version", default=None, type=str)
         parser.add_argument('--description', dest="description", default=None, type=str)
         if self.get_mode() == COREAPI_MODE:
             parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json', 'corejson'], default='openapi', type=str)
@@ -25,6 +26,7 @@ class Command(BaseCommand):
             parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json'], default='openapi', type=str)
         parser.add_argument('--urlconf', dest="urlconf", default=None, type=str)
         parser.add_argument('--generator_class', dest="generator_class", default=None, type=str)
+        parser.add_argument('--file', dest="file", default=None, type=str)
 
     def handle(self, *args, **options):
         if options['generator_class']:
@@ -36,11 +38,17 @@ class Command(BaseCommand):
             title=options['title'],
             description=options['description'],
             urlconf=options['urlconf'],
+            version=options['api_version'],
         )
         schema = generator.get_schema(request=None, public=True)
         renderer = self.get_renderer(options['format'])
         output = renderer.render(schema, renderer_context={})
-        self.stdout.write(output.decode())
+
+        if options['file']:
+            with open(options['file'], 'wb') as f:
+                f.write(output)
+        else:
+            self.stdout.write(output.decode())
 
     def get_renderer(self, format):
         if self.get_mode() == COREAPI_MODE:

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -1053,6 +1053,8 @@ class OpenAPIRenderer(BaseRenderer):
         assert yaml, 'Using OpenAPIRenderer, but `pyyaml` is not installed.'
 
     def render(self, data, media_type=None, renderer_context=None):
+        # prevent polluting the output with yaml references (aliases)
+        yaml.Dumper.ignore_aliases = lambda *args: True
         return yaml.dump(data, default_flow_style=False, sort_keys=False).encode('utf-8')
 
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -263,7 +263,7 @@ class AutoSchema(ViewInspector):
         if isinstance(field, serializers.ManyRelatedField):
             return {
                 'type': 'array',
-                'items': self._map_field(field.child_relation)
+                'items': self._map_field(method, field.child_relation)
             }
         if isinstance(field, serializers.PrimaryKeyRelatedField):
             model = getattr(field.queryset, 'model', None)

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -635,12 +635,13 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
 
-        responses = inspector._get_responses(path, method)
-        response_schema = responses['200']['content']['application/json']['schema']
-        properties = response_schema['items']['properties']
+        properties = registry.schemas['Example']['properties']
         assert 'default' not in properties['uuid_field']
 
     def test_serializer_validators(self):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -1,14 +1,19 @@
 import pytest
-from django.conf.urls import url
+from django.conf.urls import include, url
+from django.db import models
 from django.test import RequestFactory, TestCase, override_settings
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework import filters, generics, pagination, routers, serializers
+from rest_framework import (
+    filters, generics, pagination, routers, serializers, viewsets
+)
 from rest_framework.compat import uritemplate
 from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
-from rest_framework.schemas.openapi import AutoSchema, SchemaGenerator
+from rest_framework.schemas.openapi import (
+    AutoSchema, ComponentRegistry, SchemaGenerator
+)
 
 from . import views
 
@@ -57,7 +62,7 @@ class TestFieldMapping(TestCase):
         ]
         for field, mapping in cases:
             with self.subTest(field=field):
-                assert inspector._map_field(field) == mapping
+                assert inspector._map_field('GET', field) == mapping
 
     def test_lazy_string_field(self):
         class Serializer(serializers.Serializer):
@@ -65,7 +70,7 @@ class TestFieldMapping(TestCase):
 
         inspector = AutoSchema()
 
-        data = inspector._map_serializer(Serializer())
+        data = inspector._map_serializer('GET', Serializer())
         assert isinstance(data['properties']['text']['description'], str), "description must be str"
 
 
@@ -83,6 +88,7 @@ class TestOperationIntrospection(TestCase):
         )
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(ComponentRegistry())
 
         operation = inspector.get_operation(path, method)
         assert operation == {
@@ -91,17 +97,20 @@ class TestOperationIntrospection(TestCase):
             'parameters': [],
             'responses': {
                 '200': {
-                    'description': '',
                     'content': {
                         'application/json': {
                             'schema': {
                                 'type': 'array',
-                                'items': {},
-                            },
+                                'items': {
+                                    'type': 'object',
+                                    'description': 'Unspecified response body'
+                                }
+                            }
                         },
                     },
+                    'description': ''
                 },
-            },
+            }
         }
 
     def test_path_with_id_parameter(self):
@@ -114,131 +123,154 @@ class TestOperationIntrospection(TestCase):
             create_request(path)
         )
         inspector = AutoSchema()
+        inspector.init(ComponentRegistry())
         inspector.view = view
 
         operation = inspector.get_operation(path, method)
         assert operation == {
             'operationId': 'RetrieveDocStringExampleDetail',
             'description': 'A description of my GET operation.',
-            'parameters': [{
-                'description': '',
-                'in': 'path',
-                'name': 'id',
-                'required': True,
-                'schema': {
-                    'type': 'string',
-                },
-            }],
+            'parameters': [
+                {
+                    'name': 'id',
+                    'in': 'path',
+                    'required': True,
+                    'description': '',
+                    'schema': {
+                        'type': 'string'
+                    }
+                }
+            ],
             'responses': {
                 '200': {
-                    'description': '',
                     'content': {
                         'application/json': {
                             'schema': {
-                            },
-                        },
+                                'type': 'object',
+                                'description': 'Unspecified response body'
+                            }
+                        }
                     },
-                },
-            },
+                    'description': ''
+                }
+            }
         }
 
     def test_request_body(self):
         path = '/'
         method = 'POST'
 
-        class Serializer(serializers.Serializer):
+        class ExampleSerializer(serializers.Serializer):
             text = serializers.CharField()
             read_only = serializers.CharField(read_only=True)
 
-        class View(generics.GenericAPIView):
-            serializer_class = Serializer
+        class View(generics.CreateAPIView):
+            serializer_class = ExampleSerializer
 
         view = create_view(
             View,
             method,
             create_request(path)
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
 
-        request_body = inspector._get_request_body(path, method)
-        assert request_body['content']['application/json']['schema']['required'] == ['text']
-        assert list(request_body['content']['application/json']['schema']['properties'].keys()) == ['text']
+        schema = registry.schemas['Example']
+        assert schema['required'] == ['text']
+        assert schema['properties']['read_only']['readOnly'] is True
 
     def test_empty_required(self):
         path = '/'
         method = 'POST'
 
-        class Serializer(serializers.Serializer):
+        class ExampleSerializer(serializers.Serializer):
             read_only = serializers.CharField(read_only=True)
             write_only = serializers.CharField(write_only=True, required=False)
 
-        class View(generics.GenericAPIView):
-            serializer_class = Serializer
+        class View(generics.CreateAPIView):
+            serializer_class = ExampleSerializer
 
         view = create_view(
             View,
             method,
             create_request(path)
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
 
-        request_body = inspector._get_request_body(path, method)
+        schema = registry.schemas['Example']
         # there should be no empty 'required' property, see #6834
-        assert 'required' not in request_body['content']['application/json']['schema']
-
-        for response in inspector._get_responses(path, method).values():
-            assert 'required' not in response['content']['application/json']['schema']
+        assert 'required' not in schema
 
     def test_empty_required_with_patch_method(self):
         path = '/'
         method = 'PATCH'
 
-        class Serializer(serializers.Serializer):
+        class ExampleSerializer(serializers.Serializer):
             read_only = serializers.CharField(read_only=True)
             write_only = serializers.CharField(write_only=True, required=False)
 
-        class View(generics.GenericAPIView):
-            serializer_class = Serializer
+        class View(generics.UpdateAPIView):
+            serializer_class = ExampleSerializer
 
         view = create_view(
             View,
             method,
             create_request(path)
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
 
-        request_body = inspector._get_request_body(path, method)
+        schema = registry.schemas['PatchedExample']
         # there should be no empty 'required' property, see #6834
-        assert 'required' not in request_body['content']['application/json']['schema']
-        for response in inspector._get_responses(path, method).values():
-            assert 'required' not in response['content']['application/json']['schema']
+        assert 'required' not in schema
+        for field_schema in schema['properties']:
+            assert 'required' not in field_schema
 
     def test_response_body_generation(self):
         path = '/'
         method = 'POST'
 
-        class Serializer(serializers.Serializer):
+        class ExampleSerializer(serializers.Serializer):
             text = serializers.CharField()
             write_only = serializers.CharField(write_only=True)
 
-        class View(generics.GenericAPIView):
-            serializer_class = Serializer
+        class View(generics.CreateAPIView):
+            serializer_class = ExampleSerializer
 
         view = create_view(
             View,
             method,
             create_request(path)
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
 
-        responses = inspector._get_responses(path, method)
-        assert responses['200']['content']['application/json']['schema']['required'] == ['text']
-        assert list(responses['200']['content']['application/json']['schema']['properties'].keys()) == ['text']
-        assert 'description' in responses['200']
+        operation = inspector.get_operation(path, method)
+
+        assert operation['responses'] == {
+            '200': {
+                'content': {
+                    'application/json': {
+                        'schema': {'$ref': '#/components/schemas/Example'}
+                    }
+                },
+                'description': ''
+            }
+        }
+        assert sorted(registry.schemas['Example']['required']) == ['text', 'write_only']
+        assert sorted(registry.schemas['Example']['properties'].keys()) == ['text', 'write_only']
 
     def test_response_body_nested_serializer(self):
         path = '/'
@@ -247,28 +279,31 @@ class TestOperationIntrospection(TestCase):
         class NestedSerializer(serializers.Serializer):
             number = serializers.IntegerField()
 
-        class Serializer(serializers.Serializer):
+        class ExampleSerializer(serializers.Serializer):
             text = serializers.CharField()
             nested = NestedSerializer()
 
-        class View(generics.GenericAPIView):
-            serializer_class = Serializer
+        class View(generics.CreateAPIView):
+            serializer_class = ExampleSerializer
 
         view = create_view(
             View,
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
+        example_schema = registry.schemas['Example']
+        nested_schema = registry.schemas['Nested']
 
-        responses = inspector._get_responses(path, method)
-        schema = responses['200']['content']['application/json']['schema']
-        assert sorted(schema['required']) == ['nested', 'text']
-        assert sorted(list(schema['properties'].keys())) == ['nested', 'text']
-        assert schema['properties']['nested']['type'] == 'object'
-        assert list(schema['properties']['nested']['properties'].keys()) == ['number']
-        assert schema['properties']['nested']['required'] == ['number']
+        assert sorted(example_schema['required']) == ['nested', 'text']
+        assert sorted(example_schema['properties'].keys()) == ['nested', 'text']
+        assert example_schema['properties']['nested']['type'] == 'object'
+        assert sorted(nested_schema['properties'].keys()) == ['number']
+        assert nested_schema['required'] == ['number']
 
     def test_list_response_body_generation(self):
         """Test that an array schema is returned for list views."""
@@ -278,7 +313,7 @@ class TestOperationIntrospection(TestCase):
         class ItemSerializer(serializers.Serializer):
             text = serializers.CharField()
 
-        class View(generics.GenericAPIView):
+        class View(generics.ListAPIView):
             serializer_class = ItemSerializer
 
         view = create_view(
@@ -286,29 +321,25 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
 
-        responses = inspector._get_responses(path, method)
-        assert responses == {
+        operation = inspector.get_operation(path, method)
+
+        assert operation['responses'] == {
             '200': {
-                'description': '',
                 'content': {
                     'application/json': {
                         'schema': {
                             'type': 'array',
-                            'items': {
-                                'properties': {
-                                    'text': {
-                                        'type': 'string',
-                                    },
-                                },
-                                'required': ['text'],
-                            },
-                        },
-                    },
+                            'items': {'$ref': '#/components/schemas/Item'},
+                        }
+                    }
                 },
-            },
+                'description': ''
+            }
         }
 
     def test_paginated_list_response_body_generation(self):
@@ -326,7 +357,7 @@ class TestOperationIntrospection(TestCase):
         class ItemSerializer(serializers.Serializer):
             text = serializers.CharField()
 
-        class View(generics.GenericAPIView):
+        class View(generics.ListAPIView):
             serializer_class = ItemSerializer
             pagination_class = Pagination
 
@@ -337,9 +368,10 @@ class TestOperationIntrospection(TestCase):
         )
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(ComponentRegistry())
 
-        responses = inspector._get_responses(path, method)
-        assert responses == {
+        operation = inspector.get_operation(path, method)
+        assert operation['responses'] == {
             '200': {
                 'description': '',
                 'content': {
@@ -348,14 +380,7 @@ class TestOperationIntrospection(TestCase):
                             'type': 'object',
                             'item': {
                                 'type': 'array',
-                                'items': {
-                                    'properties': {
-                                        'text': {
-                                            'type': 'string',
-                                        },
-                                    },
-                                    'required': ['text'],
-                                },
+                                'items': {'$ref': '#/components/schemas/Item'},
                             },
                         },
                     },
@@ -378,11 +403,12 @@ class TestOperationIntrospection(TestCase):
         )
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(ComponentRegistry())
 
-        responses = inspector._get_responses(path, method)
-        assert responses == {
+        operation = inspector.get_operation(path, method)
+        assert operation['responses'] == {
             '204': {
-                'description': '',
+                'description': 'No response body',
             },
         }
 
@@ -402,19 +428,20 @@ class TestOperationIntrospection(TestCase):
         )
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(ComponentRegistry())
 
-        request_body = inspector._get_request_body(path, method)
-
-        assert len(request_body['content'].keys()) == 2
-        assert 'multipart/form-data' in request_body['content']
-        assert 'application/json' in request_body['content']
+        operation = inspector.get_operation(path, method)
+        content = operation['requestBody']['content']
+        assert len(content.keys()) == 2
+        assert 'multipart/form-data' in content
+        assert 'application/json' in content
 
     def test_renderer_mapping(self):
         """Test that view's renderers are mapped to OA media types"""
         path = '/{id}/'
         method = 'GET'
 
-        class View(generics.CreateAPIView):
+        class View(generics.ListCreateAPIView):
             serializer_class = views.ExampleSerializer
             renderer_classes = [JSONRenderer]
 
@@ -423,13 +450,15 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
 
-        responses = inspector._get_responses(path, method)
+        operation = inspector.get_operation(path, method)
         # TODO this should be changed once the multiple response
         # schema support is there
-        success_response = responses['200']
+        success_response = operation['responses']['200']
 
         assert len(success_response['content'].keys()) == 1
         assert 'application/json' in success_response['content']
@@ -449,13 +478,15 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
 
-        request_body = inspector._get_request_body(path, method)
-        mp_media = request_body['content']['multipart/form-data']
-        attachment = mp_media['schema']['properties']['attachment']
-        assert attachment['format'] == 'binary'
+        operation = inspector.get_operation(path, method)
+
+        assert 'multipart/form-data' in operation['requestBody']['content']
+        assert registry.schemas['Item']['properties']['attachment']['format'] == 'binary'
 
     def test_retrieve_response_body_generation(self):
         """
@@ -476,7 +507,7 @@ class TestOperationIntrospection(TestCase):
         class ItemSerializer(serializers.Serializer):
             text = serializers.CharField()
 
-        class View(generics.GenericAPIView):
+        class View(generics.RetrieveAPIView):
             serializer_class = ItemSerializer
             pagination_class = Pagination
 
@@ -485,26 +516,30 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
 
-        responses = inspector._get_responses(path, method)
-        assert responses == {
+        operation = inspector.get_operation(path, method)
+
+        assert operation['responses'] == {
             '200': {
-                'description': '',
                 'content': {
                     'application/json': {
-                        'schema': {
-                            'properties': {
-                                'text': {
-                                    'type': 'string',
-                                },
-                            },
-                            'required': ['text'],
-                        },
-                    },
+                        'schema': {'$ref': '#/components/schemas/Item'}
+                    }
+                },
+                'description': ''
+            }
+        }
+        assert registry.schemas['Item'] == {
+            'properties': {
+                'text': {
+                    'type': 'string',
                 },
             },
+            'required': ['text'],
         }
 
     def test_operation_id_generation(self):
@@ -518,6 +553,7 @@ class TestOperationIntrospection(TestCase):
         )
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(ComponentRegistry())
 
         operationId = inspector._get_operation_id(path, method)
         assert operationId == 'listExamples'
@@ -532,7 +568,6 @@ class TestOperationIntrospection(TestCase):
         request = create_request('/')
         schema = generator.get_schema(request=request)
         schema_str = str(schema)
-        print(schema_str)
         assert schema_str.count("operationId") == 2
         assert schema_str.count("newExample") == 1
         assert schema_str.count("oldExample") == 1
@@ -545,12 +580,13 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
 
-        responses = inspector._get_responses(path, method)
-        response_schema = responses['200']['content']['application/json']['schema']
-        properties = response_schema['items']['properties']
+        properties = registry.schemas['Example']['properties']
         assert properties['date']['type'] == properties['datetime']['type'] == 'string'
         assert properties['date']['format'] == 'date'
         assert properties['datetime']['format'] == 'date-time'
@@ -563,12 +599,13 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
 
-        responses = inspector._get_responses(path, method)
-        response_schema = responses['200']['content']['application/json']['schema']
-        properties = response_schema['items']['properties']
+        properties = registry.schemas['Example']['properties']
         assert properties['hstore']['type'] == 'object'
 
     def test_serializer_callable_default(self):
@@ -595,12 +632,13 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
+        registry = ComponentRegistry()
         inspector = AutoSchema()
         inspector.view = view
+        inspector.init(registry)
+        inspector.get_operation(path, method)
 
-        responses = inspector._get_responses(path, method)
-        response_schema = responses['200']['content']['application/json']['schema']
-        properties = response_schema['items']['properties']
+        properties = registry.schemas['ExampleValidated']['properties']
 
         assert properties['integer']['type'] == 'integer'
         assert properties['integer']['maximum'] == 99
@@ -643,6 +681,34 @@ class TestOperationIntrospection(TestCase):
         assert properties['ip']['type'] == 'string'
         assert 'format' not in properties['ip']
 
+    def test_modelviewset(self):
+        class ExampleModel(models.Model):
+            text = models.TextField()
+
+        class ExampleSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = ExampleModel
+                fields = ['id', 'text']
+
+        class ExampleViewSet(viewsets.ModelViewSet):
+            serializer_class = ExampleSerializer
+            queryset = ExampleModel.objects.none()
+
+        router = routers.DefaultRouter()
+        router.register(r'example', ExampleViewSet)
+
+        generator = SchemaGenerator(patterns=[
+            url(r'api/', include(router.urls))
+        ])
+        generator._initialise_endpoints()
+
+        schema = generator.get_schema(request=None, public=True)
+
+        assert sorted(schema['paths']['/api/example/'].keys()) == ['get', 'post']
+        assert sorted(schema['paths']['/api/example/{id}/'].keys()) == ['delete', 'get', 'patch', 'put']
+        assert sorted(schema['components']['schemas'].keys()) == ['Example', 'PatchedExample']
+        # TODO do more checks
+
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')
 @override_settings(REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.openapi.AutoSchema'})
@@ -659,7 +725,7 @@ class TestGenerator(TestCase):
         generator = SchemaGenerator(patterns=patterns)
         generator._initialise_endpoints()
 
-        paths = generator.get_paths()
+        paths = generator.parse()
 
         assert '/example/' in paths
         example_operations = paths['/example/']
@@ -676,7 +742,7 @@ class TestGenerator(TestCase):
         generator = SchemaGenerator(patterns=patterns)
         generator._initialise_endpoints()
 
-        paths = generator.get_paths()
+        paths = generator.parse()
 
         assert '/v1/example/' in paths
         assert '/v1/example/{id}/' in paths
@@ -689,7 +755,7 @@ class TestGenerator(TestCase):
         generator = SchemaGenerator(patterns=patterns, url='/api')
         generator._initialise_endpoints()
 
-        paths = generator.get_paths()
+        paths = generator.parse()
 
         assert '/api/example/' in paths
         assert '/api/example/{id}/' in paths


### PR DESCRIPTION
As requested, this is a subset of PR #7089, because it contained too much changes.

Thanks @carltongibson! Sorry that this is still a big change, as the code structure didn't easily accommodate a persistence layer. The remaining additions should be a lot more clearer after that though.

Feature subset here:

 * abstraction of serializers into components section (better support for openapi-generator)
 * seperate component versions for `PATCH` serializers (no required fields)
 * `generateschema` file output and more parameters for generateschema
 * `generateschema` bugfix yaml aliases output in schema