### PR TITLE
Avoid outputting callable defaults to schema

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -393,7 +393,7 @@ class AutoSchema(ViewInspector):
                 schema['writeOnly'] = True
             if field.allow_null:
                 schema['nullable'] = True
-            if field.default and field.default != empty:  # why don't they use None?!
+            if field.default and field.default != empty and not callable(field.default):  # why don't they use None?!
                 schema['default'] = field.default
             if field.help_text:
                 schema['description'] = str(field.help_text)

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -571,6 +571,22 @@ class TestOperationIntrospection(TestCase):
         properties = response_schema['items']['properties']
         assert properties['hstore']['type'] == 'object'
 
+    def test_serializer_callable_default(self):
+        path = '/'
+        method = 'GET'
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema()
+        inspector.view = view
+
+        responses = inspector._get_responses(path, method)
+        response_schema = responses['200']['content']['application/json']['schema']
+        properties = response_schema['items']['properties']
+        assert 'default' not in properties['uuid_field']
+
     def test_serializer_validators(self):
         path = '/'
         method = 'GET'

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -58,6 +58,7 @@ class ExampleSerializer(serializers.Serializer):
     date = serializers.DateField()
     datetime = serializers.DateTimeField()
     hstore = serializers.HStoreField()
+    uuid_field = serializers.UUIDField(default=uuid.uuid4)
 
 
 class ExampleGenericAPIView(generics.GenericAPIView):


### PR DESCRIPTION
This simply avoids emitting callable field defaults to the openapi schema.
Fixes #6858