### PR TITLE
Return valid OpenAPI schema even when empty.

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -35,12 +35,7 @@ class SchemaGenerator(BaseSchemaGenerator):
     def get_paths(self, request=None):
         result = {}
 
-        paths, view_endpoints = self._get_paths_and_endpoints(request)
-
-        # Only generate the path prefix for paths that will be included
-        if not paths:
-            return None
-
+        _, view_endpoints = self._get_paths_and_endpoints(request)
         for path, method, view in view_endpoints:
             if not self.has_view_permissions(path, method, view):
                 continue
@@ -62,9 +57,6 @@ class SchemaGenerator(BaseSchemaGenerator):
         self._initialise_endpoints()
 
         paths = self.get_paths(None if public else request)
-        if not paths:
-            return None
-
         schema = {
             'openapi': '3.0.2',
             'info': self.get_info(),

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -707,6 +707,15 @@ class TestGenerator(TestCase):
         assert 'openapi' in schema
         assert 'paths' in schema
 
+    def test_schema_with_no_paths(self):
+        patterns = []
+        generator = SchemaGenerator(patterns=patterns)
+
+        request = create_request('/')
+        schema = generator.get_schema(request=request)
+
+        assert schema['paths'] == {}
+
     def test_schema_information(self):
         """Construction of the top level dictionary."""
         patterns = [


### PR DESCRIPTION
Small clean-up. There's no reason to not return a valid schema if `patterns` were empty. 

(The checks were a hangover from development...)