### PR TITLE
Fix: use 201 status code for POST requests.

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -558,9 +558,9 @@ class AutoSchema(ViewInspector):
                 response_schema = paginator.get_paginated_response_schema(response_schema)
         else:
             response_schema = item_schema
-
+        status_code = '201' if method == 'POST' else '200'
         return {
-            '200': {
+            status_code: {
                 'content': {
                     ct: {'schema': response_schema}
                     for ct in self.response_media_types

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -275,9 +275,10 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         responses = inspector._get_responses(path, method)
-        assert responses['200']['content']['application/json']['schema']['required'] == ['text']
-        assert list(responses['200']['content']['application/json']['schema']['properties'].keys()) == ['text']
-        assert 'description' in responses['200']
+        assert '201' in responses
+        assert responses['201']['content']['application/json']['schema']['required'] == ['text']
+        assert list(responses['201']['content']['application/json']['schema']['properties'].keys()) == ['text']
+        assert 'description' in responses['201']
 
     def test_response_body_nested_serializer(self):
         path = '/'
@@ -302,7 +303,7 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         responses = inspector._get_responses(path, method)
-        schema = responses['200']['content']['application/json']['schema']
+        schema = responses['201']['content']['application/json']['schema']
         assert sorted(schema['required']) == ['nested', 'text']
         assert sorted(list(schema['properties'].keys())) == ['nested', 'text']
         assert schema['properties']['nested']['type'] == 'object'


### PR DESCRIPTION
## Description

Related to: https://github.com/encode/django-rest-framework/issues/7205
Fixes only 201 status code for POST request.
I've added additional asset to check if status code 201 available in responses for POST action.

I will try to fix all issues with openapi because I really need this in my project.
