### PR TITLE
Fix BasePermission.has_object_permission() from short circuiting in permission composition.

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -77,11 +77,10 @@ class OR:
         )
 
     def has_object_permission(self, request, view, obj):
-        return (
-            (self.op1.has_permission(request, view) and self.op1.has_object_permission(request, view, obj))
-            or
-            (self.op2.has_permission(request, view) and self.op2.has_object_permission(request, view, obj))
-        )
+        op1 = self.op1.has_permission(request, view) and self.op1.has_object_permission(request, view, obj)
+        if op1:
+            return op1
+        return self.op2.has_permission(request, view) and self.op2.has_object_permission(request, view, obj)
 
 
 class NOT:

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -78,8 +78,9 @@ class OR:
 
     def has_object_permission(self, request, view, obj):
         return (
-            self.op1.has_object_permission(request, view, obj) or
-            self.op2.has_object_permission(request, view, obj)
+            (self.op1.has_permission(request, view) and self.op1.has_object_permission(request, view, obj))
+            or
+            (self.op2.has_permission(request, view) and self.op2.has_object_permission(request, view, obj))
         )
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -648,7 +648,7 @@ class PermissionsCompositionTests(TestCase):
                 mock_deny.assert_not_called()
 
         with mock.patch.object(permissions.AllowAny, 'has_object_permission', return_value=True) as mock_allow:
-            with mock.patch.object(permissions.IsAuthenticated, 'has_object_permission', return_value=False) as mock_deny:
+            with mock.patch.object(permissions.IsAuthenticated, 'has_permission', return_value=False) as mock_deny:
                 composed_perm = (permissions.IsAuthenticated | permissions.AllowAny)
                 hasperm = composed_perm().has_object_permission(request, None, None)
                 assert hasperm is True

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -615,7 +615,6 @@ class PermissionsCompositionTests(TestCase):
         )
         assert composed_perm().has_object_permission(request, None, None) is False
 
-    @pytest.mark.skipif(not PY36, reason="assert_called_once() not available")
     def test_or_lazyness(self):
         request = factory.get('/1', format='json')
         request.user = AnonymousUser()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -311,6 +311,7 @@ class ObjectPermissionsIntegrationTests(TestCase):
     """
     Integration tests for the object level permissions API.
     """
+
     def setUp(self):
         from guardian.shortcuts import assign_perm
 
@@ -605,6 +606,16 @@ class PermissionsCompositionTests(TestCase):
         )
         assert composed_perm().has_permission(request, None) is True
 
+    def test_has_object_permissions_not_short_circuited(self):
+        request = factory.get('/1', format='json')
+        request.user = self.user
+        composed_perm = (
+            permissions.IsAdminUser |
+            BasicObjectPerm
+        )
+        assert composed_perm().has_object_permission(request, None, None) is False
+
+    @pytest.mark.skipif(not PY36, reason="assert_called_once() not available")
     def test_or_lazyness(self):
         request = factory.get('/1', format='json')
         request.user = AnonymousUser()


### PR DESCRIPTION
## Description

Attempts to fix #7117 

If an object permission evaluates to False while being composed with an object only implementing `.has_permission()`, then it is short circuited due to the default of `BasePermission.has_object_permission()`. An example where this can be problematic is if you are calculating an object permission and an admin permission. This is replicated in the failing test.

I resolved the failing test by changing `BasePermission.has_object_permission()` to return the value of `BasePermission.has_permission()`
