### PR TITLE
Added support for TimescaleDB primary keys

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -219,7 +219,7 @@ class SimpleRouter(BaseRouter):
         # consume `.json` style suffixes and should break at '/' boundaries.
         lookup_field = getattr(viewset, 'lookup_field', 'pk')
         lookup_url_kwarg = getattr(viewset, 'lookup_url_kwarg', None) or lookup_field
-        lookup_value = getattr(viewset, 'lookup_value_regex', '[^/.]+')
+        lookup_value = getattr(viewset, 'lookup_value_regex', '[^/]+')
         return base_regex.format(
             lookup_prefix=lookup_prefix,
             lookup_url_kwarg=lookup_url_kwarg,

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -271,7 +271,7 @@ class TestTrailingSlashIncluded(TestCase):
         self.urls = self.router.urls
 
     def test_urls_have_trailing_slash_by_default(self):
-        expected = ['^notes/$', '^notes/(?P<pk>[^/.]+)/$']
+        expected = ['^notes/$', '^notes/(?P<pk>[^/]+)/$']
         for idx in range(len(expected)):
             assert expected[idx] == get_regex_pattern(self.urls[idx])
 
@@ -286,7 +286,7 @@ class TestTrailingSlashRemoved(TestCase):
         self.urls = self.router.urls
 
     def test_urls_can_have_trailing_slash_removed(self):
-        expected = ['^notes$', '^notes/(?P<pk>[^/.]+)$']
+        expected = ['^notes$', '^notes/(?P<pk>[^/]+)$']
         for idx in range(len(expected)):
             assert expected[idx] == get_regex_pattern(self.urls[idx])
 


### PR DESCRIPTION
## Description

When using [TimescaleDB](https://www.timescale.com/) the primary keys are timestamps with microseconds included (e.g. `2020-03-05T12:43:28.542873+01:00`). This causes the primary key to contain a `.` which DRF didn't support up to this patch.

