### PR TITLE
Allow serializer data to include related objects by object

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -250,6 +250,10 @@ class PrimaryKeyRelatedField(RelatedField):
         return True
 
     def to_internal_value(self, data):
+
+        if isinstance(data, self.get_queryset().model):
+            return data
+
         if self.pk_field is not None:
             data = self.pk_field.to_internal_value(data)
         try:
@@ -331,6 +335,10 @@ class HyperlinkedRelatedField(RelatedField):
         return self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
     def to_internal_value(self, data):
+
+        if isinstance(data, self.get_queryset().model):
+            return data
+
         request = self.context.get('request', None)
         try:
             http_prefix = data.startswith(('http:', 'https:'))


### PR DESCRIPTION
When instantiating a serializer from cleaned data, the relational fields have been already converted into objects, which makes the fields invalid. Having a valid object as the value of a field should be considered valid, even if not in the prescribed format.

As such, this change adds a check to allow objects of the model type in lieu of the proper representation.

Not included in this patch, but could be something to consider, is the case where there is an object of the proper type, but would not be in the queryset.