### PR TITLE
Fix docs 404

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -137,12 +137,12 @@ Finally, we're including default login and logout views for use with the browsab
 
 ## Pagination
 Pagination allows you to control how many objects per page are returned. To enable it add the following lines to `tutorial/settings.py`
-    
+
     REST_FRAMEWORK = {
         'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
         'PAGE_SIZE': 10
     }
-    
+
 ## Settings
 
 Add `'rest_framework'` to `INSTALLED_APPS`. The settings module will be in `tutorial/settings.py`
@@ -224,5 +224,5 @@ If you want to get a more in depth understanding of how REST framework fits toge
 
 [image]: ../img/quickstart.png
 [tutorial]: 1-serialization.md
-[guide]: ../#api-guide
+[guide]: ../api-guide/requests.md
 [httpie]: https://github.com/jakubroztocil/httpie#installation

--- a/docs_theme/404.html
+++ b/docs_theme/404.html
@@ -4,6 +4,6 @@
 
   <h1 id="404-page-not-found" style="text-align: center">404</h1>
   <p style="text-align: center"><strong>Page not found</strong></p>
-  <p style="text-align: center">Try the <a href="{{ site_url }}">homepage</a>, or <a href="#searchModal" data-toggle="modal">search the documentation</a>.</p>
+  <p style="text-align: center">Try the <a href="{{ site_url }}">homepage</a>, or <a href="#mkdocs_search_modal" data-toggle="modal">search the documentation</a>.</p>
 
 {% endblock %}

--- a/docs_theme/404.html
+++ b/docs_theme/404.html
@@ -4,6 +4,6 @@
 
   <h1 id="404-page-not-found" style="text-align: center">404</h1>
   <p style="text-align: center"><strong>Page not found</strong></p>
-  <p style="text-align: center">Try the <a href="{{ site_url }}">homepage</a>, or <a href="#mkdocs_search_modal" data-toggle="modal">search the documentation</a>.</p>
+  <p style="text-align: center">Try the <a href="{{ base_url }}">homepage</a>, or <a href="#mkdocs_search_modal" data-toggle="modal">search the documentation</a>.</p>
 
 {% endblock %}

--- a/docs_theme/404.html
+++ b/docs_theme/404.html
@@ -4,6 +4,6 @@
 
   <h1 id="404-page-not-found" style="text-align: center">404</h1>
   <p style="text-align: center"><strong>Page not found</strong></p>
-  <p style="text-align: center">Try the <a href="https://www.django-rest-framework.org/">homepage</a>, or <a href="#searchModal" data-toggle="modal">search the documentation</a>.</p>
+  <p style="text-align: center">Try the <a href="{{ site_url }}">homepage</a>, or <a href="#searchModal" data-toggle="modal">search the documentation</a>.</p>
 
 {% endblock %}

--- a/docs_theme/main.html
+++ b/docs_theme/main.html
@@ -5,17 +5,17 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta charset="utf-8">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
-  <link href="{{ base_url }}/img/favicon.ico" rel="icon" type="image/x-icon">
+  <link href="{{ 'img/favicon.ico'|url }}" rel="icon" type="image/x-icon">
   <link rel="canonical" href="{{ page.canonical_url|url }}" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Django, API, REST{% if page %}, {{ page.title }}{% endif %}">
   <meta name="author" content="Tom Christie">
 
   <!-- Le styles -->
-  <link href="{{ base_url }}/css/prettify.css" rel="stylesheet">
-  <link href="{{ base_url }}/css/bootstrap.css" rel="stylesheet">
-  <link href="{{ base_url }}/css/bootstrap-responsive.css" rel="stylesheet">
-  <link href="{{ base_url }}/css/default.css" rel="stylesheet">
+  <link href="{{ 'css/prettify.css'|url }}" rel="stylesheet">
+  <link href="{{ 'css/bootstrap.css'|url }}" rel="stylesheet">
+  <link href="{{ 'css/bootstrap-responsive.css'|url }}" rel="stylesheet">
+  <link href="{{ 'css/default.css'|url }}" rel="stylesheet">
 
   <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
   <!--[if lt IE 9]>
@@ -139,10 +139,10 @@
   ================================================== -->
   <!-- Placed at the end of the document so the pages load faster -->
   <script async src="https://fund.django-rest-framework.org/sidebar_include.js"></script>
-  <script src="{{ base_url }}/js/jquery-1.8.1-min.js"></script>
-  <script src="{{ base_url }}/js/prettify-1.0.js"></script>
-  <script src="{{ base_url }}/js/bootstrap-2.1.1-min.js"></script>
-  <script src="{{ base_url }}/js/theme.js"></script>
+  <script src="{{ 'js/jquery-1.8.1-min.js'|url }}"></script>
+  <script src="{{ 'js/prettify-1.0.js'|url }}"></script>
+  <script src="{{ 'js/bootstrap-2.1.1-min.js'|url }}"></script>
+  <script src="{{ 'js/theme.js'|url }}"></script>
 
   <script>var base_url = '{{ base_url }}';</script>
   {% for path in config.extra_javascript %}

--- a/docs_theme/main.html
+++ b/docs_theme/main.html
@@ -102,7 +102,7 @@
                 {% endfor %}
 
                   <div class="promo">
-                    <hr/>
+                    {% if page.toc %}<hr/>{% endif %}
                     <div id="sidebarInclude">
                   </div>
               </ul>


### PR DESCRIPTION
This fixes #7180 by linking to a valid API guide doc, but it also generally fixes our 404 styling. See individual commits for details.

The issue with the template is that the `base_url` for the 404 pages was `/`, so the templated URLs were like `//foo.css` instead of `/foo.css`. We could just remove the extra slash, but it's more correct to use the `url` template filter.

Update 404 page now looks like:
<img width="1170" alt="Screen Shot 2020-02-19 at 6 00 11 PM" src="https://user-images.githubusercontent.com/2370209/74893810-15635600-5342-11ea-9cd3-c1bf872cca95.png">
