### PR TITLE
Openapi custom operation name

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -300,10 +300,27 @@ from rest_framework.schemas.openapi import AutoSchema
 
 class ExampleView(APIView):
     """APIView subclass with custom schema introspection."""
-    schema = AutoSchema(operation_name="Custom")
+    schema = AutoSchema(operation_id_base="Custom")
 ```
 
 The previous example will generate the following operationid: "ListCustoms", "RetrieveCustom", "UpdateCustom", "PartialUpdateCustom", "DestroyCustom".
+
+You need to provide the singular form of he operation name. For the list operation, a "s" will be append at the end of the name.
+
+If you need more configuration over the `operationId` field, you can override the `get_operation_id_base` and `get_operation_id` methods from the `AutoSchema` class.
+
+```python
+class CustomSchema(AutoSchema):
+    def get_operation_id_base(self, action):
+        pass
+
+    def get_operation_id(self, path, method):
+        pass
+
+class CustomView(APIView):
+    """APIView subclass with custom schema introspection."""
+    schema = CustomSchema()
+```
 
 [openapi]: https://github.com/OAI/OpenAPI-Specification
 [openapi-specification-extensions]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#specification-extensions

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -288,8 +288,25 @@ class MyView(APIView):
     ...
 ```
 
+### OperationId
+
+The schema generator generates an [operationid](openapi-operationid) for each operation. This `operationId` is deduced from the model name, serializer name or view name. The operationId may looks like "ListItems", "RetrieveItem", "UpdateItem", etc..
+
+If you have several views with the same model, the generator may generate duplicate operationId.
+In order to work around this, you can override the second part of the operationId: operation name.
+
+```python
+from rest_framework.schemas.openapi import AutoSchema
+
+class ExampleView(APIView):
+    """APIView subclass with custom schema introspection."""
+    schema = AutoSchema(operation_name="Custom")
+```
+
+The previous example will generate the following operationid: "ListCustoms", "RetrieveCustom", "UpdateCustom", "PartialUpdateCustom", `DestroyCustom`.
 
 [openapi]: https://github.com/OAI/OpenAPI-Specification
 [openapi-specification-extensions]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#specification-extensions
 [openapi-operation]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#operationObject
 [openapi-tags]: https://swagger.io/specification/#tagObject
+[openapi-operationid]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields-17

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -310,7 +310,7 @@ If you need more configuration over the `operationId` field, you can override th
 
 ```python
 class CustomSchema(AutoSchema):
-    def get_operation_id_base(self, action):
+    def get_operation_id_base(self, path, method, action):
         pass
 
     def get_operation_id(self, path, method):

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -303,11 +303,10 @@ class ExampleView(APIView):
     schema = AutoSchema(operation_id_base="Custom")
 ```
 
-The previous example will generate the following operationid: "ListCustoms", "RetrieveCustom", "UpdateCustom", "PartialUpdateCustom", "DestroyCustom".
+The previous example will generate the following operationId: "ListCustoms", "RetrieveCustom", "UpdateCustom", "PartialUpdateCustom", "DestroyCustom".
+You need to provide the singular form of he operation name. For the list operation, a "s" will be appended at the end of the operation.
 
-You need to provide the singular form of he operation name. For the list operation, a "s" will be append at the end of the name.
-
-If you need more configuration over the `operationId` field, you can override the `get_operation_id_base` and `get_operation_id` methods from the `AutoSchema` class.
+If you need more configuration over the `operationId` field, you can override the `get_operation_id_base` and `get_operation_id` methods from the `AutoSchema` class:
 
 ```python
 class CustomSchema(AutoSchema):

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -303,7 +303,7 @@ class ExampleView(APIView):
     schema = AutoSchema(operation_name="Custom")
 ```
 
-The previous example will generate the following operationid: "ListCustoms", "RetrieveCustom", "UpdateCustom", "PartialUpdateCustom", `DestroyCustom`.
+The previous example will generate the following operationid: "ListCustoms", "RetrieveCustom", "UpdateCustom", "PartialUpdateCustom", "DestroyCustom".
 
 [openapi]: https://github.com/OAI/OpenAPI-Specification
 [openapi-specification-extensions]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#specification-extensions

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -71,10 +71,14 @@ class SchemaGenerator(BaseSchemaGenerator):
 
 class AutoSchema(ViewInspector):
 
-    def __init__(self, tags=None):
+    def __init__(self, operation_id_base=None, tags=None):
+        """
+        :param operation_id_base: user-defined name in operationId. If empty, it will be deducted from the Model/Serializer/View name.
+        """
         if tags and not all(isinstance(tag, str) for tag in tags):
             raise ValueError('tags must be a list or tuple of string.')
         self._tags = tags
+        self.operation_id_base = operation_id_base
         super().__init__()
 
     request_media_types = []
