### PR TITLE
Extra action detection is too permissive. Add failing test + fix

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -25,11 +25,12 @@ from django.utils.decorators import classonlymethod
 from django.views.decorators.csrf import csrf_exempt
 
 from rest_framework import generics, mixins, views
+from rest_framework.decorators import MethodMapper
 from rest_framework.reverse import reverse
 
 
 def _is_extra_action(attr):
-    return hasattr(attr, 'mapping')
+    return hasattr(attr, 'mapping') and isinstance(attr.mapping, MethodMapper)
 
 
 class ViewSetMixin:

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -81,10 +81,21 @@ class ActionNamesViewSet(GenericViewSet):
         raise NotImplementedError
 
 
+class ThingWithMapping:
+    def __init__(self):
+        self.mapping = {}
+
+
+class ActionViewSetWithMapping(ActionViewSet):
+    mapper = ThingWithMapping()
+
+
+
 router = SimpleRouter()
 router.register(r'actions', ActionViewSet)
 router.register(r'actions-alt', ActionViewSet, basename='actions-alt')
 router.register(r'names', ActionNamesViewSet, basename='names')
+router.register(r'mapping', ActionViewSetWithMapping, basename='mapping')
 
 
 urlpatterns = [
@@ -144,16 +155,6 @@ class InitializeViewSetsTestCase(TestCase):
         for attribute in ('args', 'kwargs', 'request', 'action_map'):
             self.assertNotIn(attribute, dir(bare_view))
             self.assertIn(attribute, dir(view))
-
-
-class ThingWithMapping:
-    def __init__(self):
-        self.mapping = {}
-
-
-class ActionViewSetWithMapping(ActionViewSet):
-    mapper = ThingWithMapping()
-
 
 class GetExtraActionsTests(TestCase):
 

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -90,7 +90,6 @@ class ActionViewSetWithMapping(ActionViewSet):
     mapper = ThingWithMapping()
 
 
-
 router = SimpleRouter()
 router.register(r'actions', ActionViewSet)
 router.register(r'actions-alt', ActionViewSet, basename='actions-alt')
@@ -155,6 +154,7 @@ class InitializeViewSetsTestCase(TestCase):
         for attribute in ('args', 'kwargs', 'request', 'action_map'):
             self.assertNotIn(attribute, dir(bare_view))
             self.assertIn(attribute, dir(view))
+
 
 class GetExtraActionsTests(TestCase):
 

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -146,6 +146,15 @@ class InitializeViewSetsTestCase(TestCase):
             self.assertIn(attribute, dir(view))
 
 
+class ThingWithMapping:
+    def __init__(self):
+        self.mapping = {}
+
+
+class ActionViewSetWithMapping(ActionViewSet):
+    mapper = ThingWithMapping()
+
+
 class GetExtraActionsTests(TestCase):
 
     def test_extra_actions(self):
@@ -159,6 +168,18 @@ class GetExtraActionsTests(TestCase):
             'unresolvable_detail_action',
         ]
 
+        self.assertEqual(actual, expected)
+
+    def test_should_only_return_decorated_methods(self):
+        view = ActionViewSetWithMapping()
+        actual = [action.__name__ for action in view.get_extra_actions()]
+        expected = [
+            'custom_detail_action',
+            'custom_list_action',
+            'detail_action',
+            'list_action',
+            'unresolvable_detail_action',
+        ]
         self.assertEqual(actual, expected)
 
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Fixes #7216

This adds a failing test to demonstrate the inspection of a viewset to find its actions is too permissive.
The same can be achieved with mocked objects because unfortunately `hasattr(MagicMock(), 'mapping') is always true.
