### PR TITLE
Add ViewSet get_data extension points

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -14,7 +14,7 @@ class CreateModelMixin:
     Create a model instance.
     """
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(data=self.get_create_data(request))
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
@@ -22,6 +22,9 @@ class CreateModelMixin:
 
     def perform_create(self, serializer):
         serializer.save()
+
+    def get_create_data(self, request):
+        return request.data
 
     def get_success_headers(self, data):
         try:

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -14,7 +14,8 @@ class CreateModelMixin:
     Create a model instance.
     """
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=self.get_create_data(request))
+        data = self.get_create_data(request)
+        serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
@@ -66,7 +67,8 @@ class UpdateModelMixin:
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        data = self.get_update_data(request)
+        serializer = self.get_serializer(instance, data=data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
 
@@ -76,6 +78,9 @@ class UpdateModelMixin:
             instance._prefetched_objects_cache = {}
 
         return Response(serializer.data)
+
+    def get_update_data(self, request):
+        return request.data
 
     def perform_update(self, serializer):
         serializer.save()


### PR DESCRIPTION
Right now there doesn't appear to be a nice way to control the `data` arg that goes into the Serializer in a ViewSet without effectively copying out the whole `create/update` method. `request.data` is immutable, and overriding `get_serializer` changes a bunch of other behavior beyond what I want. I'm proposing to add a couple of simple extension points which users can override to control the data. For instance, in my own use case, I'd like to do the following:

```py
class MyViewSet(viewsets.ModelViewSet):
    def get_create_data(self, request):
        return {**request.data.dict(), 'template_id': self.kwargs['template_id']}
```
