### PR TITLE
Changes to 'Adding login' section

### DIFF
--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -135,10 +135,6 @@ If you open a browser and navigate to the browsable API at the moment, you'll fi
 
 We can add a login view for use with the browsable API, by editing the URLconf in our project-level `urls.py` file.
 
-Add the following import at the top of the file:
-
-    from django.conf.urls import include
-
 And, at the end of the file, add a pattern to include the login and logout views for the browsable API.
 
     urlpatterns += [
@@ -147,7 +143,7 @@ And, at the end of the file, add a pattern to include the login and logout views
 
 The `'api-auth/'` part of pattern can actually be whatever URL you want to use.
 
-Now if you open up the browser again and refresh the page you'll see a 'Login' link in the top right of the page.  If you log in as one of the users you created earlier, you'll be able to create code snippets again.
+Now if you open up the browser again at the `/snippets/` endpoint and refresh the page you'll see a 'Login' link in the top right of the page.  If you log in as one of the users you created earlier, you'll be able to create code snippets again.
 
 Once you've created a few code snippets, navigate to the '/users/' endpoint, and notice that the representation includes a list of the snippet ids that are associated with each user, in each user's 'snippets' field.
 


### PR DESCRIPTION
# Removed section that said to: add import line `from django.conf.urls import include`
* Reasoning: Tutorial already had user add from `django.urls import include` in part 1.  Alternatively mention that either import will link to the same module function. The implication was that this new `include` import had different functionality or that maybe one of the imports were deprecated or something.

# Added clarification to open browser at snippets endpoint
* Reasoning: there are a lot of possible endpoints at this point in the tutorial and user hasn't been given a browser URL/endpoint for a while.  Neither the index `/` or the newly added `/api-auth/` give the described Login button,  potentially leading user to believe code was enterered incorrectly at some point .

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
