### PR TITLE
Convert openapi.AutoSchema methods to public API.

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -25,9 +25,9 @@ ISO_8601 = 'iso-8601'
 default_app_config = 'rest_framework.apps.RestFrameworkConfig'
 
 
-class RemovedInDRF312Warning(DeprecationWarning):
+class RemovedInDRF313Warning(DeprecationWarning):
     pass
 
 
-class RemovedInDRF313Warning(PendingDeprecationWarning):
+class RemovedInDRF314Warning(PendingDeprecationWarning):
     pass

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -83,7 +83,7 @@ class TestFieldMapping(TestCase):
         ]
         for field, mapping in cases:
             with self.subTest(field=field):
-                assert inspector._map_field(field) == mapping
+                assert inspector.map_field(field) == mapping
 
     def test_lazy_string_field(self):
         class ItemSerializer(serializers.Serializer):
@@ -91,7 +91,7 @@ class TestFieldMapping(TestCase):
 
         inspector = AutoSchema()
 
-        data = inspector._map_serializer(ItemSerializer())
+        data = inspector.map_serializer(ItemSerializer())
         assert isinstance(data['properties']['text']['description'], str), "description must be str"
 
     def test_boolean_default_field(self):
@@ -102,7 +102,7 @@ class TestFieldMapping(TestCase):
 
         inspector = AutoSchema()
 
-        data = inspector._map_serializer(Serializer())
+        data = inspector.map_serializer(Serializer())
         assert data['properties']['default_true']['default'] is True, "default must be true"
         assert data['properties']['default_false']['default'] is False, "default must be false"
         assert 'default' not in data['properties']['without_default'], "default must not be defined"
@@ -202,7 +202,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        request_body = inspector._get_request_body(path, method)
+        request_body = inspector.get_request_body(path, method)
         print(request_body)
         assert request_body['content']['application/json']['schema']['$ref'] == '#/components/schemas/Item'
 
@@ -229,7 +229,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        serializer = inspector._get_serializer(path, method)
+        serializer = inspector.get_serializer(path, method)
 
         with pytest.raises(Exception) as exc:
             inspector.get_component_name(serializer)
@@ -259,7 +259,7 @@ class TestOperationIntrospection(TestCase):
         # there should be no empty 'required' property, see #6834
         assert 'required' not in component
 
-        for response in inspector._get_responses(path, method).values():
+        for response in inspector.get_responses(path, method).values():
             assert 'required' not in component
 
     def test_empty_required_with_patch_method(self):
@@ -285,7 +285,7 @@ class TestOperationIntrospection(TestCase):
         component = components['Item']
         # there should be no empty 'required' property, see #6834
         assert 'required' not in component
-        for response in inspector._get_responses(path, method).values():
+        for response in inspector.get_responses(path, method).values():
             assert 'required' not in component
 
     def test_response_body_generation(self):
@@ -307,7 +307,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        responses = inspector._get_responses(path, method)
+        responses = inspector.get_responses(path, method)
         assert responses['201']['content']['application/json']['schema']['$ref'] == '#/components/schemas/Item'
 
         components = inspector.get_components(path, method)
@@ -337,7 +337,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        responses = inspector._get_responses(path, method)
+        responses = inspector.get_responses(path, method)
         assert responses['201']['content']['application/json']['schema']['$ref'] == '#/components/schemas/Item'
         components = inspector.get_components(path, method)
         assert components['Item']
@@ -368,7 +368,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        responses = inspector._get_responses(path, method)
+        responses = inspector.get_responses(path, method)
         assert responses == {
             '200': {
                 'description': '',
@@ -424,7 +424,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        responses = inspector._get_responses(path, method)
+        responses = inspector.get_responses(path, method)
         assert responses == {
             '200': {
                 'description': '',
@@ -472,7 +472,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        responses = inspector._get_responses(path, method)
+        responses = inspector.get_responses(path, method)
         assert responses == {
             '204': {
                 'description': '',
@@ -496,7 +496,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        request_body = inspector._get_request_body(path, method)
+        request_body = inspector.get_request_body(path, method)
 
         assert len(request_body['content'].keys()) == 2
         assert 'multipart/form-data' in request_body['content']
@@ -519,7 +519,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        responses = inspector._get_responses(path, method)
+        responses = inspector.get_responses(path, method)
         # TODO this should be changed once the multiple response
         # schema support is there
         success_response = responses['200']
@@ -594,7 +594,7 @@ class TestOperationIntrospection(TestCase):
         inspector = AutoSchema()
         inspector.view = view
 
-        responses = inspector._get_responses(path, method)
+        responses = inspector.get_responses(path, method)
         assert responses == {
             '200': {
                 'description': '',


### PR DESCRIPTION
- Bumps deprecation warning classes for 3.12. 
- Removes RemovedInDRF312Warning.
- Adds RemovedInDRF314Warning. 
- Renames AutoSchema methods to be public. 
- Deprecates old hooks. (Didn't add additional tests for these...) 

Docs changes for now public methods in schemas.md to follow separately. 