### PR TITLE
Add type for choicefield

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -231,7 +231,8 @@ class AutoSchema(ViewInspector):
             'enum': choices
         }
 
-        # If We figured out `type` then and only then we should set it. It must be string or an array.
+        # If We figured out `type` then and only then we should set it. It must be a string.
+        # Ref: https://swagger.io/docs/specification/data-models/data-types/#mixed-type
         # It is optional but it can not be null.
         # Ref: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.21
         if type:

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -218,7 +218,7 @@ class AutoSchema(ViewInspector):
         elif all(isinstance(choice, int) for choice in choices):
             type = 'integer'
         elif all(isinstance(choice, (int, float, Decimal)) for choice in choices):  # `number` includes `integer`
-            # SEE: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.21
+            # Ref: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.21
             type = 'number'
         elif all(isinstance(choice, str) for choice in choices):
             type = 'string'

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -212,20 +212,21 @@ class AutoSchema(ViewInspector):
         return paginator.get_schema_operation_parameters(view)
 
     def _map_choicefield(self, field):
-        type = None
         choices = list(field.choices)
-        if all(isinstance(choice, int) for choice in choices):
-            type = 'integer'
-        if all(isinstance(choice, float) or isinstance(choice, Decimal) for choice in choices):
-            type = 'number'
-        if all(isinstance(choice, str) for choice in choices):
-            type = 'string'
         if all(isinstance(choice, bool) for choice in choices):
             # Here we can not use `boolean` as type because choicefield expects `True` and `False` which is different
             # from the `true` and `false` of OpenAPI Specification.
             # Ref: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#format
             type = 'string'
             choices = list(map(lambda choice: str(choice), choices))
+        elif all(isinstance(choice, int) for choice in choices):
+            type = 'integer'
+        elif all(isinstance(choice, (int, float, Decimal)) for choice in choices):  # `number` includes `integer`
+            type = 'number'
+        elif all(isinstance(choice, str) for choice in choices):
+            type = 'string'
+        else:
+            type = None
 
         mapping = {
             # The value of `enum` keyword MUST be an array and SHOULD be unique.

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -212,7 +212,7 @@ class AutoSchema(ViewInspector):
         return paginator.get_schema_operation_parameters(view)
 
     def _map_choicefield(self, field):
-        choices = list(field.choices)
+        choices = list(OrderedDict.fromkeys(field.choices))  # preserve order and remove duplicates
         if all(isinstance(choice, bool) for choice in choices):
             type = 'boolean'
         elif all(isinstance(choice, int) for choice in choices):
@@ -228,7 +228,7 @@ class AutoSchema(ViewInspector):
         mapping = {
             # The value of `enum` keyword MUST be an array and SHOULD be unique.
             # Ref: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.20
-            'enum': list(OrderedDict.fromkeys(choices))  # preserve order and remove duplicates
+            'enum': choices
         }
 
         # If We figured out `type` then and only then we should set it. It must be string or an array.

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -218,6 +218,7 @@ class AutoSchema(ViewInspector):
         elif all(isinstance(choice, int) for choice in choices):
             type = 'integer'
         elif all(isinstance(choice, (int, float, Decimal)) for choice in choices):  # `number` includes `integer`
+            # SEE: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.21
             type = 'number'
         elif all(isinstance(choice, str) for choice in choices):
             type = 'string'

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -214,11 +214,7 @@ class AutoSchema(ViewInspector):
     def _map_choicefield(self, field):
         choices = list(field.choices)
         if all(isinstance(choice, bool) for choice in choices):
-            # Here we can not use `boolean` as type because choicefield expects `True` and `False` which is different
-            # from the `true` and `false` of OpenAPI Specification.
-            # Ref: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#format
-            type = 'string'
-            choices = list(map(lambda choice: str(choice), choices))
+            type = 'boolean'
         elif all(isinstance(choice, int) for choice in choices):
             type = 'integer'
         elif all(isinstance(choice, (int, float, Decimal)) for choice in choices):  # `number` includes `integer`

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -68,6 +68,8 @@ class TestFieldMapping(TestCase):
              {'items': {'enum': ['True', 'False'], 'type': 'string'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(uuid1, 'uuid1'), (uuid2, 'uuid2')])),
              {'items': {'enum': [uuid1, uuid2]}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[(1, 'One'), ('a', 'Choice A')])),
