### PR TITLE
Remove a few submenu scroll bars on docs site

### DIFF
--- a/docs_theme/css/default.css
+++ b/docs_theme/css/default.css
@@ -6,7 +6,7 @@ pre {
 
 .dropdown .dropdown-menu {
   display: none;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .dropdown.open .dropdown-menu {


### PR DESCRIPTION
Remove the scroll bars for the "Topics" and "Tutorial" submenus on the website. Previously, unnecessary scroll bars appeared in Firefox and Chrome. Applying this change allows "Community" and "API Guide" submenues to still have scroll bars as necessary.