### PR TITLE
Fix viewsets action urls with namespaces (#7287)

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -150,6 +150,11 @@ class ViewSetMixin:
         Reverse the action for the given `url_name`.
         """
         url_name = '%s-%s' % (self.basename, url_name)
+        namespace = None
+        if self.request and self.request.resolver_match:
+            namespace = self.request.resolver_match.namespace
+        if namespace:
+            url_name = namespace + ':' + url_name
         kwargs.setdefault('request', self.request)
 
         return reverse(url_name, *args, **kwargs)


### PR DESCRIPTION
Use the current request's namespace to resolve action urls.

## Description

Use the current request's namespace to resolve action urls.
Fixes #7287