### PR TITLE
Fix remove unnecessary import sentence from api guide renderers example document

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -273,7 +273,6 @@ By default this will include the following keys: `view`, `request`, `response`, 
 
 The following is an example plaintext renderer that will return a response with the `data` parameter as the content of the response.
 
-    from django.utils.encoding import smart_unicode
     from rest_framework import renderers
 
 


### PR DESCRIPTION
## Description
Hi there.

I guess there is unnecessary import sentence in [renderers api guide](https://www.django-rest-framework.org/api-guide/renderers/#example).

If I write this import sentence, then it throws the below error and I think `smart_unicode` is not used so it is unnecessary.

```
ImportError: cannot import name 'smart_unicode' from 'django.utils.encoding' (/usr/local/lib/python3.7/site-packages/django/utils/encoding.py)
```