### PR TITLE
Possible solution for tags generation 

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -222,23 +222,30 @@ Tags can be used for logical grouping operations. Each tag name in the list MUST
 
 ---
 **Django REST Framework generates tags automatically with following logic:**
-1. Extract tag name from `ViewSet`. If `ViewSet` name ends with `ViewSet`, or `View`, it will be truncated from tag name.
+1. Extract tag from `ViewSet`. 
+    1. If `ViewSet` name ends with `ViewSet`, or `View`, remove them.
+    2. Convert class name into words & join each word with a space. 
+    
+    Examples:
+    
+        ViewSet Class   |   Tags
+        ----------------|------------
+        User            |   ['user']	 
+        UserView        |   ['user']	 
+        UserViewSet     |   ['user']	
+        PascalCaseXYZ   |   ['pascal case xyz']
+        IPAddressView   |   ['ip address']
 
-    ViewSet Class   |   Tags
-    ----------------|------------
-    User            |   User	 
-    UserView        |   User	 
-    UserViewSet     |   user	 
-
-2. If View is not an instance of ViewSet, tag name will be first element from the path. Consider below examples.
+2. If View is not an instance of ViewSet, tag name will be first element from the path. Also, any `-` or `_` in path name will be converted as a space.
+Consider below examples.
 
     Example 1: Consider a user management system. The following table will illustrate the tag generation logic.
     Here first element from the paths is: `users`. Hence tag wil be `users`
 
     Http Method                          |        Path       |     Tags
     -------------------------------------|-------------------|-------------
-    PUT, PATCH, GET(Retrieve), DELETE    |     /users/{id}/  |   [users]
-    POST, GET(List)                      |     /users/       |   [users]
+    PUT, PATCH, GET(Retrieve), DELETE    |     /users/{id}/  |   ['users']
+    POST, GET(List)                      |     /users/       |   ['users']
     
     Example 2: Consider a restaurant management system. The System has restaurants. Each restaurant has branches.
     Consider REST APIs to deal with a branch of a particular restaurant.
@@ -246,11 +253,21 @@ Tags can be used for logical grouping operations. Each tag name in the list MUST
     
     Http Method                          |                         Path                       |     Tags
     -------------------------------------|----------------------------------------------------|-------------------
-    PUT, PATCH, GET(Retrieve), DELETE:   | /restaurants/{restaurant_id}/branches/{branch_id}  |   [restaurants]
-    POST, GET(List):                     | /restaurants/{restaurant_id}/branches/             |   [restaurants]
+    PUT, PATCH, GET(Retrieve), DELETE:   | /restaurants/{restaurant_id}/branches/{branch_id}  |   ['restaurants']
+    POST, GET(List):                     | /restaurants/{restaurant_id}/branches/             |   ['restaurants']
+    
+    Example 3: Consider Order items for an e commerce company.
+    
+    Http Method                          |          Path           |     Tags
+    -------------------------------------|-------------------------|-------------
+    PUT, PATCH, GET(Retrieve), DELETE    |     /order-items/{id}/  |   ['order items']
+    POST, GET(List)                      |     /order-items/       |   ['order items']
+   
 
 ---
-**You can override auto-generated tags by passing a list of tags to each `View` by passing `tags` as an argument to the constructor of `AutoSchema`. `tags` argument can be:**
+**You can override auto-generated tags by passing `tags` argument to the constructor of `AutoSchema`.**
+
+**`tags` argument can be a**
 1. list of string.
     ```python
    class MyView(APIView):

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -218,13 +218,13 @@ project you may adjust `settings.DEFAULT_SCHEMA_CLASS`  appropriately.
 
 ### Grouping Operations With Tags
 
-Tags can be used for logical grouping operations. Each tag name in the list MUST be unique. 
+Tags can be used to group logical operations. Each tag name in the list MUST be unique. 
 
 ---
 **Django REST Framework generates tags automatically with following logic:**
 1. Extract tag from `ViewSet`. 
-    1. If `ViewSet` name ends with `ViewSet`, or `View`, remove them.
-    2. Convert class name into words & join each word with a space. 
+    1. If `ViewSet` name ends with `ViewSet`, or `View`; remove it.
+    2. Convert class name into lowercase words & join each word with a space. 
     
     Examples:
     

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -239,7 +239,7 @@ Tags can be used for logical grouping `View`s. Each tag name in the list MUST be
     POST, GET(List):                     |     /users/       |   [users]
     
     Example 2: Consider a restaurant management system. The System has restaurants. Each restaurant has branches.
-    Consider a REST APIs to deal with a branch of a particular restaurant.
+    Consider REST APIs to deal with a branch of a particular restaurant.
     
     Http Method                          |                         Path                       |     Tags
     -------------------------------------|----------------------------------------------------|-------------------

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -267,7 +267,7 @@ Consider below examples.
 
 ---
 #### Overriding auto generated tags:
-You can override auto-generated tags by passing `tags` argument to the constructor of `AutoSchema`. `tags` argument must be a list of string.
+You can override auto-generated tags by passing `tags` argument to the constructor of `AutoSchema`. `tags` argument must be a list or tuple of string.
 ```python
 from rest_framework.schemas.openapi import AutoSchema
 from rest_framework.views import APIView

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -221,10 +221,11 @@ project you may adjust `settings.DEFAULT_SCHEMA_CLASS`  appropriately.
 Tags can be used to group logical operations. Each tag name in the list MUST be unique. 
 
 ---
