### PR TITLE
Fix schema endpoint example

### DIFF
--- a/docs/api-guide/metadata.md
+++ b/docs/api-guide/metadata.md
@@ -71,7 +71,7 @@ If you have specific requirements for creating schema endpoints that are accesse
 For example, the following additional route could be used on a viewset to provide a linkable schema endpoint.
 
     @action(methods=['GET'], detail=False)
-    def _schema(self, request):
+    def api_schema(self, request):
         meta = self.metadata_class()
         data = meta.determine_metadata(request, self)
         return Response(data)

--- a/docs/api-guide/metadata.md
+++ b/docs/api-guide/metadata.md
@@ -71,7 +71,7 @@ If you have specific requirements for creating schema endpoints that are accesse
 For example, the following additional route could be used on a viewset to provide a linkable schema endpoint.
 
     @action(methods=['GET'], detail=False)
-    def schema(self, request):
+    def _schema(self, request):
         meta = self.metadata_class()
         data = meta.determine_metadata(request, self)
         return Response(data)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Endpoint `schema` collides with `schema` class variable which is used for specification generation. Fixed docs
