### PR TITLE
add nested multipart support

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -914,6 +914,14 @@ class MultiPartRenderer(BaseRenderer):
         return encode_multipart(self.BOUNDARY, data)
 
 
+class NestedMultiPartRenderer(MultiPartRenderer):
+    format = 'nestedmultipart'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        encoder = encoders.NestedMultiPartEncoder()
+        return encoder.encode(self.BOUNDARY, data)
+
+
 class CoreJSONRenderer(BaseRenderer):
     media_type = 'application/coreapi+json'
     charset = None

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -87,6 +87,7 @@ DEFAULTS = {
 
     # Testing
     'TEST_REQUEST_RENDERER_CLASSES': [
+        'rest_framework.renderers.NestedMultiPartRenderer',
         'rest_framework.renderers.MultiPartRenderer',
         'rest_framework.renderers.JSONRenderer'
     ],


### PR DESCRIPTION
This pull request is a answer to the need to test nested file uploads.

However, a question may be discussed: is Django-Rest-Framework not supporting nested multipart rendering by choice, for some technical reasons, or maybe just because the need has not been felt by any of its contributors?

So I'm suggesting so solution I use for a personnal project that works well in encoding nested lists and dicts and dicts of lists or dicts of lists of dicts :smile:

About that, another question should be asked:
- should I fix a maximum recursion level ? (do serializers have that kind of limit?)

Technically then, its goal is to transcribe complex objects to a form that can be parsed by `rest_framework.utils.html.parse_html_list()` and `rest_framework.utils.html.parse_html_dict()`.
Thus for example: 
`{'foo': 42, 'bar': [{'django': 'rest', 'framework': 'is'}, {'so': {'great': 'thx'}}]}`
gives us thoses keys:
`name="foo"` `name="bar[0]django"` `name="bar[0]framework"` `name="bar[1]so.great"`

Given the way parsing is done, the ability to nest serializers, and the generic serializers already integrated in Django-Rest-Framework, it was a pleasure to add that little renderer, so really, thank for your efforts all that time.

Thomas Mignot.