### PR TITLE
SearchFilter to support JSONField and HStoreField

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -205,6 +205,10 @@ This will allow the client to filter the items in the list by making queries suc
 You can also perform a related lookup on a ForeignKey or ManyToManyField with the lookup API double-underscore notation:
 
     search_fields = ['username', 'email', 'profile__profession']
+    
+For [JSONField][JSONField] and [HStoreField][HStoreField] fields you can filter based on nested values within the data structure using the same double-underscore notation:
+
+    search_fields = ['data__breed', 'data__owner__other_pets__0__name']
 
 By default, searches will use case-insensitive partial matches.  The search parameter may contain multiple search terms, which should be whitespace and/or comma separated.  If multiple search terms are used then objects will be returned in the list only if all the provided terms are matched.
 
@@ -360,3 +364,5 @@ The [djangorestframework-word-filter][django-rest-framework-word-search-filter] 
 [django-rest-framework-word-search-filter]: https://github.com/trollknurr/django-rest-framework-word-search-filter
 [django-url-filter]: https://github.com/miki725/django-url-filter
 [drf-url-filter]: https://github.com/manjitkumar/drf-url-filters
+[HStoreField]: https://docs.djangoproject.com/en/3.0/ref/contrib/postgres/fields/#hstorefield
+[JSONField]: https://docs.djangoproject.com/en/3.0/ref/contrib/postgres/fields/#jsonfield

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -97,6 +97,9 @@ class SearchFilter(BaseFilterBackend):
                     if any(path.m2m for path in path_info):
                         # This field is a m2m relation so we know we need to call distinct
                         return True
+                else:
+                    # This field has a custom __ query transform but is not a relational field.
+                    break
         return False
 
     def filter_queryset(self, request, queryset, view):


### PR DESCRIPTION
Since JSONFields and HStoreFields use `__` we needed to update the m2m checking code to handle search_fields that contain __ that are not relationships.

## Description

For `SearchFilter` to support [JSONFields](https://docs.djangoproject.com/en/3.0/ref/contrib/postgres/fields/#querying-jsonfield) and [HStoreFields](https://docs.djangoproject.com/en/3.0/ref/contrib/postgres/fields/#querying-hstorefield).

This enables:
`search_fields = ['jsonfieldname__nestedkey__path',]`.

### The Bug:

When traversing the `__` separated search_field path the code expects the `opts` value to be updated on each iteration of the traversal. However the JsonField/HStoreField does not provide a `get_path_info` (since it is not a relation). This results in the next iteration of the traversal reusing the old `opts` value and raising an error (`MyModel has not attribute nestedkey`). 

### The fix:

When we check if it is a `relation` if it is not we can stop traversing that search_field and continue on to the next search_field.
