### PR TITLE
Add example for caching

### DIFF
--- a/docs/api-guide/caching.md
+++ b/docs/api-guide/caching.md
@@ -13,13 +13,13 @@ provided in Django.
 
 Django provides a [`method_decorator`][decorator] to use
 decorators with class based views. This can be used with
-other cache decorators such as [`cache_page`][page] and
-[`vary_on_cookie`][cookie].
+other cache decorators such as [`cache_page`][page],
+[`vary_on_cookie`][cookie] and [`vary_on_headers`][headers].
 
 ```python
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-from django.views.decorators.vary import vary_on_cookie
+from django.views.decorators.vary import vary_on_cookie, vary_on_headers
 
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -27,8 +27,7 @@ from rest_framework import viewsets
 
 
 class UserViewSet(viewsets.ViewSet):
-
-    # Cache requested url for each user for 2 hours
+    # With cookie: cache requested url for each user for 2 hours
     @method_decorator(cache_page(60*60*2))
     @method_decorator(vary_on_cookie)
     def list(self, request, format=None):
@@ -38,8 +37,18 @@ class UserViewSet(viewsets.ViewSet):
         return Response(content)
 
 
-class PostView(APIView):
+class ProfileView(APIView):
+    # With auth: cache requested url for each user for 2 hours
+    @method_decorator(cache_page(60*60*2))
+    @method_decorator(vary_on_headers("Authorization",))
+    def get(self, request, format=None):
+        content = {
+            'user_feed': request.user.get_user_feed()
+        }
+        return Response(content)
 
+
+class PostView(APIView):
     # Cache page for the requested url
     @method_decorator(cache_page(60*60*2))
     def get(self, request, format=None):
@@ -55,4 +64,5 @@ class PostView(APIView):
 
 [page]: https://docs.djangoproject.com/en/dev/topics/cache/#the-per-view-cache
 [cookie]: https://docs.djangoproject.com/en/dev/topics/http/decorators/#django.views.decorators.vary.vary_on_cookie
+[headers]: https://docs.djangoproject.com/en/dev/topics/http/decorators/#django.views.decorators.vary.vary_on_headers
 [decorator]: https://docs.djangoproject.com/en/dev/topics/class-based-views/intro/#decorating-the-class


### PR DESCRIPTION
add an example base on `vary_on_headers`， and  allowed it  to use auth(token) to cache.