### PR TITLE
Fix modify custom render example document

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -273,7 +273,7 @@ By default this will include the following keys: `view`, `request`, `response`, 
 
 The following is an example plaintext renderer that will return a response with the `data` parameter as the content of the response.
 
-    from django.utils.encoding import smart_unicode
+    from django.utils.encoding import smart_text
     from rest_framework import renderers
 
 
@@ -282,7 +282,7 @@ The following is an example plaintext renderer that will return a response with 
         format = 'txt'
 
         def render(self, data, media_type=None, renderer_context=None):
-            return data.encode(self.charset)
+            return smart_text(data, encoding=self.charset)
 
 ## Setting the character set
 


### PR DESCRIPTION
## Description

Hi there.

I guess [this example](https://www.django-rest-framework.org/api-guide/renderers/#example) is not working now.

And if I write this example, then it throws the below error and I think smart_unicode is not used. 

```
ImportError: cannot import name 'smart_unicode' from 'django.utils.encoding' (/usr/local/lib/python3.7/site-packages/django/utils/encoding.py)
```

If I delete `from django.utils.encoding import smart_unicode`, then it throws the below error.

```
AttributeError: 'ReturnList' object has no attribute 'encode'
```

So I replace `smart_unicode` to `smart_text`, and use it for encoding data.