-**Django REST Framework generates tags automatically with following logic:**
+#### Django REST Framework generates tags automatically with following logic:
+
 1. Extract tag from `ViewSet`. 
     1. If `ViewSet` name ends with `ViewSet`, or `View`; remove it.
-    2. Convert class name into lowercase words & join each word using a space. 
+    2. Convert class name into lowercase words & join each word using a `-`(dash). 
     
     Examples:
     
@@ -233,10 +234,10 @@ Tags can be used to group logical operations. Each tag name in the list MUST be 
         User            |   ['user']	 
         UserView        |   ['user']	 
         UserViewSet     |   ['user']	
-        PascalCaseXYZ   |   ['pascal case xyz']
-        IPAddressView   |   ['ip address']
+        PascalCaseXYZ   |   ['pascal-case-xyz']
+        IPAddressView   |   ['ip-address']
 
-2. If View is not an instance of ViewSet, tag name will be first element from the path. Also, any `-` or `_` in path name will be replaced by a space.
+2. If View is not an instance of ViewSet, tag name will be first element from the path. Also, any `_` in path name will be replaced by a `-`.
 Consider below examples.
 
     Example 1: Consider a user management system. The following table will illustrate the tag generation logic.
@@ -260,65 +261,23 @@ Consider below examples.
     
     Http Method                          |          Path           |     Tags
     -------------------------------------|-------------------------|-------------
-    PUT, PATCH, GET(Retrieve), DELETE    |     /order-items/{id}/  |   ['order items']
-    POST, GET(List)                      |     /order-items/       |   ['order items']
+    PUT, PATCH, GET(Retrieve), DELETE    |     /order_items/{id}/  |   ['order-items']
+    POST, GET(List)                      |     /order_items/       |   ['order-items']
    
 
 ---
-**You can override auto-generated tags by passing `tags` argument to the constructor of `AutoSchema`.**
+#### Overriding auto generated tags:
+You can override auto-generated tags by passing `tags` argument to the constructor of `AutoSchema`. `tags` argument must be a list of string.
+```python
+from rest_framework.schemas.openapi import AutoSchema
+from rest_framework.views import APIView
 
-**`tags` argument can be a**
-1. list of string.
-    ```python
-   class MyView(APIView):
-        ...
-        schema = AutoSchema(tags=['tag1', 'tag2'])
-   ```
-2.  list of dict. This adds metadata to a single tag. Each dict can have 3 possible keys:
-
-    Field name   | Data type | Required | Description 
-    -------------|-----------|----------|-------------------------------------------------------------------------
-    name         |  string   |   yes    | The name of the tag.
-    description  |  string   |    no    | A short description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-    externalDocs |  dict     |    no    | Additional external documentation for this tag. [Click here](https://swagger.io/specification/#externalDocumentationObject) to know more.
-
-    Note: A tag dict with only `name` as a key is logically equivalent to passing a `string` as a tag.
-
-    ```python
-    class MyView(APIView):
-        ...
-        schema = AutoSchema(tags=[
-            {
-                "name": "user"
-            },
-            {
-                "name": "pet",
-                "description": "Everything about your Pets"
-            },
-            {
-                "name": "store",
-                "description": "Access to Petstore orders",
-                "externalDocs": {
-                    "url": "https://example.com",
-                    "description": "Find more info here"
-                }
-            },
-        ])
-    ```
-3. list which is mix of dicts and strings.
-    ```python
-    class MyView(APIView):
-        ...
-        schema = AutoSchema(tags=[
-            'user',
-            {
-                "name": "order",
-                "description": "Everything about your Pets"
-            },
-           'pet'
-        ])
-    ```
+class MyView(APIView):
+    schema = AutoSchema(tags=['tag1', 'tag2'])
+    ...
+```
 
 [openapi]: https://github.com/OAI/OpenAPI-Specification
 [openapi-specification-extensions]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#specification-extensions
 [openapi-operation]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#operationObject
+[openapi-tags]: https://swagger.io/specification/#tagObject

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -223,46 +223,32 @@ Tags can be used to group logical operations. Each tag name in the list MUST be 
 ---
 #### Django REST Framework generates tags automatically with the following logic:
 
