### PR TITLE
Infer description from property docstring

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -2,6 +2,7 @@ import re
 import warnings
 from collections import OrderedDict
 from decimal import Decimal
+from inspect import getdoc
 from operator import attrgetter
 from urllib.parse import urljoin
 
@@ -283,6 +284,11 @@ class AutoSchema(ViewInspector):
                     description = force_str(model_field.help_text)
                 elif model_field is not None and model_field.primary_key:
                     description = get_pk_description(model, model_field)
+
+                if model_field is None and variable in model.__dict__.keys() and \
+                        isinstance(model.__dict__[variable], property):
+                    doc = getdoc(model.__dict__[variable])
+                    description = '' if doc is None else doc
 
             parameter = {
                 "name": variable,


### PR DESCRIPTION
This PR allows the openapi AutoSchema `get_path_parameters` method to infer a proper path parameter description when the underlying field is actually a property; it uses the property docstring since help_text cannot be set for a property.  Currently, a path parameter based on a property will always have an empty description, even if the property has a descriptive docstring.
