### PR TITLE
add permissions to quickstart tutorial

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -85,6 +85,7 @@ Right, we'd better write some views then.  Open `tutorial/quickstart/views.py` a
 
     from django.contrib.auth.models import User, Group
     from rest_framework import viewsets
+    from rest_framework import permissions
     from tutorial.quickstart.serializers import UserSerializer, GroupSerializer
 
 
@@ -94,6 +95,7 @@ Right, we'd better write some views then.  Open `tutorial/quickstart/views.py` a
         """
         queryset = User.objects.all().order_by('-date_joined')
         serializer_class = UserSerializer
+        permission_classes = [permissions.IsAuthenticated]
 
 
     class GroupViewSet(viewsets.ModelViewSet):
@@ -102,6 +104,7 @@ Right, we'd better write some views then.  Open `tutorial/quickstart/views.py` a
         """
         queryset = Group.objects.all()
         serializer_class = GroupSerializer
+        permission_classes = [permissions.IsAuthenticated]
 
 Rather than write multiple views we're grouping together all the common behavior into classes called `ViewSets`.
 


### PR DESCRIPTION
The quickstart tutorial implies that the endpoints are restricted to authorized users and the examples include basic authentication for an "admin" user.

`curl -H 'Accept: application/json; indent=4' -u admin:password123 http://127.0.0.1:8000/users/`

However, the requests are successful with or without authentication which is confusing to beginners like me.  This patch adds `permission_classes = [permissions.IsAuthenticated]` to each endpoint.

Alternatively, we could keep the quickstart tutorial simple and remove the basic authentication from the example `curl` and `httpie` requests.