### PR TITLE
Remove unnecessary object class derive in docs

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -603,7 +603,7 @@ The `to_internal_value()` method is called to restore a primitive datatype into 
 
 Let's look at an example of serializing a class that represents an RGB color value:
 
-    class Color(object):
+    class Color:
         """
         A color represented in the RGB colorspace.
         """

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -319,7 +319,7 @@ Often you'll want to use the existing generic views, but use some slightly custo
 
 For example, if you need to lookup objects based on multiple fields in the URL conf, you could create a mixin class like the following:
 
-    class MultipleFieldLookupMixin(object):
+    class MultipleFieldLookupMixin:
         """
         Apply this mixin to any view or viewset to get multiple field filtering
         based on a `lookup_fields` attribute, instead of the default single field filtering.

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -21,7 +21,7 @@ Let's start by creating a simple object we can use for example purposes:
 
     from datetime import datetime
 
-    class Comment(object):
+    class Comment:
         def __init__(self, email, content, created=None):
             self.email = email
             self.content = content

--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -282,7 +282,7 @@ to your `Serializer` subclass. This is documented in the
 
 To write a class-based validator, use the `__call__` method. Class-based validators are useful as they allow you to parameterize and reuse behavior.
 
-    class MultipleOf(object):
+    class MultipleOf:
         def __init__(self, base):
             self.base = base
 

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -143,7 +143,7 @@ class EndpointEnumerator:
         return [method for method in methods if method not in ('OPTIONS', 'HEAD')]
 
 
-class BaseSchemaGenerator(object):
+class BaseSchemaGenerator:
     endpoint_inspector_cls = EndpointEnumerator
 
     # 'pk' isn't great as an externally exposed name for an identifier,


### PR DESCRIPTION
Since Python 2.7 has been dropped, the docs can be simplified and the unnecessary `object` base class removed as this is default behavior in Python 3.
