### PR TITLE
Corrected OpenAPI schema type for DecimalField

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -444,7 +444,7 @@ class AutoSchema(ViewInspector):
             return content
 
         if isinstance(field, serializers.DecimalField):
-            if field.coerce_to_string:
+            if getattr(field, 'coerce_to_string', api_settings.COERCE_DECIMAL_TO_STRING):
                 return {
                     'type': 'string',
                     'format': 'decimal',

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -445,7 +445,7 @@ class AutoSchema(ViewInspector):
 
         if isinstance(field, serializers.DecimalField):
             if getattr(field, 'coerce_to_string', api_settings.COERCE_DECIMAL_TO_STRING):
-                return {
+                content = {
                     'type': 'string',
                     'format': 'decimal',
                 }
@@ -453,13 +453,14 @@ class AutoSchema(ViewInspector):
                 content = {
                     'type': 'number'
                 }
-                if field.decimal_places:
-                    content['multipleOf'] = float('.' + (field.decimal_places - 1) * '0' + '1')
-                if field.max_whole_digits:
-                    content['maximum'] = int(field.max_whole_digits * '9') + 1
-                    content['minimum'] = -content['maximum']
-                self._map_min_max(field, content)
-                return content
+
+            if field.decimal_places:
+                content['multipleOf'] = float('.' + (field.decimal_places - 1) * '0' + '1')
+            if field.max_whole_digits:
+                content['maximum'] = int(field.max_whole_digits * '9') + 1
+                content['minimum'] = -content['maximum']
+            self._map_min_max(field, content)
+            return content
 
         if isinstance(field, serializers.FloatField):
             content = {

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -830,13 +830,9 @@ class TestOperationIntrospection(TestCase):
         assert properties['regex']['pattern'] == r'[ABC]12{3}'
         assert properties['regex']['description'] == 'must have an A, B, or C followed by 1222'
 
-        assert properties['decimal1']['type'] == 'number'
-        assert properties['decimal1']['multipleOf'] == .01
-        assert properties['decimal1']['maximum'] == 10000
-        assert properties['decimal1']['minimum'] == -10000
+        assert properties['decimal1'] == {'type': 'string', 'format': 'decimal'}
 
-        assert properties['decimal2']['type'] == 'number'
-        assert properties['decimal2']['multipleOf'] == .0001
+        assert properties['decimal2'] == {'type': 'string', 'format': 'decimal'}
 
         assert properties['email']['type'] == 'string'
         assert properties['email']['format'] == 'email'

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -830,9 +830,16 @@ class TestOperationIntrospection(TestCase):
         assert properties['regex']['pattern'] == r'[ABC]12{3}'
         assert properties['regex']['description'] == 'must have an A, B, or C followed by 1222'
 
-        assert properties['decimal1'] == {'type': 'string', 'format': 'decimal'}
+        assert properties['decimal1']['type'] == 'number'
+        assert properties['decimal1']['multipleOf'] == .01
+        assert properties['decimal1']['maximum'] == 10000
+        assert properties['decimal1']['minimum'] == -10000
 
-        assert properties['decimal2'] == {'type': 'string', 'format': 'decimal'}
+        assert properties['decimal2']['type'] == 'number'
+        assert properties['decimal2']['multipleOf'] == .0001
+
+        assert properties['decimal3'] == {'type': 'string', 'format': 'decimal'}
+        assert properties['decimal4'] == {'type': 'string', 'format': 'decimal'}
 
         assert properties['email']['type'] == 'string'
         assert properties['email']['format'] == 'email'

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -838,8 +838,15 @@ class TestOperationIntrospection(TestCase):
         assert properties['decimal2']['type'] == 'number'
         assert properties['decimal2']['multipleOf'] == .0001
 
-        assert properties['decimal3'] == {'type': 'string', 'format': 'decimal'}
-        assert properties['decimal4'] == {'type': 'string', 'format': 'decimal'}
+        assert properties['decimal3'] == {
+            'type': 'string', 'format': 'decimal', 'maximum': 1000000, 'minimum': -1000000, 'multipleOf': 0.01
+        }
+        assert properties['decimal4'] == {
+            'type': 'string', 'format': 'decimal', 'maximum': 1000000, 'minimum': -1000000, 'multipleOf': 0.01
+        }
+        assert properties['decimal5'] == {
+            'type': 'string', 'format': 'decimal', 'maximum': 10000, 'minimum': -10000, 'multipleOf': 0.01
+        }
 
         assert properties['email']['type'] == 'string'
         assert properties['email']['format'] == 'email'

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -125,6 +125,7 @@ class ExampleValidatedSerializer(serializers.Serializer):
     decimal3 = serializers.DecimalField(max_digits=8, decimal_places=2, coerce_to_string=True)
     decimal4 = serializers.DecimalField(max_digits=8, decimal_places=2, coerce_to_string=True,
                                         validators=(DecimalValidator(max_digits=17, decimal_places=4),))
+    decimal5 = serializers.DecimalField(max_digits=6, decimal_places=2)
     email = serializers.EmailField(default='foo@bar.com')
     url = serializers.URLField(default='http://www.example.com', allow_null=True)
     uuid = serializers.UUIDField()

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -119,8 +119,11 @@ class ExampleValidatedSerializer(serializers.Serializer):
             MinLengthValidator(limit_value=2),
         )
     )
-    decimal1 = serializers.DecimalField(max_digits=6, decimal_places=2)
-    decimal2 = serializers.DecimalField(max_digits=5, decimal_places=0,
+    decimal1 = serializers.DecimalField(max_digits=6, decimal_places=2, coerce_to_string=False)
+    decimal2 = serializers.DecimalField(max_digits=5, decimal_places=0, coerce_to_string=False,
+                                        validators=(DecimalValidator(max_digits=17, decimal_places=4),))
+    decimal3 = serializers.DecimalField(max_digits=8, decimal_places=2, coerce_to_string=True)
+    decimal4 = serializers.DecimalField(max_digits=8, decimal_places=2, coerce_to_string=True,
                                         validators=(DecimalValidator(max_digits=17, decimal_places=4),))
     email = serializers.EmailField(default='foo@bar.com')
     url = serializers.URLField(default='http://www.example.com', allow_null=True)


### PR DESCRIPTION
## Description

The API renders DecimalFields as strings. The generated schema now renders decimal fields correctly as strings.

Fixes #7253