### PR TITLE
Fix punctuation in system check

### DIFF
--- a/rest_framework/checks.py
+++ b/rest_framework/checks.py
@@ -9,7 +9,7 @@ def pagination_system_check(app_configs, **kwargs):
     if api_settings.PAGE_SIZE and not api_settings.DEFAULT_PAGINATION_CLASS:
         errors.append(
             Warning(
-                "You have specified a default PAGE_SIZE pagination rest_framework setting,"
+                "You have specified a default PAGE_SIZE pagination rest_framework setting, "
                 "without specifying also a DEFAULT_PAGINATION_CLASS.",
                 hint="The default for DEFAULT_PAGINATION_CLASS is None. "
                      "In previous versions this was PageNumberPagination. "


### PR DESCRIPTION
Add a missing space in warning message when `DEFAULT_PAGINATION_CLASS` is unset.