-1. Extract tag from `ViewSet`. 
-    1. If `ViewSet` name ends with `ViewSet`, or `View`; remove it.
-    2. Convert class name into lowercase words & join each word using a `-`(dash). 
-    
-    Examples:
-    
-        ViewSet Class   |   Tags
-        ----------------|------------
-        User            |   ['user']	 
-        UserView        |   ['user']	 
-        UserViewSet     |   ['user']	
-        PascalCaseXYZ   |   ['pascal-case-xyz']
-        IPAddressView   |   ['ip-address']
-
-2. If View is not an instance of ViewSet, tag name will be first element from the path. Also, any `_` in path name will be replaced by a `-`.
+Tag name will be first element from the path. Also, any `_` in path name will be replaced by a `-`.
 Consider below examples.
 
-    Example 1: Consider a user management system. The following table will illustrate the tag generation logic.
-    Here first element from the paths is: `users`. Hence tag wil be `users`
+Example 1: Consider a user management system. The following table will illustrate the tag generation logic.
+Here first element from the paths is: `users`. Hence tag wil be `users`
 
-    Http Method                          |        Path       |     Tags
-    -------------------------------------|-------------------|-------------
-    PUT, PATCH, GET(Retrieve), DELETE    |     /users/{id}/  |   ['users']
-    POST, GET(List)                      |     /users/       |   ['users']
-    
-    Example 2: Consider a restaurant management system. The System has restaurants. Each restaurant has branches.
-    Consider REST APIs to deal with a branch of a particular restaurant.
-    Here first element from the paths is: `restaurants`. Hence tag wil be `restaurants`.
-    
-    Http Method                          |                         Path                       |     Tags
-    -------------------------------------|----------------------------------------------------|-------------------
-    PUT, PATCH, GET(Retrieve), DELETE:   | /restaurants/{restaurant_id}/branches/{branch_id}  |   ['restaurants']
-    POST, GET(List):                     | /restaurants/{restaurant_id}/branches/             |   ['restaurants']
-    
-    Example 3: Consider Order items for an e commerce company.
-    
-    Http Method                          |          Path           |     Tags
-    -------------------------------------|-------------------------|-------------
-    PUT, PATCH, GET(Retrieve), DELETE    |     /order_items/{id}/  |   ['order-items']
-    POST, GET(List)                      |     /order_items/       |   ['order-items']
+Http Method                          |        Path       |     Tags
+-------------------------------------|-------------------|-------------
+PUT, PATCH, GET(Retrieve), DELETE    |     /users/{id}/  |   ['users']
+POST, GET(List)                      |     /users/       |   ['users']
+
+Example 2: Consider a restaurant management system. The System has restaurants. Each restaurant has branches.
+Consider REST APIs to deal with a branch of a particular restaurant.
+Here first element from the paths is: `restaurants`. Hence tag wil be `restaurants`.
+
+Http Method                          |                         Path                       |     Tags
+-------------------------------------|----------------------------------------------------|-------------------
+PUT, PATCH, GET(Retrieve), DELETE:   | /restaurants/{restaurant_id}/branches/{branch_id}  |   ['restaurants']
+POST, GET(List):                     | /restaurants/{restaurant_id}/branches/             |   ['restaurants']
+
+Example 3: Consider Order items for an e commerce company.
+
+Http Method                          |          Path           |     Tags
+-------------------------------------|-------------------------|-------------
+PUT, PATCH, GET(Retrieve), DELETE    |     /order_items/{id}/  |   ['order-items']
+POST, GET(List)                      |     /order_items/       |   ['order-items']
    
 
 ---

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -218,35 +218,38 @@ project you may adjust `settings.DEFAULT_SCHEMA_CLASS`  appropriately.
 
 ### Grouping Operations With Tags
 
-Tags can be used for logical grouping `View`s. Each tag name in the list MUST be unique. 
+Tags can be used for logical grouping operations. Each tag name in the list MUST be unique. 
 
-**Django REST Framework generates tags automatically by the following logic:**
+---
+**Django REST Framework generates tags automatically with following logic:**
 1. Extract tag name from `ViewSet`. If `ViewSet` name ends with `ViewSet`, or `View`, it will be truncated from tag name.
 
-    ViewSet Class   |  Tag Name
+    ViewSet Class   |   Tags
     ----------------|------------
-    User	        |   user	 
-    UserView	    |   user	 
+    User            |   User	 
+    UserView        |   User	 
     UserViewSet     |   user	 
 
-2. If View is not an instance of ViewSet, generate tag name from the path. Consider the below table to understand more about path-based tag generation.
+2. If View is not an instance of ViewSet, tag name will be first element from the path. Consider below examples.
 
     Example 1: Consider a user management system. The following table will illustrate the tag generation logic.
