### PR TITLE
Component should not be generated for delete method

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -185,6 +185,10 @@ class AutoSchema(ViewInspector):
         """
         Return components with their properties from the serializer.
         """
+
+        if method.lower() == 'delete':
+            return {}
+
         serializer = self._get_serializer(path, method)
 
         if not isinstance(serializer, serializers.Serializer):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -1087,3 +1087,15 @@ class TestGenerator(TestCase):
         assert 'components' in schema
         assert 'schemas' in schema['components']
         assert 'Duplicate' in schema['components']['schemas']
+
+    def test_component_should_not_be_generated_for_delete_method(self):
+        class ExampleView(generics.DestroyAPIView):
+            schema = AutoSchema(operation_id_base='example')
+
+        url_patterns = [
+            url(r'^example/?$', ExampleView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=url_patterns)
+        schema = generator.get_schema(request=create_request('/'))
+        assert 'components' not in schema
+        assert 'content' not in schema['paths']['/example/']['delete']['responses']['204']


### PR DESCRIPTION
Mostly, We do not need a serializer for the delete method. Component generation logic expects a serializer defined for each method. which will create an error in the following scenarios:

1. A View with only delete action & serializer class is not defined.
2. A View with overridden `get_serializer_class` method that does not provide serializer for the delete action. 

This merge request fixes the above scenarios.
Also, I have added a test case that will fail without this fix.