### PR TITLE
decode base64 credentials as utf8; adjust tests

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -74,7 +74,7 @@ class BasicAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed(msg)
 
         try:
-            auth_parts = base64.b64decode(auth[1]).decode(HTTP_HEADER_ENCODING).partition(':')
+            auth_parts = base64.b64decode(auth[1]).decode('utf-8').partition(':')
         except (TypeError, UnicodeDecodeError, binascii.Error):
             msg = _('Invalid basic header. Credentials not correctly base64 encoded.')
             raise exceptions.AuthenticationFailed(msg)

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -74,7 +74,11 @@ class BasicAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed(msg)
 
         try:
-            auth_parts = base64.b64decode(auth[1]).decode('utf-8').partition(':')
+            try:
+                auth_decoded = base64.b64decode(auth[1]).decode('utf-8')
+            except UnicodeDecodeError:
+                auth_decoded = base64.b64decode(auth[1]).decode('latin-1')
+            auth_parts = auth_decoded.partition(':')
         except (TypeError, UnicodeDecodeError, binascii.Error):
             msg = _('Invalid basic header. Credentials not correctly base64 encoded.')
             raise exceptions.AuthenticationFailed(msg)

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -85,7 +85,7 @@ class BasicAuthTests(TestCase):
         self.csrf_client = APIClient(enforce_csrf_checks=True)
         self.username = 'john'
         self.email = 'lennon@thebeatles.com'
-        self.password = 'password'
+        self.password = 'pässwörd'
         self.user = User.objects.create_user(
             self.username, self.email, self.password
         )
@@ -94,7 +94,7 @@ class BasicAuthTests(TestCase):
         """Ensure POSTing json over basic auth with correct credentials passes and does not require CSRF"""
         credentials = ('%s:%s' % (self.username, self.password))
         base64_credentials = base64.b64encode(
-            credentials.encode(HTTP_HEADER_ENCODING)
+            credentials.encode('utf-8')
         ).decode(HTTP_HEADER_ENCODING)
         auth = 'Basic %s' % base64_credentials
         response = self.csrf_client.post(
@@ -108,7 +108,7 @@ class BasicAuthTests(TestCase):
         """Ensure POSTing form over basic auth with correct credentials passes and does not require CSRF"""
         credentials = ('%s:%s' % (self.username, self.password))
         base64_credentials = base64.b64encode(
-            credentials.encode(HTTP_HEADER_ENCODING)
+            credentials.encode('utf-8')
         ).decode(HTTP_HEADER_ENCODING)
         auth = 'Basic %s' % base64_credentials
         response = self.csrf_client.post(


### PR DESCRIPTION
This PR concerns issue https://github.com/encode/django-rest-framework/issues/7183 and makes `BasicAuthentication` auth backend decode the base64-encoded credentials with utf-8.