### PR TITLE
Allow context to be provided to get_serializer

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -106,7 +106,7 @@ class GenericAPIView(views.APIView):
         deserializing input, and for serializing output.
         """
         serializer_class = self.get_serializer_class()
-        kwargs['context'] = self.get_serializer_context()
+        kwargs.setdefault('context', self.get_serializer_context())
         return serializer_class(*args, **kwargs)
 
     def get_serializer_class(self):


### PR DESCRIPTION
Allows the `context` kwarg to be provided to the call to `get_serializer`. Currently a given context is overridden by the `get_serializer_context` result. 

refs #6956

