### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -122,7 +122,7 @@ on a per-view basis.
 
 ### Schema Level Customization
 
-In order to customize the top-level schema sublass
+In order to customize the top-level schema subclass
 `rest_framework.schemas.openapi.SchemaGenerator` and provide it as an argument
 to the `generateschema` command or `get_schema_view()` helper function.
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

I think there is a typo in `docs/api-guide/schemas.md`.
I propose to change `sublass` to `subclass`.
