### PR TITLE
Update link to dry-rest-permissions

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -322,7 +322,7 @@ The [Django Rest Framework Role Filters][django-rest-framework-role-filters] pac
 [filtering]: filtering.md
 [composed-permissions]: https://github.com/niwibe/djangorestframework-composed-permissions
 [rest-condition]: https://github.com/caxap/rest_condition
-[dry-rest-permissions]: https://github.com/Helioscene/dry-rest-permissions
+[dry-rest-permissions]: https://github.com/FJNR-inc/dry-rest-permissions
 [django-rest-framework-roles]: https://github.com/computer-lab/django-rest-framework-roles
 [djangorestframework-api-key]: https://florimondmanca.github.io/djangorestframework-api-key/
 [django-rest-framework-role-filters]: https://github.com/allisson/django-rest-framework-role-filters

--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -327,7 +327,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [django-versatileimagefield-drf-docs]:https://django-versatileimagefield.readthedocs.io/en/latest/drf_integration.html
 [drf-tracking]: https://github.com/aschn/drf-tracking
 [django-rest-framework-braces]: https://github.com/dealertrack/django-rest-framework-braces
-[dry-rest-permissions]: https://github.com/Helioscene/dry-rest-permissions
+[dry-rest-permissions]: https://github.com/FJNR-inc/dry-rest-permissions
 [django-url-filter]: https://github.com/miki725/django-url-filter
 [drf-url-filter]: https://github.com/manjitkumar/drf-url-filters
 [cookiecutter-django-rest]:  https://github.com/agconti/cookiecutter-django-rest


### PR DESCRIPTION
## Description

`dry-rest-permissions` was no maintain since 2018 and communications with the maintener are broked since more than a year, so FJNR-inc just got a new PyPi version on their fork. I changed the URL available in DRF doc in order to correctly help DRF's users find this package.