### PR TITLE
Fix serializer example in docs

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -238,10 +238,12 @@ Serializer classes can also include reusable validators that are applied to the 
 
         class Meta:
             # Each room only has one event per day.
-            validators = UniqueTogetherValidator(
-                queryset=Event.objects.all(),
-                fields=['room_number', 'date']
-            )
+            validators = [
+                UniqueTogetherValidator(
+                    queryset=Event.objects.all(),
+                    fields=['room_number', 'date']
+                )
+            ]
 
 For more information see the [validators documentation](validators.md).
 


### PR DESCRIPTION
## Description

The [serializer docs](https://www.django-rest-framework.org/api-guide/serializers/), contain an example of a `UniqueTogetherValidator` that's not correct and if someone tries to use this as is he will get an error.
As stated in its [documentation](https://www.django-rest-framework.org/api-guide/validators/#uniquetogethervalidator), the `validators` Meta field needs to be a list. This PR wraps that `UniqueTogetherValidator` in a list.