+    Here first element from the paths is: `users`. Hence tag wil be `users`
 
     Http Method                          |        Path       |     Tags
     -------------------------------------|-------------------|-------------
-    PUT, PATCH, GET(Retrieve), DELETE:   |     /users/{id}/  |   [users]
-    POST, GET(List):                     |     /users/       |   [users]
+    PUT, PATCH, GET(Retrieve), DELETE    |     /users/{id}/  |   [users]
+    POST, GET(List)                      |     /users/       |   [users]
     
     Example 2: Consider a restaurant management system. The System has restaurants. Each restaurant has branches.
     Consider REST APIs to deal with a branch of a particular restaurant.
+    Here first element from the paths is: `restaurants`. Hence tag wil be `restaurants`.
     
     Http Method                          |                         Path                       |     Tags
     -------------------------------------|----------------------------------------------------|-------------------
     PUT, PATCH, GET(Retrieve), DELETE:   | /restaurants/{restaurant_id}/branches/{branch_id}  |   [restaurants]
     POST, GET(List):                     | /restaurants/{restaurant_id}/branches/             |   [restaurants]
 
-
+---
 **You can override auto-generated tags by passing a list of tags to each `View` by passing `tags` as an argument to the constructor of `AutoSchema`. `tags` argument can be:**
 1. list of string.
     ```python
@@ -258,9 +261,9 @@ Tags can be used for logical grouping `View`s. Each tag name in the list MUST be
 
     Field name   | Data type | Required | Description 
     -------------|-----------|----------|-------------------------------------------------------------------------
-    name	     |   string	 | yes      | The name of the tag.
-    description	 |   string  | no       | A short description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-    externalDocs |	  dict   | no       | Additional external documentation for this tag. [Click here](https://swagger.io/specification/#externalDocumentationObject) to know more.
+    name         |  string   |   yes    | The name of the tag.
+    description  |  string   |    no    | A short description for the tag. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+    externalDocs |  dict     |    no    | Additional external documentation for this tag. [Click here](https://swagger.io/specification/#externalDocumentationObject) to know more.
 
     Note: A tag dict with only `name` as a key is logically equivalent to passing a `string` as a tag.
 
@@ -285,7 +288,7 @@ Tags can be used for logical grouping `View`s. Each tag name in the list MUST be
             },
         ])
     ```
-3. list which is mix of string and strings.
+3. list which is mix of dicts and strings.
     ```python
     class MyView(APIView):
         ...

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -224,7 +224,7 @@ Tags can be used to group logical operations. Each tag name in the list MUST be 
 **Django REST Framework generates tags automatically with following logic:**
 1. Extract tag from `ViewSet`. 
     1. If `ViewSet` name ends with `ViewSet`, or `View`; remove it.
-    2. Convert class name into lowercase words & join each word with a space. 
+    2. Convert class name into lowercase words & join each word using a space. 
     
     Examples:
     
@@ -236,7 +236,7 @@ Tags can be used to group logical operations. Each tag name in the list MUST be 
         PascalCaseXYZ   |   ['pascal case xyz']
         IPAddressView   |   ['ip address']
 
-2. If View is not an instance of ViewSet, tag name will be first element from the path. Also, any `-` or `_` in path name will be converted as a space.
+2. If View is not an instance of ViewSet, tag name will be first element from the path. Also, any `-` or `_` in path name will be replaced by a space.
 Consider below examples.
 
     Example 1: Consider a user management system. The following table will illustrate the tag generation logic.

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -221,7 +221,7 @@ project you may adjust `settings.DEFAULT_SCHEMA_CLASS`  appropriately.
 Tags can be used to group logical operations. Each tag name in the list MUST be unique. 
 
 ---
-#### Django REST Framework generates tags automatically with following logic:
+#### Django REST Framework generates tags automatically with the following logic:
 
 1. Extract tag from `ViewSet`. 
     1. If `ViewSet` name ends with `ViewSet`, or `View`; remove it.
@@ -276,6 +276,32 @@ class MyView(APIView):
     schema = AutoSchema(tags=['tag1', 'tag2'])
     ...
 ```
+
+If you need more customization, you can override the `get_tags` method of `AutoSchema` class. Consider the following example:
+
+```python
+from rest_framework.schemas.openapi import AutoSchema
+from rest_framework.views import APIView
+
+class MySchema(AutoSchema):
+    ...
+    def get_tags(self, path, method):
+        if method == 'POST':
+            tags = ['tag1', 'tag2']
+        elif method == 'GET':
+            tags = ['tag2', 'tag3'] 
+        elif path == '/example/path/':
+            tags = ['tag3', 'tag4']
+        else:
+            tags = ['tag5', 'tag6', 'tag7']
+    
+        return tags
+
+class MyView(APIView):
+    schema = MySchema()
+    ...
+```
+
 
 [openapi]: https://github.com/OAI/OpenAPI-Specification
 [openapi-specification-extensions]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#specification-extensions

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -587,7 +587,7 @@ class AutoSchema(ViewInspector):
                 name = name[:-7]
             elif name.endswith('View'):
                 name = name[:-4]
