### PR TITLE
Pass serializer to HTMLFormRenderer through renderer_context rather than .data

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -355,7 +355,7 @@ class HTMLFormRenderer(BaseRenderer):
         Render serializer data and return an HTML form, as a string.
         """
         renderer_context = renderer_context or {}
-        form = data.serializer
+        form = renderer_context.get('serializer')
 
         style = renderer_context.get('style', {})
         if 'template_pack' not in style:
@@ -518,7 +518,10 @@ class BrowsableAPIRenderer(BaseRenderer):
         return form_renderer.render(
             serializer.data,
             self.accepted_media_type,
-            {'style': {'template_pack': 'rest_framework/horizontal'}}
+            {
+                'style': {'template_pack': 'rest_framework/horizontal'},
+                'serializer': serializer
+            }
         )
 
     def get_raw_data_form(self, data, view, method, request):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -539,14 +539,6 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
             return JSONBoundField(field, value, error)
         return BoundField(field, value, error)
 
-    # Include a backlink to the serializer class on return objects.
-    # Allows renderers such as HTMLFormRenderer to get the full field info.
-
-    @property
-    def data(self):
-        ret = super().data
-        return ReturnDict(ret, serializer=self)
-
     @property
     def errors(self):
         ret = super().errors
@@ -736,14 +728,6 @@ class ListSerializer(BaseSerializer):
 
     def __repr__(self):
         return representation.list_repr(self, indent=1)
-
-    # Include a backlink to the serializer class on return objects.
-    # Allows renderers such as HTMLFormRenderer to get the full field info.
-
-    @property
-    def data(self):
-        ret = super().data
-        return ReturnList(ret, serializer=self)
 
     @property
     def errors(self):

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -78,7 +78,7 @@ def get_pagination_html(pager):
 def render_form(serializer, template_pack=None):
     style = {'template_pack': template_pack} if template_pack else {}
     renderer = HTMLFormRenderer()
-    return renderer.render(serializer.data, None, {'style': style})
+    return renderer.render(serializer.data, None, {'style': style, 'serializer': serializer})
 
 
 @register.simple_tag

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -499,17 +499,15 @@ class TestHTMLFormRenderer(TestCase):
 
     def test_render_with_default_args(self):
         self.serializer.is_valid()
-        renderer = HTMLFormRenderer()
 
-        result = renderer.render(self.serializer.data)
+        result = self.renderer.render(self.serializer.data, renderer_context={'serializer': self.serializer})
 
         self.assertIsInstance(result, SafeText)
 
     def test_render_with_provided_args(self):
         self.serializer.is_valid()
-        renderer = HTMLFormRenderer()
 
-        result = renderer.render(self.serializer.data, None, {})
+        result = self.renderer.render(self.serializer.data, None, {'serializer': self.serializer})
 
         self.assertIsInstance(result, SafeText)
 
@@ -531,7 +529,7 @@ class TestChoiceFieldHTMLFormRenderer(TestCase):
 
     def test_render_initial_option(self):
         serializer = self.TestSerializer()
-        result = self.renderer.render(serializer.data)
+        result = self.renderer.render(serializer.data, renderer_context={'serializer': serializer})
 
         self.assertIsInstance(result, SafeText)
 
@@ -544,7 +542,7 @@ class TestChoiceFieldHTMLFormRenderer(TestCase):
         serializer = self.TestSerializer(data={'test_field': '12'})
 
         serializer.is_valid()
-        result = self.renderer.render(serializer.data)
+        result = self.renderer.render(serializer.data, renderer_context={'serializer': serializer})
 
         self.assertIsInstance(result, SafeText)
 
@@ -572,7 +570,7 @@ class TestMultipleChoiceFieldHTMLFormRenderer(TestCase):
         serializer = TestSerializer(data={'test_field': ['12']})
         serializer.is_valid()
 
-        result = self.renderer.render(serializer.data)
+        result = self.renderer.render(serializer.data, renderer_context={'serializer': serializer})
 
         self.assertIsInstance(result, SafeText)
 
@@ -591,7 +589,7 @@ class TestMultipleChoiceFieldHTMLFormRenderer(TestCase):
         serializer = TestSerializer(data={'test_field': ['12']})
         serializer.is_valid()
 
-        result = self.renderer.render(serializer.data)
+        result = self.renderer.render(serializer.data, renderer_context={'serializer': serializer})
 
         self.assertIsInstance(result, SafeText)
 


### PR DESCRIPTION
## Description

This PR improves memory usage, by removing a reference like `serializer.data.serializer`. Looks like   `.data` might not have reference to `serializer` object.

There are two more  ([one](https://github.com/encode/django-rest-framework/blob/master/rest_framework/renderers.py#L454-L460), [two](https://github.com/encode/django-rest-framework/blob/master/rest_framework/renderers.py#L531-L537)) places, where the reference expected optionally. Probably we can remove that code, since serializer gets instantiated few lines below.

 Thoughts ?

Discussion here: #7250 


