### PR TITLE
Open API AutoSchema generation improves

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -290,12 +290,24 @@ class AutoSchema(ViewInspector):
 
         return parameters
 
+    def _get_manual_query_parameters(self, path, method):
+        # TODO: parse method docstring / typing / something else?
+        return []
+
     def _get_filter_parameters(self, path, method):
+        """
+        Return a list of parameters from filter_backends if defined, or from manual implementation.
+        """
         if not self._allows_filters(path, method):
             return []
+
         parameters = []
-        for filter_backend in self.view.filter_backends:
-            parameters += filter_backend().get_schema_operation_parameters(self.view)
+        if self.view.filter_backends:
+            for filter_backend in self.view.filter_backends:
+                parameters += filter_backend().get_schema_operation_parameters(self.view)
+        else:
+            parameters += self._get_manual_query_parameters(path, method)
+
         return parameters
 
     def _allows_filters(self, path, method):


### PR DESCRIPTION
## Description

Hello! I want to discuss about automatic documentation in DRF. It seems to me that it is far from perfect, since the slightest customization is a headache with inheritance of generators, redefinition of methods, study of Open API documentation for creating valid fields, and so on...

It seems to me that a good example of automatic documentation, but at the same time easily customizable, is the [Fast API](https://fastapi.tiangolo.com/features/#automatic-docs).

I would like to do the same easy customization, or at least close to it. How much does the community need this, does anyone use it (manual customization)? Or is the standard implementation enough for everyone?

For example, just a simple APIView:
```python
from rest_framework.views import APIView
from rest_framework.response import Response

class SimpleAPIView(views.APIView):
    def get(self, request):
        needed_param = request.GET.get("needed_param", "not specified")
        return Response(f"Needed param: {needed_param}")
```

And then, we will not see this parameter when viewing the generated schema, because AutoSchema will look in filter_backends, which is missing. It seems logical, but you must admit, additionally creating filter_backends to simply specify a parameter is too much, imho.

Final code in DRF:

```python
from rest_framework.views import APIView
from rest_framework.response import Response
from rest_framework.filters import BaseFilterBackend


class CustomFilter(BaseFilterBackend):
    def get_schema_operation_parameters(self, view):
        return [
            {
                "name": "needed_param",
                "in": "query",
                "required": False,
                "description": "Needed param.",
                'schema': {
                    'type': 'string',
                },
            },
        ]


class SimpleAPIView(views.APIView):
    filter_backends = (CustomFilter,)

    def get(self, request):
        needed_param = request.GET.get("needed_param", "not specified")
        return Response(f"Needed param: {needed_param}")

```


And that's all for only 1 param with only basic information. It's not fair, i think.