-            return [camelcase_to_spaces(name).lower()]
+            return [camelcase_to_spaces(name).lower().replace(' ', '-')]
 
         # First element of a specific path could be valid tag. This is a fallback solution.
         # PUT, PATCH, GET(Retrieve), DELETE:        /users/{id}/       tags = [users]
@@ -595,4 +595,4 @@ class AutoSchema(ViewInspector):
         if path.startswith('/'):
             path = path[1:]
 
-        return [path.split('/')[0].translate(str.maketrans({'-': ' ', '_': ' '}))]
+        return [path.split('/')[0].replace('_', '-')]

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -590,12 +590,14 @@ class AutoSchema(ViewInspector):
             return self._tags
 
         # Extract tag from viewset name
-        # UserViewSet      tags = [User]
+        # UserView         tags = [User]
         # User             tags = [User]
         if hasattr(self.view, 'action'):
             name = self.view.__class__.__name__
-            if name.lower().endswith('viewset'):
-                name = name[:-7]  # remove trailing `viewset` from name
+            if name.endswith('APIView') or name.endswith('ViewSet'):
+                name = name[:-7]
+            elif name.endswith('View'):
+                name = name[:-4]
             return [name]
 
         # First element of a specific path could be valid tag. This is a fallback solution.

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -74,7 +74,7 @@ class AutoSchema(ViewInspector):
 
     def __init__(self, tags=None):
         if tags and not all(isinstance(tag, str) for tag in tags):
-            raise ValueError('tags must be a list of string.')
+            raise ValueError('tags must be a list or tuple of string.')
         self._tags = tags
         super().__init__()
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -579,8 +579,9 @@ class AutoSchema(ViewInspector):
             return self._tags
 
         # Extract tag from viewset name
-        # UserView         tags = [User]
-        # User             tags = [User]
+        # UserProfileViewSet      tags = [user-profile]
+        # UserProfileView         tags = [user-profile]
+        # UserProfile             tags = [user-profile]
         if hasattr(self.view, 'action'):
             name = self.view.__class__.__name__
             if name.endswith('ViewSet'):
@@ -590,8 +591,8 @@ class AutoSchema(ViewInspector):
             return [camelcase_to_spaces(name).lower().replace(' ', '-')]
 
         # First element of a specific path could be valid tag. This is a fallback solution.
-        # PUT, PATCH, GET(Retrieve), DELETE:        /users/{id}/       tags = [users]
-        # POST, GET(List):                          /users/            tags = [users]
+        # PUT, PATCH, GET(Retrieve), DELETE:        /user_profile/{id}/       tags = [user-profile]
+        # POST, GET(List):                          /user_profile/            tags = [user-profile]
         if path.startswith('/'):
             path = path[1:]
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -73,7 +73,6 @@ class SchemaGenerator(BaseSchemaGenerator):
 
         return schema
 
-
 # View Inspectors
 
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -105,7 +105,7 @@ class AutoSchema(ViewInspector):
         if request_body:
             operation['requestBody'] = request_body
         operation['responses'] = self._get_responses(path, method)
-        operation['tags'] = self._get_tags(path, method)
+        operation['tags'] = self.get_tags(path, method)
 
         return operation
 
@@ -573,7 +573,7 @@ class AutoSchema(ViewInspector):
             }
         }
 
-    def _get_tags(self, path, method):
+    def get_tags(self, path, method):
         # If user have specified tags, use them.
         if self._tags:
             return self._tags

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -593,7 +593,7 @@ class AutoSchema(ViewInspector):
         # User             tags = [User]
         if hasattr(self.view, 'action'):
             name = self.view.__class__.__name__
-            if name.endswith('APIView') or name.endswith('ViewSet'):
+            if name.endswith('ViewSet'):
                 name = name[:-7]
             elif name.endswith('View'):
                 name = name[:-4]

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -15,7 +15,6 @@ from rest_framework import exceptions, renderers, serializers
 from rest_framework.compat import uritemplate
 from rest_framework.fields import _UnvalidatedField, empty
 
-from ..utils.formatting import camelcase_to_spaces
 from .generators import BaseSchemaGenerator
 from .inspectors import ViewInspector
 from .utils import get_pk_description, is_list_view
@@ -577,18 +576,6 @@ class AutoSchema(ViewInspector):
         # If user have specified tags, use them.
         if self._tags:
             return self._tags
