### PR TITLE
Fix full-text search typo (mysql => postgres)

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -212,7 +212,7 @@ The search behavior may be restricted by prepending various characters to the `s
 
 * '^' Starts-with search.
 * '=' Exact matches.
-* '@' Full-text search.  (Currently only supported Django's MySQL backend.)
+* '@' Full-text search.  (Currently only supported Django's [PostgreSQL backend](https://docs.djangoproject.com/en/dev/ref/contrib/postgres/search/).)
 * '$' Regex search.
 
 For example:


### PR DESCRIPTION
As far as I can tell, Django supports full text search with PostgreSQL, not MySQL.  I updated the wording in the `filtering.md`.

https://docs.djangoproject.com/en/3.0/topics/db/search/#document-based-search
https://docs.djangoproject.com/en/dev/ref/contrib/postgres/search/

