### PR TITLE
handle default=false for boolean fields

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -378,7 +378,7 @@ class AutoSchema(ViewInspector):
                 schema['writeOnly'] = True
             if field.allow_null:
                 schema['nullable'] = True
-            if field.default and field.default != empty and not callable(field.default):
+            if field.default is not None and field.default != empty and not callable(field.default):
                 schema['default'] = field.default
             if field.help_text:
                 schema['description'] = str(field.help_text)

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -70,6 +70,19 @@ class TestFieldMapping(TestCase):
         data = inspector._map_serializer(Serializer())
         assert isinstance(data['properties']['text']['description'], str), "description must be str"
 
+    def test_boolean_default_field(self):
+        class Serializer(serializers.Serializer):
+            default_true = serializers.BooleanField(default=True)
+            default_false = serializers.BooleanField(default=False)
+            without_default = serializers.BooleanField()
+
+        inspector = AutoSchema()
+
+        data = inspector._map_serializer(Serializer())
+        assert data['properties']['default_true']['default'] is True, "default must be true"
+        assert data['properties']['default_false']['default'] is False, "default must be false"
+        assert 'default' not in data['properties']['without_default'], "default must not be defined"
+
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')
 class TestOperationIntrospection(TestCase):


### PR DESCRIPTION
## Description

Includes in the OpenAPI schema of boolean fields the default value when it's false
e.g. `serializers.BooleanField(default=False)` generates `{type: boolean, default: false}`
