### PR TITLE
start dropping EOL django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,15 @@ matrix:
     include:
 
       - { python: "3.5", env: DJANGO=1.11 }
-      - { python: "3.5", env: DJANGO=2.0 }
       - { python: "3.5", env: DJANGO=2.1 }
       - { python: "3.5", env: DJANGO=2.2 }
 
       - { python: "3.6", env: DJANGO=1.11 }
-      - { python: "3.6", env: DJANGO=2.0 }
       - { python: "3.6", env: DJANGO=2.1 }
       - { python: "3.6", env: DJANGO=2.2 }
       - { python: "3.6", env: DJANGO=3.0 }
       - { python: "3.6", env: DJANGO=master }
 
-      - { python: "3.7", env: DJANGO=2.0 }
       - { python: "3.7", env: DJANGO=2.1 }
       - { python: "3.7", env: DJANGO=2.2 }
       - { python: "3.7", env: DJANGO=3.0 }


### PR DESCRIPTION
I would like to start work on dropping django 2.x and 1.11 for 3.12