-
-        # Extract tag from viewset name
-        # UserProfileViewSet      tags = [user-profile]
-        # UserProfileView         tags = [user-profile]
-        # UserProfile             tags = [user-profile]
-        if hasattr(self.view, 'action'):
-            name = self.view.__class__.__name__
-            if name.endswith('ViewSet'):
-                name = name[:-7]
-            elif name.endswith('View'):
-                name = name[:-4]
-            return [camelcase_to_spaces(name).lower().replace(' ', '-')]
 
         # First element of a specific path could be valid tag. This is a fallback solution.
         # PUT, PATCH, GET(Retrieve), DELETE:        /user_profile/{id}/       tags = [user-profile]

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -15,6 +15,7 @@ from rest_framework import exceptions, renderers, serializers
 from rest_framework.compat import uritemplate
 from rest_framework.fields import _UnvalidatedField, empty
 
+from ..utils.formatting import camelcase_to_spaces
 from .generators import BaseSchemaGenerator
 from .inspectors import ViewInspector
 from .utils import get_pk_description, is_list_view
@@ -597,7 +598,7 @@ class AutoSchema(ViewInspector):
                 name = name[:-7]
             elif name.endswith('View'):
                 name = name[:-4]
-            return [name]
+            return [camelcase_to_spaces(name).lower()]
 
         # First element of a specific path could be valid tag. This is a fallback solution.
         # PUT, PATCH, GET(Retrieve), DELETE:        /users/{id}/       tags = [users]
@@ -605,4 +606,4 @@ class AutoSchema(ViewInspector):
         if path.startswith('/'):
             path = path[1:]
 
-        return [path.split('/')[0]]
+        return [path.split('/')[0].translate(str.maketrans({'-': ' ', '_': ' '}))]

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -698,7 +698,7 @@ class TestOperationIntrospection(TestCase):
         assert properties['ip']['type'] == 'string'
         assert 'format' not in properties['ip']
 
-    def test_overridden_string_tags(self):
+    def test_overridden_tags(self):
         class ExampleStringTagsViewSet(views.ExampleTagsViewSet):
             schema = AutoSchema(tags=['example1', 'example2'])
 
@@ -707,73 +707,6 @@ class TestOperationIntrospection(TestCase):
         generator = SchemaGenerator(patterns=router.urls)
         schema = generator.get_schema(request=create_request('/'))
         assert schema['paths']['/test/{id}/']['get']['tags'] == ['example1', 'example2']
-        assert schema['tags'] == []
-
-    def test_overridden_dict_tags(self):
-        class ExampleDictTagsViewSet(views.ExampleTagsViewSet):
-            schema = AutoSchema(tags=[
-                {
-                    "name": "user"
-                },
-                {
-                    "name": "pet",
-                    "description": "Everything about your Pets"
-                },
-                {
-                    "name": "store",
-                    "description": "Access to Petstore orders",
-                    "externalDocs": {
-                        "url": "https://example.com",
-                        "description": "Find more info here"
-                    }
-                },
-            ])
-
-        router = routers.SimpleRouter()
-        router.register('test', ExampleDictTagsViewSet, basename="test")
-        generator = SchemaGenerator(patterns=router.urls)
-        schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/test/{id}/']['get']['tags'] == ['user', 'pet', 'store']
-        assert schema['tags'] == [
-            {
-                "name": "user"
-            },
-            {
-                "name": "pet",
-                "description": "Everything about your Pets"
-            },
-            {
-                "name": "store",
-                "description": "Access to Petstore orders",
-                "externalDocs": {
-                    "url": "https://example.com",
-                    "description": "Find more info here"
-                }
-            },
-        ]
-
-    def test_mix_of_string_and_dict_tags(self):
-        class ExampleMixTagsViewSet(views.ExampleTagsViewSet):
-            schema = AutoSchema(tags=[
-                'user',
-                {
-                    "name": "order",
-                    "description": "Everything about your Pets"
-                },
-                'pet'
-            ])
-
-        router = routers.SimpleRouter()
-        router.register('test', ExampleMixTagsViewSet, basename="test")
-        generator = SchemaGenerator(patterns=router.urls)
-        schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/test/{id}/']['get']['tags'] == ['user', 'order', 'pet']
-        assert schema['tags'] == [
-            {
-                "name": "order",
-                "description": "Everything about your Pets"
-            }
-        ]
 
     def test_auto_generated_viewset_tags(self):
         class ExampleIPViewSet(views.ExampleTagsViewSet):
@@ -796,12 +729,10 @@ class TestOperationIntrospection(TestCase):
 
         generator = SchemaGenerator(patterns=router.urls)
         schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/test1/{id}/']['get']['tags'] == ['example ip']
-        assert schema['paths']['/test2/{id}/']['get']['tags'] == ['example xyz']
+        assert schema['paths']['/test1/{id}/']['get']['tags'] == ['example-ip']
+        assert schema['paths']['/test2/{id}/']['get']['tags'] == ['example-xyz']
         assert schema['paths']['/test3/{id}/']['get']['tags'] == ['example']
