### PR TITLE
Allow for SerializerMethodField to raise SkipField

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -511,7 +511,10 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
             if check_for_none is None:
                 ret[field.field_name] = None
             else:
-                ret[field.field_name] = field.to_representation(attribute)
+                try:
+                    ret[field.field_name] = field.to_representation(attribute)
+                except SkipField:
+                    continue
 
         return ret
 


### PR DESCRIPTION
## Description

Currently, SerializerMethodField has no way to be excluded from serialization. 

If the field is computed in the model we can raise AttributeError whenever we want to exclude the field from serialization. However, if we compute it through a SerializerMethodField this is not possible.

This small PR allows to raise SkipField in SerializerMethodField whenever we wan to exclude this from serialization.