### PR TITLE
Create schema components for each response schema

### DIFF
--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -308,7 +308,8 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         responses = inspector.get_responses(path, method)
-        assert responses['201']['content']['application/json']['schema']['$ref'] == '#/components/schemas/Item'
+        assert responses['201']['content']['application/json']['schema']['$ref'] == \
+            '#/components/schemas/CreateItemResponse'
 
         components = inspector.get_components(path, method)
         assert sorted(components['Item']['required']) == ['text', 'write_only']
@@ -338,7 +339,7 @@ class TestOperationIntrospection(TestCase):
         inspector.view = view
 
         responses = inspector.get_responses(path, method)
-        assert responses['201']['content']['application/json']['schema']['$ref'] == '#/components/schemas/Item'
+        assert responses['201']['content']['application/json']['schema']['$ref'] == '#/components/schemas/CreateItemResponse'
         components = inspector.get_components(path, method)
         assert components['Item']
 
@@ -375,10 +376,7 @@ class TestOperationIntrospection(TestCase):
                 'content': {
                     'application/json': {
                         'schema': {
-                            'type': 'array',
-                            'items': {
-                                '$ref': '#/components/schemas/Item'
-                            },
+                            '$ref': '#/components/schemas/ListItemsResponse'
                         },
                     },
                 },
@@ -386,6 +384,12 @@ class TestOperationIntrospection(TestCase):
         }
         components = inspector.get_components(path, method)
         assert components == {
+            'ListItemsResponse': {
+                'type': 'array',
+                'items': {
+                    '$ref': '#/components/schemas/Item',
+                },
+            },
             'Item': {
                 'type': 'object',
                 'properties': {
@@ -431,13 +435,7 @@ class TestOperationIntrospection(TestCase):
                 'content': {
                     'application/json': {
                         'schema': {
-                            'type': 'object',
-                            'item': {
-                                'type': 'array',
-                                'items': {
-                                    '$ref': '#/components/schemas/Item'
-                                },
-                            },
+                            '$ref': '#/components/schemas/ListItemsResponse'
                         },
                     },
                 },
@@ -445,6 +443,15 @@ class TestOperationIntrospection(TestCase):
         }
         components = inspector.get_components(path, method)
         assert components == {
+            'ListItemsResponse': {
+                'type': 'object',
+                'item': {
+                    'type': 'array',
+                    'items': {
+                        '$ref': '#/components/schemas/Item',
+                    },
+                },
+            },
             'Item': {
                 'type': 'object',
                 'properties': {
@@ -601,7 +608,7 @@ class TestOperationIntrospection(TestCase):
                 'content': {
                     'application/json': {
                         'schema': {
-                            '$ref': '#/components/schemas/Item'
+                            '$ref': '#/components/schemas/RetrieveItemResponse'
                         },
                     },
                 },
@@ -610,6 +617,9 @@ class TestOperationIntrospection(TestCase):
 
         components = inspector.get_components(path, method)
         assert components == {
+            'RetrieveItemResponse': {
+                '$ref': '#/components/schemas/Item'
+            },
             'Item': {
                 'type': 'object',
                 'properties': {


### PR DESCRIPTION
Always wrap response in a component schema, also paginated once, to improve processability of API code generators. Adresses #7299

## Description

In djangorestframework's `AutoSchema` I modified the schema generation to always Provide a wrapping `OperationIdResponse` schema component. That serves the purpose, that if the schema generator add's more fields to the response, like pagination properties the response doesn't have to inline those fields, but instead _always_ points to a schema component.

That makes the resulting openapi specification more processable by API client generators like [openapi-generator](https://github.com/OpenAPITools/openapi-generator/).

Inlined responses would lead to fallback type names like `InlinedRespose2000` - see #7299  