### PR TITLE
Set action for HEAD requests

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -93,6 +93,10 @@ class ViewSetMixin:
 
         def view(request, *args, **kwargs):
             self = cls(**initkwargs)
+
+            if 'get' in actions and 'head' not in actions:
+                actions['head'] = actions['get']
+
             # We also store the mapping of request methods to actions,
             # so that we can later set the action attribute.
             # eg. `self.action = 'list'` on an incoming GET request.
@@ -103,9 +107,6 @@ class ViewSetMixin:
             for method, action in actions.items():
                 handler = getattr(self, action)
                 setattr(self, method, handler)
-
-            if hasattr(self, 'get') and not hasattr(self, 'head'):
-                self.head = self.get
 
             self.request = request
             self.args = args


### PR DESCRIPTION
Fixes #6196 by setting the `head` handler in the `actions` map instead of on the view instance.