+             {'items': {'enum': [1, 'a']}, 'type': 'array'}),
             (serializers.IntegerField(min_value=2147483648),
              {'type': 'integer', 'minimum': 2147483648, 'format': 'int64'}),
         ]

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -63,7 +63,7 @@ class TestFieldMapping(TestCase):
             (serializers.ListField(child=serializers.ChoiceField(choices=[(1.1, 'First'), (2.2, 'Second')])),
              {'items': {'enum': [1.1, 2.2], 'type': 'number'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(True, 'true'), (False, 'false')])),
-             {'items': {'enum': ['True', 'False'], 'type': 'string'}, 'type': 'array'}),
+             {'items': {'enum': [True, False], 'type': 'boolean'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(uuid1, 'uuid1'), (uuid2, 'uuid2')])),
              {'items': {'enum': [uuid1, uuid2]}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(1, 'One'), ('a', 'Choice A')])),

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -64,8 +64,6 @@ class TestFieldMapping(TestCase):
              {'items': {'enum': [1.1, 2.2], 'type': 'number'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(True, 'true'), (False, 'false')])),
              {'items': {'enum': ['True', 'False'], 'type': 'string'}, 'type': 'array'}),
-            (serializers.ListField(child=serializers.ChoiceField(choices=[(True, 'true'), (False, 'false')])),
-             {'items': {'enum': ['True', 'False'], 'type': 'string'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(uuid1, 'uuid1'), (uuid2, 'uuid2')])),
              {'items': {'enum': [uuid1, uuid2]}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(1, 'One'), ('a', 'Choice A')])),

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.conf.urls import url
 from django.test import RequestFactory, TestCase, override_settings
@@ -44,6 +46,8 @@ class TestBasics(TestCase):
 
 class TestFieldMapping(TestCase):
     def test_list_field_mapping(self):
+        uuid1 = uuid.uuid4()
+        uuid2 = uuid.uuid4()
         inspector = AutoSchema()
         cases = [
             (serializers.ListField(), {'items': {}, 'type': 'array'}),
@@ -53,7 +57,17 @@ class TestFieldMapping(TestCase):
             (serializers.ListField(child=serializers.IntegerField(max_value=4294967295)),
              {'items': {'type': 'integer', 'maximum': 4294967295, 'format': 'int64'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[('a', 'Choice A'), ('b', 'Choice B')])),
-             {'items': {'enum': ['a', 'b']}, 'type': 'array'}),
+             {'items': {'enum': ['a', 'b'], 'type': 'string'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[(1, 'One'), (2, 'Two')])),
+             {'items': {'enum': [1, 2], 'type': 'integer'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[(1.1, 'First'), (2.2, 'Second')])),
+             {'items': {'enum': [1.1, 2.2], 'type': 'number'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[(True, 'true'), (False, 'false')])),
+             {'items': {'enum': ['True', 'False'], 'type': 'string'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[(True, 'true'), (False, 'false')])),
+             {'items': {'enum': ['True', 'False'], 'type': 'string'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[(uuid1, 'uuid1'), (uuid2, 'uuid2')])),
+             {'items': {'enum': [uuid1, uuid2]}, 'type': 'array'}),
             (serializers.IntegerField(min_value=2147483648),
              {'type': 'integer', 'minimum': 2147483648, 'format': 'int64'}),
         ]

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -68,6 +68,14 @@ class TestFieldMapping(TestCase):
              {'items': {'enum': [uuid1, uuid2]}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[(1, 'One'), ('a', 'Choice A')])),
              {'items': {'enum': [1, 'a']}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[
+                (1, 'One'), ('a', 'Choice A'), (1.1, 'First'), (1.1, 'First'), (1, 'One'), ('a', 'Choice A'), (1, 'One')
+            ])),
+                {'items': {'enum': [1, 'a', 1.1]}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.ChoiceField(choices=[
+                (1, 'One'), (2, 'Two'), (3, 'Three'), (2, 'Two'), (3, 'Three'), (1, 'One'),
+            ])),
+                {'items': {'enum': [1, 2, 3], 'type': 'integer'}, 'type': 'array'}),
             (serializers.IntegerField(min_value=2147483648),
              {'type': 'integer', 'minimum': 2147483648, 'format': 'int64'}),
         ]


### PR DESCRIPTION
@carltongibson @kevin-brown As we have discussed in #7080, In majority cases, the `type` of enum values for the choicefield will be one of the following.
1. string
2. int
3. float

In this merge request, I have added code to generate the `type` for majority cases.