### PR TITLE
Fix invalid function call syntax in example

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -382,8 +382,8 @@ This manager class now more nicely encapsulates that user instances and profile 
     def create(self, validated_data):
         return User.objects.create(
             username=validated_data['username'],
-            email=validated_data['email']
-            is_premium_member=validated_data['profile']['is_premium_member']
+            email=validated_data['email'],
+            is_premium_member=validated_data['profile']['is_premium_member'],
             has_support_contract=validated_data['profile']['has_support_contract']
         )
 


### PR DESCRIPTION
## Description

The [serializers docs](https://www.django-rest-framework.org/api-guide/serializers/#handling-saving-related-instances-in-model-manager-classes) have an example of calling a custom model manager, but the call to `create()` is invalid Python. This PR adds commas between the args/kwargs so it becomes a valid function call.

