### PR TITLE
Updated ordering field name checks for Django master

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -8,7 +8,6 @@ from functools import reduce
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.sql.constants import ORDER_PATTERN
 from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
@@ -256,7 +255,13 @@ class OrderingFilter(BaseFilterBackend):
 
     def remove_invalid_fields(self, queryset, fields, view, request):
         valid_fields = [item[0] for item in self.get_valid_fields(queryset, view, {'request': request})]
-        return [term for term in fields if term.lstrip('-') in valid_fields and ORDER_PATTERN.match(term)]
+
+        def term_valid(term):
+            if term.startswith("-"):
+                term = term[1:]
+            return term in valid_fields
+
+        return [term for term in fields if term_valid(term)]
 
     def filter_queryset(self, request, queryset, view):
         ordering = self.get_ordering(request, queryset, view)


### PR DESCRIPTION
## Description

Django master removed the `ORDER_PATTERN` regex with commit https://github.com/django/django/commit/513948735b799239f3ef8c89397592445e1a0cd5