@@ -87,13 +91,6 @@ class AutoSchema(ViewInspector):
         'patch': 'PartialUpdate',
         'delete': 'Destroy',
     }
-
-    def __init__(self, operation_id_base=None):
-        """
-        :param operation_id_base: user-defined name in operationId. If empty, it will be deducted from the Model/Serializer/View name.
-        """
-        super().__init__()
-        self.operation_id_base = operation_id_base
 
     def get_operation(self, path, method):
         operation = {}

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -88,6 +88,13 @@ class AutoSchema(ViewInspector):
         'delete': 'Destroy',
     }
 
+    def __init__(self, operation_name=None):
+        """
+        :param operation_name: user-defined name in operationId. If empty, it will be deducted from the Model/Serializer/View name.
+        """
+        super().__init__()
+        self.operation_name = operation_name
+
     def get_operation(self, path, method):
         operation = {}
 
@@ -120,9 +127,13 @@ class AutoSchema(ViewInspector):
         else:
             action = self.method_mapping[method.lower()]
 
-        # Try to deduce the ID from the view's model
         model = getattr(getattr(self.view, 'queryset', None), 'model', None)
-        if model is not None:
+
+        if self.operation_name is not None:
+            name = self.operation_name
+
+        # Try to deduce the ID from the view's model
+        elif model is not None:
             name = model.__name__
 
         # Try with the serializer class name

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -115,7 +115,7 @@ class AutoSchema(ViewInspector):
 
         return operation
 
-    def get_operation_id_base(self, action):
+    def get_operation_id_base(self, path, method, action):
         """
         Compute the base part for operation ID from the model, serializer or view name.
         """
@@ -164,7 +164,7 @@ class AutoSchema(ViewInspector):
         else:
             action = self.method_mapping[method.lower()]
 
-        name = self.get_operation_id_base(action)
+        name = self.get_operation_id_base(path, method, action)
 
         return action + name
 

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -574,8 +574,23 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        operationId = inspector._get_operation_id(path, method)
+        operationId = inspector.get_operation_id(path, method)
         assert operationId == 'listExamples'
+
+    def test_operation_id_custom_operation_id_base(self):
+        path = '/'
+        method = 'GET'
+
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema(operation_id_base="Ulysse")
+        inspector.view = view
+
+        operationId = inspector.get_operation_id(path, method)
+        assert operationId == 'listUlysses'
 
     def test_operation_id_custom_name(self):
         path = '/'
@@ -586,11 +601,47 @@ class TestOperationIntrospection(TestCase):
             method,
             create_request(path),
         )
-        inspector = AutoSchema(operation_name="Ulysse")
+        inspector = AutoSchema(operation_id_base='Ulysse')
         inspector.view = view
 
-        operationId = inspector._get_operation_id(path, method)
+        operationId = inspector.get_operation_id(path, method)
         assert operationId == 'listUlysses'
+
+    def test_operation_id_override_get(self):
+        class CustomSchema(AutoSchema):
+            def get_operation_id(self, path, method):
+                return 'myCustomOperationId'
+
+        path = '/'
+        method = 'GET'
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = CustomSchema()
+        inspector.view = view
+
+        operationId = inspector.get_operation_id(path, method)
+        assert operationId == 'myCustomOperationId'
+
+    def test_operation_id_override_base(self):
+        class CustomSchema(AutoSchema):
+            def get_operation_id_base(self, action):
+                return 'Item'
+
+        path = '/'
+        method = 'GET'
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = CustomSchema()
+        inspector.view = view
+
+        operationId = inspector.get_operation_id(path, method)
+        assert operationId == 'listItem'
 
     def test_repeat_operation_ids(self):
         router = routers.SimpleRouter()

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -577,6 +577,21 @@ class TestOperationIntrospection(TestCase):
         operationId = inspector._get_operation_id(path, method)
         assert operationId == 'listExamples'
 
+    def test_operation_id_custom_name(self):
+        path = '/'
+        method = 'GET'
+
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema(operation_name="Ulysse")
+        inspector.view = view
+
+        operationId = inspector._get_operation_id(path, method)
+        assert operationId == 'listUlysses'
+
     def test_repeat_operation_ids(self):
         router = routers.SimpleRouter()
         router.register('account', views.ExampleGenericViewSet, basename="account")

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -627,7 +627,7 @@ class TestOperationIntrospection(TestCase):
 
     def test_operation_id_override_base(self):
         class CustomSchema(AutoSchema):
-            def get_operation_id_base(self, action):
+            def get_operation_id_base(self, path, method, action):
                 return 'Item'
 
         path = '/'


### PR DESCRIPTION
This PR allow the user to customize the operationId's name.
It fixes the subtask " Allow setting a custom operation ID on views with an attribute?" defined here https://github.com/encode/django-rest-framework/pull/6549

Thanks !