### PR TITLE
Fix SearchFilter.must_call_distinict for annotation+m2m

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -86,7 +86,7 @@ class SearchFilter(BaseFilterBackend):
                 search_field = search_field[1:]
             # Annotated fields do not need to be distinct
             if isinstance(queryset, models.QuerySet) and search_field in queryset.query.annotations:
-                return False
+                continue
             parts = search_field.split(LOOKUP_SEP)
             for part in parts:
                 field = opts.get_field(part)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -368,6 +368,21 @@ class SearchFilterAnnotatedFieldTests(TestCase):
         assert len(response.data) == 1
         assert response.data[0]['title_text'] == 'ABCDEF'
 
+    def test_must_call_distinct_subsequent_m2m_fields(self):
+        f = filters.SearchFilter()
+
+        queryset = SearchFilterModelM2M.objects.annotate(
+            title_text=Upper(
+                Concat(models.F('title'), models.F('text'))
+            )
+        ).all()
+
+        # Sanity check that m2m must call distinct
+        assert f.must_call_distinct(queryset, ['attributes'])
+
+        # Annotated field should not prevent m2m must call distinct
+        assert f.must_call_distinct(queryset, ['title_text', 'attributes'])
+
 
 class OrderingFilterModel(models.Model):
     title = models.CharField(max_length=20, verbose_name='verbose title')


### PR DESCRIPTION
Fixes https://github.com/encode/django-rest-framework/pull/6240#discussion_r361321402. `SearchFilter.must_call_distinct` incorrectly exits early if it encounters an annotation. Any subsequent m2m fields are ignored instead of causing the method to return true. By continuing, the annotations still bypass the distinct check, and will return false at the end if no m2m fields are encountered.