### PR TITLE
Allow serializer data to include related objects by object

### DIFF
--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -116,6 +116,10 @@ class TestPrimaryKeyRelatedField(APISimpleTestCase):
         instance = field.to_internal_value(self.instance.pk)
         assert instance is self.instance
 
+    def test_pk_related_object_given(self):
+        instance = self.field.to_internal_value(self.instance)
+        assert instance is self.queryset.items[2]
+
 
 class TestProxiedPrimaryKeyRelatedField(APISimpleTestCase):
     def setUp(self):
@@ -216,6 +220,11 @@ class TestHyperlinkedRelatedField(APISimpleTestCase):
 
     def hyperlinked_related_queryset_error(self, exc_type):
         class QuerySet:
+            class FakeObject:
+                pass
+
+            model = FakeObject
+
             def get(self, *args, **kwargs):
                 raise exc_type
 
@@ -234,6 +243,10 @@ class TestHyperlinkedRelatedField(APISimpleTestCase):
 
     def test_hyperlinked_related_queryset_value_error(self):
         self.hyperlinked_related_queryset_error(ValueError)
+
+    def test_hyperlinked_related_object_given(self):
+        instance = self.field.to_internal_value(self.queryset.items[2])
+        assert instance is self.queryset.items[2]
 
 
 class TestHyperlinkedIdentityField(APISimpleTestCase):

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -322,6 +322,11 @@ class TestHyperlinkedRelatedField(URLPatternsTestCase, APITestCase):
         super().setUp()
 
         class MockQueryset:
+            class MockObject:
+                pass
+
+            model = MockObject
+
             def get(self, pk):
                 return 'object %s' % pk
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,8 @@ class MockObject:
 
 
 class MockQueryset:
+    model = MockObject
+
     def __init__(self, iterable):
         self.items = iterable
 


### PR DESCRIPTION
When instantiating a serializer from cleaned data, the relational fields have been already converted into objects, which makes the fields invalid. Having a valid object as the value of a field is not necessarily considered valid, if the object is not in the given queryset.

As such, this change adds a check to allow objects of the model type and in the queryset in lieu of the proper representation.