### PR TITLE
Updating documentation / switching from url to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ router.register(r'users', UserViewSet)
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    url(r'^', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    path('', include(router.urls)),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Startup up a new project like so...
 Now edit the `example/urls.py` module in your project:
 
 ```python
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.contrib.auth.models import User
 from rest_framework import serializers, viewsets, routers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -148,7 +148,7 @@ Don't forget to make sure you've also added `rest_framework` to your `INSTALLED_
 We're ready to create our API now.
 Here's our project's root `urls.py` module:
 
-    from django.conf.urls import url, include
+    from django.urls import path, include
     from django.contrib.auth.models import User
     from rest_framework import routers, serializers, viewsets
 
@@ -170,8 +170,8 @@ Here's our project's root `urls.py` module:
     # Wire up our API using automatic URL routing.
     # Additionally, we include login URLs for the browsable API.
     urlpatterns = [
-        url(r'^', include(router.urls)),
-        url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+        path('', include(router.urls)),
+        path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
 You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.


### PR DESCRIPTION
Hi! I noticed that path() in documentation is used in some places and url() in other places. Url is slowly deprecated so I allowed myself to replace in the project homepage and readme url() to path().