### PR TITLE
Minor test improvements

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -22,10 +22,6 @@ class DecoratorTestCase(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
 
-    def _finalize_response(self, request, response, *args, **kwargs):
-        response.request = request
-        return APIView.finalize_response(self, request, response, *args, **kwargs)
-
     def test_api_view_incorrect(self):
         """
         If @api_view is not applied correct, we should raise an assertion.

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -741,6 +741,11 @@ class AdminRendererTests(TestCase):
         class DummyGenericViewsetLike(APIView):
             lookup_field = 'test'
 
+            def get(self, request):
+                response = Response()
+                response.view = self
+                return response
+
             def reverse_action(view, *args, **kwargs):
                 self.assertEqual(kwargs['kwargs']['test'], 1)
                 return '/example/'
@@ -749,7 +754,7 @@ class AdminRendererTests(TestCase):
         view = DummyGenericViewsetLike.as_view()
         request = factory.get('/')
         response = view(request)
-        view = response.renderer_context['view']
+        view = response.view
 
         self.assertEqual(self.renderer.get_result_url({'test': 1}, view), '/example/')
         self.assertIsNone(self.renderer.get_result_url({}, view))
@@ -760,11 +765,16 @@ class AdminRendererTests(TestCase):
         class DummyView(APIView):
             lookup_field = 'test'
 
+            def get(self, request):
+                response = Response()
+                response.view = self
+                return response
+
         # get the view instance instead of the view function
         view = DummyView.as_view()
         request = factory.get('/')
         response = view(request)
-        view = response.renderer_context['view']
+        view = response.view
 
         self.assertIsNone(self.renderer.get_result_url({'test': 1}, view))
         self.assertIsNone(self.renderer.get_result_url({}, view))

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -42,7 +42,9 @@ class ActionViewSet(GenericViewSet):
         return response
 
     def retrieve(self, request, *args, **kwargs):
-        return Response()
+        response = Response()
+        response.view = self
+        return response
 
     @action(detail=False)
     def list_action(self, request, *args, **kwargs):
@@ -70,7 +72,9 @@ class ActionViewSet(GenericViewSet):
 class ActionNamesViewSet(GenericViewSet):
 
     def retrieve(self, request, *args, **kwargs):
-        return Response()
+        response = Response()
+        response.view = self
+        return response
 
     @action(detail=True)
     def unnamed_action(self, request, *args, **kwargs):
@@ -209,7 +213,7 @@ class GetExtraActionUrlMapTests(TestCase):
 
     def test_list_view(self):
         response = self.client.get('/api/actions/')
-        view = response.renderer_context['view']
+        view = response.view
 
         expected = OrderedDict([
             ('Custom list action', 'http://testserver/api/actions/custom_list_action/'),
@@ -220,7 +224,7 @@ class GetExtraActionUrlMapTests(TestCase):
 
     def test_detail_view(self):
         response = self.client.get('/api/actions/1/')
-        view = response.renderer_context['view']
+        view = response.view
 
         expected = OrderedDict([
             ('Custom detail action', 'http://testserver/api/actions/1/custom_detail_action/'),
@@ -236,7 +240,7 @@ class GetExtraActionUrlMapTests(TestCase):
     def test_action_names(self):
         # Action 'name' and 'suffix' kwargs should be respected
         response = self.client.get('/api/names/1/')
-        view = response.renderer_context['view']
+        view = response.view
 
         expected = OrderedDict([
             ('Custom Name', 'http://testserver/api/names/1/named_action/'),


### PR DESCRIPTION
- Removes an unused testcase helper method
- Attach the `view`/`request` directly to the response object instead of leveraging the `renderer_context`. This pattern is already used elsewhere, and it seems preferable than relying on an implementation detail of the view.