### PR TITLE
Fixed a command for initializing the snippets app in the tutorial

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -38,7 +38,7 @@ To get started, let's create a new project to work with.
 
 Once that's done we can create an app that we'll use to create a simple Web API.
 
-    python manage.py startapp snippets
+    django-admin startapp snippets
 
 We'll need to add our new `snippets` app and the `rest_framework` app to `INSTALLED_APPS`. Let's edit the `tutorial/settings.py` file:
 


### PR DESCRIPTION
I was following the example commands, but after cding into 'tutorials' then trying to run `python manage.py startapp snippets`, python said there was no manage.py to be found. The quickstart guide uses django-admin in the tutorial directory for the startapp command, so I'm adding that here.

