### PR TITLE
fix(obtain_auth_token): Fix openapi schema generation

### DIFF
--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -5,11 +5,19 @@ from rest_framework import serializers
 
 
 class AuthTokenSerializer(serializers.Serializer):
-    username = serializers.CharField(label=_("Username"))
+    username = serializers.CharField(
+        label=_("Username"),
+        write_only=True
+    )
     password = serializers.CharField(
         label=_("Password"),
         style={'input_type': 'password'},
-        trim_whitespace=False
+        trim_whitespace=False,
+        write_only=True
+    )
+    token = serializers.CharField(
+        label=_("Token"),
+        read_only=True
     )
 
     def validate(self, attrs):


### PR DESCRIPTION
This PR fixes the AutoSchema generation for the `obtain_auth_token` view.

Here is the invalid (partial) OpenAPI schema currently generated.
```yaml
  /api-token-auth/:
    post:
      operationId: CreateObtainAuthToken
      description: ''
      parameters: []
      requestBody:
        content:
          application/x-www-form-urlencoded:
            schema: &id029 {}
          multipart/form-data:
            schema: *id029
          application/json:
            schema: *id029
      responses:
        '200':
          content:
            application/json:
              schema: {}
          description: ''
```

As you can see the requestBody's schema and response's schema are empty.
This is because:
- The `ObtainAuthToken` class inherit from `rest_framework.views.APIView` which do not have a `get_serializer` method (this is what is used by the `rest_framework.schemas.openapi.AutoSchema` class to get the serializer).
- The `AuthTokenSerializer` did not had the token field.

With this PR, the generated schema is 
```yaml
  /api-token-auth/:
    post:
      operationId: CreateObtainAuthToken
      description: ''
      parameters: []
      requestBody:
        content:
          application/x-www-form-urlencoded:
            schema: &id029
              type: object
              properties:
                username:
                  type: string
                  writeOnly: true
                password:
                  type: string
                  writeOnly: true
                required:
                  - username
                  - password
          multipart/form-data:
            schema: *id029
          application/json:
            schema: *id029
      responses:
        '200':
          content:
            application/json:
              schema:
                type: object
                properties:
                  token:
                    type: string
                    readOnly: true
                required: []
          description: ''
```

NB: In the `ObtainAuthToken` class, the schema field (`ManualSchema` , for `coreapi` only) was override when the `coreapi` dependency was installed.
Instead of checking the installed dependency, I replaced the check with `coreapi_schema.is_enabled`.
This change enables us to run the test script (where `coreapi` is installed) with the AutoSchema, unless `coreapi` is explicitly configured.