### PR TITLE
Changed the user object get&set to the Request._request.user

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -218,6 +218,12 @@ class Request:
         if not hasattr(self, '_user'):
             with wrap_attributeerrors():
                 self._authenticate()
+
+            # if we have user from upstream middlewares / django auth - we would like to use it
+            if hasattr(self._request, 'user'):
+                if hasattr(self._request.user, 'is_authenticated') and self._request.user.is_authenticated:
+                    self._user = self._request.user
+
         return self._user
 
     @user.setter


### PR DESCRIPTION
Currently we are **setting** the user object in both django's WSGIRequest and in the Request object, but not **getting** it from the `self._request.user` which causes issues when I am trying to add an authentication middleware

in the PR I've added the `self._user = self._request.user` if `self._request.user` exists and authenticated - otherwise leaving it as is