### PR TITLE
Do not treat empty payload as empty dict

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -334,7 +334,7 @@ class Request:
             if media_type and is_form_media_type(media_type):
                 empty_data = QueryDict('', encoding=self._request._encoding)
             else:
-                empty_data = {}
+                empty_data = None
             empty_files = MultiValueDict()
             return (empty_data, empty_files)
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -56,14 +56,14 @@ class TestContentParsing(TestCase):
         Ensure request.data returns empty QueryDict for GET request.
         """
         request = Request(factory.get('/'))
-        assert request.data == {}
+        assert request.data is None
 
     def test_standard_behaviour_determines_no_content_HEAD(self):
         """
         Ensure request.data returns empty QueryDict for HEAD request.
         """
         request = Request(factory.head('/'))
-        assert request.data == {}
+        assert request.data is None
 
     def test_request_DATA_with_form_content(self):
         """

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.shortcuts import redirect
 from django.test import TestCase, override_settings
 
-from rest_framework import fields, serializers
+from rest_framework import serializers
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.test import (
@@ -35,13 +35,10 @@ def redirect_view(request):
     return redirect('/view/')
 
 
-class BasicSerializer(serializers.Serializer):
-    flag = fields.BooleanField(default=lambda: True)
-
-
 @api_view(['POST'])
 def post_view(request):
-    serializer = BasicSerializer(data=request.data)
+    serializer = serializers.Serializer(data=request.data)
+    serializer.allow_null = True
     serializer.is_valid(raise_exception=True)
     return Response(serializer.validated_data)
 
@@ -198,7 +195,7 @@ class TestAPITestClient(TestCase):
             content_type='application/json'
         )
         assert response.status_code == 200
-        assert response.data == {"flag": True}
+        assert response.data is None
 
 
 class TestAPIRequestFactory(TestCase):


### PR DESCRIPTION
This allows views to distinguish missing payload from empty payload.

Related: #3647, #4566

## Description

Previously, empty non-form payload caused `request.data` to equal `{}`. Note that the choice of `{}` is arbitrary, and while it may appear appropriate for views that use a regular `Serializer`, it does cause issues for views that use a `ListSerializer`. For list endpoints, `[]` clearly would have been the less arbitrary choice (but also cause other problems, cf. #3647).

The problem becomes more obscure with a list endpoint that may accept lists of objects, or single objects. In this case, the serializer's `many` argument has to be set to `False` if and only if an object was given, and to `True` if and only if a list was given. If the client does not pass any payload in such a scenario, the request will be treated as if the user had passed an empty dictionary. This is *simply not correct*.

This PR changes the behavior such that empty non-form payload will cause `request.data` to be `None`. This allows views to distinguish between missing payload and a non-`None` but empty payload data structure.

In #4566, @tomchristie argued that it would be an option to
> Use the `None` sentinel for non-form data. (but don't want to go that way because it'd play less well with Django's existing behavior, and could easily break existing codebases)

While this change may break existing code bases, the current situation makes life hard for all who need to distinguish empty payload from missing payload. In particular, changing the behavior in a DRF-based application currently requires overwriting into `APIView.initialize_request()`, and doing some magic there based on whether `request.stream is None` or not (repeating the logic that is given in `Request._parse()`, with the danger of missing the `RawPostDataException` exception or other edge cases). This situation is error-prone and smells like future maintenance work within the application.

On the other hand, with the proposed change applied, users can simply fix their code bases by replacing instances of e.g. `serializers.Serializer(data=request.data)` with `serializers.Serializer(data=request.data or {})` to recover the old behavior. (The reverse approach which has been taken so far is much more complicated, as the information about missing payload is lost at the point when the request has been dispatched for processing in a view.)

So, despite of the small backwards incompatibility, but in light of the simplicity of a corresponding fix, I propose to take the risk (and maybe announce in the next major release that the change will be upcoming in the next-to-next, or something like that).

Note that this does not cause the problem described in #3647 to resurface: The problem there was that empty content caused a side-effect and a success response, while the user expected a "Bad Request" response. With the proposed fix, this expectation will remain fulfilled.

Lastly, if people need empty payload to be accepted, one can set `allow_null = True` on the serializer. Without the proposed fix, the `allow_null` property is meaningless on the serializer used by the view (although the attribute does exist by virtue of the serializers being `Field`s, and is documented in general terms). In this regard, the proposed fix removes ambiguity and increases flexibility.