-        assert schema['paths']['/test4/{id}/']['get']['tags'] == ['pascal case xyz test ip']
-
-        assert schema['tags'] == []
+        assert schema['paths']['/test4/{id}/']['get']['tags'] == ['pascal-case-xyz-test-ip']
 
     def test_auto_generated_apiview_tags(self):
         class RestaurantAPIView(views.ExampleGenericAPIView):
@@ -816,9 +747,8 @@ class TestOperationIntrospection(TestCase):
         ]
         generator = SchemaGenerator(patterns=url_patterns)
         schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/any-dash_underscore/']['get']['tags'] == ['any dash underscore']
+        assert schema['paths']['/any-dash_underscore/']['get']['tags'] == ['any-dash-underscore']
         assert schema['paths']['/restaurants/branches/']['get']['tags'] == ['restaurants']
-        assert schema['tags'] == []
 
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -699,14 +699,15 @@ class TestOperationIntrospection(TestCase):
         assert 'format' not in properties['ip']
 
     def test_overridden_tags(self):
-        class ExampleStringTagsViewSet(views.ExampleTagsViewSet):
+        class ExampleStringTagsViewSet(views.ExampleGenericAPIView):
             schema = AutoSchema(tags=['example1', 'example2'])
 
-        router = routers.SimpleRouter()
-        router.register('test', ExampleStringTagsViewSet, basename="test")
-        generator = SchemaGenerator(patterns=router.urls)
+        url_patterns = [
+            url(r'^test/?$', ExampleStringTagsViewSet.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=url_patterns)
         schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/test/{id}/']['get']['tags'] == ['example1', 'example2']
+        assert schema['paths']['/test/']['get']['tags'] == ['example1', 'example2']
 
     def test_overridden_get_tags_method(self):
         class MySchema(AutoSchema):
@@ -729,32 +730,6 @@ class TestOperationIntrospection(TestCase):
         schema = generator.get_schema(request=create_request('/'))
         assert schema['paths']['/example/new/']['get']['tags'] == ['tag1', 'tag2']
         assert schema['paths']['/example/old/']['get']['tags'] == ['tag2', 'tag3']
-
-    def test_auto_generated_viewset_tags(self):
-        class ExampleIPViewSet(views.ExampleTagsViewSet):
-            pass
-
-        class ExampleXYZView(views.ExampleTagsViewSet):
-            pass
-
-        class Example(views.ExampleTagsViewSet):
-            pass
-
-        class PascalCaseXYZTestIp(views.ExampleTagsViewSet):
-            pass
-
-        router = routers.SimpleRouter()
-        router.register('test1', ExampleIPViewSet, basename="test1")
-        router.register('test2', ExampleXYZView, basename="test2")
-        router.register('test3', Example, basename="test3")
-        router.register('test4', PascalCaseXYZTestIp, basename="test4")
-
-        generator = SchemaGenerator(patterns=router.urls)
-        schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/test1/{id}/']['get']['tags'] == ['example-ip']
-        assert schema['paths']['/test2/{id}/']['get']['tags'] == ['example-xyz']
-        assert schema['paths']['/test3/{id}/']['get']['tags'] == ['example']
-        assert schema['paths']['/test4/{id}/']['get']['tags'] == ['pascal-case-xyz-test-ip']
 
     def test_auto_generated_apiview_tags(self):
         class RestaurantAPIView(views.ExampleGenericAPIView):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -776,25 +776,25 @@ class TestOperationIntrospection(TestCase):
         ]
 
     def test_auto_generated_viewset_tags(self):
-        class ExampleViewSet(views.ExampleTagsViewSet):
+        class ExampleIPViewSet(views.ExampleTagsViewSet):
             pass
 
-        class ExampleView(views.ExampleTagsViewSet):
+        class ExampleXYZView(views.ExampleTagsViewSet):
             pass
 
         class Example(views.ExampleTagsViewSet):
             pass
 
         router = routers.SimpleRouter()
-        router.register('test1', ExampleViewSet, basename="test")
-        router.register('test2', ExampleView, basename="test")
+        router.register('test1', ExampleIPViewSet, basename="test")
+        router.register('test2', ExampleXYZView, basename="test")
         router.register('test3', Example, basename="test")
 
         generator = SchemaGenerator(patterns=router.urls)
         schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/test1/{id}/']['get']['tags'] == ['Example']
-        assert schema['paths']['/test2/{id}/']['get']['tags'] == ['Example']
-        assert schema['paths']['/test3/{id}/']['get']['tags'] == ['Example']
+        assert schema['paths']['/test1/{id}/']['get']['tags'] == ['example ip']
+        assert schema['paths']['/test2/{id}/']['get']['tags'] == ['example xyz']
+        assert schema['paths']['/test3/{id}/']['get']['tags'] == ['example']
         assert schema['tags'] == []
 
     def test_auto_generated_apiview_tags(self):
