### PR TITLE
feat #6084: Adding mixin that allows for many object creations.

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -30,6 +30,19 @@ class CreateModelMixin:
             return {}
 
 
+class CreateOneOrMoreModelMixin(CreateModelMixin):
+    """
+    Create one or more model instances.
+    """
+
+    def get_serializer(self, *args, **kwargs):
+        if self.request.method == 'POST':
+            kwargs['many'] = isinstance(self.request.data, list) or kwargs.get(
+                'many', False
+            )
+        return super().get_serializer(*args, **kwargs)
+
+
 class ListModelMixin:
     """
     List a queryset.


### PR DESCRIPTION
The original issue #6084 has an issue where the browsable api cannot
create multiple objects, but sometimes being able to creat more than
object object is desired.

This commit proposes a mixin that allows for one or more objects to
be created, which allows normal browsable api operation, and the use
case of creating more than one instance.

This mixin relates to: 
https://github.com/encode/django-rest-framework/issues/6084
