### PR TITLE
Base authentication abc implementation

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -36,6 +36,7 @@ class BaseAuthentication(abc.ABC):
     All authentication classes should extend BaseAuthentication.
     """
 
+    @abc.abstractmethod
     def authenticate(self, request):
         """
         Authenticate the request and return a two-tuple of (user, token).

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -1,6 +1,7 @@
 """
 Provides various authentication policies.
 """
+import abc
 import base64
 import binascii
 
@@ -30,7 +31,7 @@ class CSRFCheck(CsrfViewMiddleware):
         return reason
 
 
-class BaseAuthentication:
+class BaseAuthentication(abc.ABC):
     """
     All authentication classes should extend BaseAuthentication.
     """

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -537,7 +537,7 @@ class NoAuthenticationClassesTests(TestCase):
 class BasicAuthenticationUnitTests(TestCase):
 
     def test_base_authentication_abstract_method(self):
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             BaseAuthentication().authenticate({})
 
     def test_basic_authentication_raises_error_if_user_not_found(self):


### PR DESCRIPTION
## Description

refs #7376 

Added `abc.ABC` as a super class to `BaseAuthentication` and decorated `BaseAuthentication.authenticate` with `abc.abstractmethod`. Also fixed the expected Exception from `NotImplementedError` to `TypeError` since instantiating an abstract class raises a TypeError.