### PR TITLE
Add --file option to generateschema

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -30,7 +30,7 @@ into the commonly used YAML-based OpenAPI format.
 If your schema is static, you can use the `generateschema` management command:
 
 ```bash
-./manage.py generateschema > openapi-schema.yml
+./manage.py generateschema --file openapi-schema.yml
 ```
 
 Once you've generated a schema in this way you can annotate it with any

--- a/rest_framework/management/commands/generateschema.py
+++ b/rest_framework/management/commands/generateschema.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
             parser.add_argument('--format', dest="format", choices=['openapi', 'openapi-json'], default='openapi', type=str)
         parser.add_argument('--urlconf', dest="urlconf", default=None, type=str)
         parser.add_argument('--generator_class', dest="generator_class", default=None, type=str)
+        parser.add_argument('--file', dest="file", default=None, type=str)
 
     def handle(self, *args, **options):
         if options['generator_class']:
@@ -40,7 +41,12 @@ class Command(BaseCommand):
         schema = generator.get_schema(request=None, public=True)
         renderer = self.get_renderer(options['format'])
         output = renderer.render(schema, renderer_context={})
-        self.stdout.write(output.decode())
+
+        if options['file']:
+            with open(options['file'], 'wb') as f:
+                f.write(output)
+        else:
+            self.stdout.write(output.decode())
 
     def get_renderer(self, format):
         if self.get_mode() == COREAPI_MODE:


### PR DESCRIPTION
@carltongibson as requested in #7096

If a codebase outputs anything on stdout (e.g. debug messages) while generating schema, the schema will be broken.

Add explicit "write to file" as a robust way to obtain a schema.


