### PR TITLE
Disable yaml aliases for generateschema

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -1053,6 +1053,8 @@ class OpenAPIRenderer(BaseRenderer):
         assert yaml, 'Using OpenAPIRenderer, but `pyyaml` is not installed.'
 
     def render(self, data, media_type=None, renderer_context=None):
+        # disable yaml advanced feature 'alias' for clean, portable, and readable output
+        yaml.Dumper.ignore_aliases = lambda *args: True
         return yaml.dump(data, default_flow_style=False, sort_keys=False).encode('utf-8')
 
 

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -1054,8 +1054,10 @@ class OpenAPIRenderer(BaseRenderer):
 
     def render(self, data, media_type=None, renderer_context=None):
         # disable yaml advanced feature 'alias' for clean, portable, and readable output
-        yaml.Dumper.ignore_aliases = lambda *args: True
-        return yaml.dump(data, default_flow_style=False, sort_keys=False).encode('utf-8')
+        class Dumper(yaml.Dumper):
+            def ignore_aliases(self, data):
+                return True
+        return yaml.dump(data, default_flow_style=False, sort_keys=False, Dumper=Dumper).encode('utf-8')
 
 
 class JSONOpenAPIRenderer(BaseRenderer):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import filters, generics, pagination, routers, serializers
 from rest_framework.compat import uritemplate
 from rest_framework.parsers import JSONParser, MultiPartParser
-from rest_framework.renderers import JSONRenderer
+from rest_framework.renderers import JSONRenderer, OpenAPIRenderer
 from rest_framework.request import Request
 from rest_framework.schemas.openapi import AutoSchema, SchemaGenerator
 
@@ -433,6 +433,19 @@ class TestOperationIntrospection(TestCase):
 
         assert len(success_response['content'].keys()) == 1
         assert 'application/json' in success_response['content']
+
+    def test_openapi_yaml_rendering_without_aliases(self):
+        renderer = OpenAPIRenderer()
+
+        reused_object = {'test': 'test'}
+        data = {
+            'o1': reused_object,
+            'o2': reused_object,
+        }
+        assert (
+            renderer.render(data) == b'o1:\n  test: test\no2:\n  test: test\n' or
+            renderer.render(data) == b'o2:\n  test: test\no1:\n  test: test\n'  # py <= 3.5
+        )
 
     def test_serializer_filefield(self):
         path = '/{id}/'


### PR DESCRIPTION
@carltongibson as requested in #7096

when objects are reused in a structure, yaml creates aliases for those objects. 

- makes the schema harder to read with only alias tags like `&id001` instead of proper names
- usage of advanced yaml feature possibly not supported everywhere
- the openapi client generators also chokes on that feature

(will push fix once test fails)