### PR TITLE
openapi AutoSchema move FIELD_CLASS_SCHEMA_TYPE out of map_field

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -358,6 +358,13 @@ class AutoSchema(ViewInspector):
             mapping['type'] = type
         return mapping
 
+    FIELD_CLASS_SCHEMA_TYPE = {
+        serializers.BooleanField: 'boolean',
+        serializers.JSONField: 'object',
+        serializers.DictField: 'object',
+        serializers.HStoreField: 'object',
+    }
+
     def map_field(self, field):
 
         # Nested Serializers, `many` or not.
@@ -492,13 +499,7 @@ class AutoSchema(ViewInspector):
             }
 
         # Simplest cases, default to 'string' type:
-        FIELD_CLASS_SCHEMA_TYPE = {
-            serializers.BooleanField: 'boolean',
-            serializers.JSONField: 'object',
-            serializers.DictField: 'object',
-            serializers.HStoreField: 'object',
-        }
-        return {'type': FIELD_CLASS_SCHEMA_TYPE.get(field.__class__, 'string')}
+        return {'type': self.FIELD_CLASS_SCHEMA_TYPE.get(field.__class__, 'string')}
 
     def _map_min_max(self, field, content):
         if field.max_value:


### PR DESCRIPTION
Move FIELD_CLASS_SCHEMA_TYPE out of the map_field method so that it may be extended by a subclass easily, for example when adding a custom serializer field.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Make FIELD_CLASS_SCHEMA_TYPE from the method of AutoSchema.map_field available and extendable, for example by subclassing.