### PR TITLE
Improve ListField introspection of the child field

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -268,13 +268,7 @@ class AutoSchema(ViewInspector):
                 'items': {},
             }
             if not isinstance(field.child, _UnvalidatedField):
-                map_field = self._map_field(field.child)
-                items = {
-                    "type": map_field.get('type')
-                }
-                if 'format' in map_field:
-                    items['format'] = map_field.get('format')
-                mapping['items'] = items
+                mapping['items'] = self._map_field(field.child)
             return mapping
 
         # DateField and DateTimeField type is string

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -51,7 +51,7 @@ class TestFieldMapping(TestCase):
             (serializers.ListField(child=serializers.FloatField()), {'items': {'type': 'number'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.CharField()), {'items': {'type': 'string'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.IntegerField(max_value=4294967295)),
-             {'items': {'type': 'integer', 'format': 'int64'}, 'type': 'array'}),
+             {'items': {'type': 'integer', 'maximum': 4294967295, 'format': 'int64'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[('a', 'Choice A'), ('b', 'Choice B')])),
              {'items': {'enum': ['a', 'b']}, 'type': 'array'}),
             (serializers.IntegerField(min_value=2147483648),

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -52,6 +52,8 @@ class TestFieldMapping(TestCase):
             (serializers.ListField(child=serializers.CharField()), {'items': {'type': 'string'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.IntegerField(max_value=4294967295)),
              {'items': {'type': 'integer', 'format': 'int64'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[('a', 'Choice A'), ('b', 'Choice B')])),
+             {'items': {'enum': ['a', 'b']}, 'type': 'array'}),
             (serializers.IntegerField(min_value=2147483648),
              {'type': 'integer', 'minimum': 2147483648, 'format': 'int64'}),
         ]


### PR DESCRIPTION
Instead of copying over a select few fields from the schema generation for `ListField`, we are now copying over the entire generated schema and trusting our schema generation to produce the right sub-schema for the child field.

This fixes #7023.
This closes #7080.