@@ -805,12 +805,12 @@ class TestOperationIntrospection(TestCase):
             pass
 
         url_patterns = [
-            url(r'^restaurants/?$', RestaurantAPIView.as_view()),
+            url(r'^any-dash_underscore/?$', RestaurantAPIView.as_view()),
             url(r'^restaurants/branches/?$', BranchAPIView.as_view())
         ]
         generator = SchemaGenerator(patterns=url_patterns)
         schema = generator.get_schema(request=create_request('/'))
-        assert schema['paths']['/restaurants/']['get']['tags'] == ['restaurants']
+        assert schema['paths']['/any-dash_underscore/']['get']['tags'] == ['any dash underscore']
         assert schema['paths']['/restaurants/branches/']['get']['tags'] == ['restaurants']
         assert schema['tags'] == []
 

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -785,16 +785,22 @@ class TestOperationIntrospection(TestCase):
         class Example(views.ExampleTagsViewSet):
             pass
 
+        class PascalCaseXYZTestIp(views.ExampleTagsViewSet):
+            pass
+
         router = routers.SimpleRouter()
-        router.register('test1', ExampleIPViewSet, basename="test")
-        router.register('test2', ExampleXYZView, basename="test")
-        router.register('test3', Example, basename="test")
+        router.register('test1', ExampleIPViewSet, basename="test1")
+        router.register('test2', ExampleXYZView, basename="test2")
+        router.register('test3', Example, basename="test3")
+        router.register('test4', PascalCaseXYZTestIp, basename="test4")
 
         generator = SchemaGenerator(patterns=router.urls)
         schema = generator.get_schema(request=create_request('/'))
         assert schema['paths']['/test1/{id}/']['get']['tags'] == ['example ip']
         assert schema['paths']['/test2/{id}/']['get']['tags'] == ['example xyz']
         assert schema['paths']['/test3/{id}/']['get']['tags'] == ['example']
+        assert schema['paths']['/test4/{id}/']['get']['tags'] == ['pascal case xyz test ip']
+
         assert schema['tags'] == []
 
     def test_auto_generated_apiview_tags(self):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -126,6 +126,7 @@ class TestOperationIntrospection(TestCase):
             'operationId': 'listDocStringExamples',
             'description': 'A description of my GET operation.',
             'parameters': [],
+            'tags': ['example'],
             'responses': {
                 '200': {
                     'description': '',
@@ -166,6 +167,7 @@ class TestOperationIntrospection(TestCase):
                     'type': 'string',
                 },
             }],
+            'tags': ['example'],
             'responses': {
                 '200': {
                     'description': '',

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -137,3 +137,14 @@ class ExampleValidatedAPIView(generics.GenericAPIView):
                                          url='http://localhost', uuid=uuid.uuid4(), ip4='127.0.0.1', ip6='::1',
                                          ip='192.168.1.1')
         return Response(serializer.data)
+
+
+class ExampleTagsViewSet(GenericViewSet):
+    serializer_class = ExampleSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        serializer = self.get_serializer(integer=33, string='hello', regex='foo', decimal1=3.55,
+                                         decimal2=5.33, email='a@b.co',
+                                         url='http://localhost', uuid=uuid.uuid4(), ip4='127.0.0.1', ip6='::1',
+                                         ip='192.168.1.1')
+        return Response(serializer.data)

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -137,14 +137,3 @@ class ExampleValidatedAPIView(generics.GenericAPIView):
                                          url='http://localhost', uuid=uuid.uuid4(), ip4='127.0.0.1', ip6='::1',
                                          ip='192.168.1.1')
         return Response(serializer.data)
-
-
-class ExampleTagsViewSet(GenericViewSet):
-    serializer_class = ExampleSerializer
-
-    def retrieve(self, request, *args, **kwargs):
-        serializer = self.get_serializer(integer=33, string='hello', regex='foo', decimal1=3.55,
-                                         decimal2=5.33, email='a@b.co',
-                                         url='http://localhost', uuid=uuid.uuid4(), ip4='127.0.0.1', ip6='::1',
-                                         ip='192.168.1.1')
-        return Response(serializer.data)


### PR DESCRIPTION
This merge request adds logic to generate open API tags automatically. It also allows the user to override auto-generated tags as an argument to the constructor of `AutoSchema`. This solution will not break the encapsulation of schema generation. Inspiration: https://github.com/encode/django-rest-framework/issues/7103#issuecomment-582583173

There is another merge request(#7182) with a possible solution. You can merge whichever solution is the best. 

This Fixes: #7103 
This closes: #7104 & #7177 