### PR TITLE
Add Request repr

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -179,6 +179,13 @@ class Request:
             forced_auth = ForcedAuthentication(force_user, force_token)
             self.authenticators = (forced_auth,)
 
+    def __repr__(self):
+        return '<%s.%s: %s %r>' % (
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.method,
+            self.get_full_path())
+
     def _default_negotiator(self):
         return api_settings.DEFAULT_CONTENT_NEGOTIATION_CLASS()
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -272,6 +272,12 @@ class TestSecure(TestCase):
 
 
 class TestHttpRequest(TestCase):
+    def test_repr(self):
+        http_request = factory.get('/path')
+        request = Request(http_request)
+
+        assert repr(request) == "<rest_framework.request.Request: GET '/path'>"
+
     def test_attribute_access_proxy(self):
         http_request = factory.get('/')
         request = Request(http_request)


### PR DESCRIPTION
Adds a repr to Request, returning:
```
<rest_framework.request.Request: GET '/example'>
```

This is similar to the underlying `WSGIRequest`, which returns:

```
<WSGIRequest: GET '/example'>
```

One question is if we want to provide the full `Request` class path, or just the name.

Fixes #7231. 

