### PR TITLE
Docs tweak

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -75,7 +75,7 @@ We can override `.get_queryset()` to deal with URLs such as `http://example.com/
             by filtering against a `username` query parameter in the URL.
             """
             queryset = Purchase.objects.all()
-            username = self.request.query_params.get('username', None)
+            username = self.request.query_params.get('username')
             if username is not None:
                 queryset = queryset.filter(purchaser__username=username)
             return queryset


### PR DESCRIPTION
Since `query_params` is as same as `QueryDict` which uses `None` as default return value, we don't need to explicitly set `None`, especially in the official document which would mislead the users.