### PR TITLE
Corrected regex serialization for OpenAPI. 

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -554,6 +554,8 @@ class AutoSchema(ViewInspector):
             if isinstance(v, URLValidator):
                 schema['format'] = 'uri'
             if isinstance(v, RegexValidator):
+                # In Python, the token \Z does what \z does in other engines.
+                # https://stackoverflow.com/questions/53283160
                 schema['pattern'] = v.regex.pattern.replace('\\Z', '\\z')
             elif isinstance(v, MaxLengthValidator):
                 attr_name = 'maxLength'

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -554,7 +554,7 @@ class AutoSchema(ViewInspector):
             if isinstance(v, URLValidator):
                 schema['format'] = 'uri'
             if isinstance(v, RegexValidator):
-                schema['pattern'] = v.regex.pattern
+                schema['pattern'] = v.regex.pattern.replace('\\Z', '\\z')
             elif isinstance(v, MaxLengthValidator):
                 attr_name = 'maxLength'
                 if isinstance(field, serializers.ListField):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -13,6 +13,7 @@ from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.renderers import JSONRenderer, OpenAPIRenderer
 from rest_framework.request import Request
 from rest_framework.schemas.openapi import AutoSchema, SchemaGenerator
+
 from . import views
 
 

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -13,7 +13,6 @@ from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.renderers import JSONRenderer, OpenAPIRenderer
 from rest_framework.request import Request
 from rest_framework.schemas.openapi import AutoSchema, SchemaGenerator
-
 from . import views
 
 
@@ -855,6 +854,12 @@ class TestOperationIntrospection(TestCase):
         assert properties['url']['type'] == 'string'
         assert properties['url']['nullable'] is True
         assert properties['url']['default'] == 'http://www.example.com'
+        assert properties['url']['pattern'] == r"^(?:[a-z0-9\.\-\+]*)://(?:[^\s:@/]+(?::[^\s:@/]*)?@)?(?:(?:25[0-5]" \
+                                               r"|2[0-4]\d|[0-1]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}|" \
+                                               r"\[[0-9a-f:\.]+\]|([a-z¡-￿0-9](?:[a-z¡-￿0-9-]{0,61}[a-z¡-￿0-9])?" \
+                                               r"(?:\.(?!-)[a-z¡-￿0-9-]{1,63}(?<!-))*\.(?!-)(?:[a-z¡-￿-]{2,63}|" \
+                                               r"xn--[a-z0-9]{1,59})(?<!-)\.?|localhost))(?::\d{2,5})?(?:[/?#][^\s]*)" \
+                                               r"?\z"
 
         assert properties['uuid']['type'] == 'string'
         assert properties['uuid']['format'] == 'uuid'

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -854,12 +854,7 @@ class TestOperationIntrospection(TestCase):
         assert properties['url']['type'] == 'string'
         assert properties['url']['nullable'] is True
         assert properties['url']['default'] == 'http://www.example.com'
-        assert properties['url']['pattern'] == r"^(?:[a-z0-9\.\-\+]*)://(?:[^\s:@/]+(?::[^\s:@/]*)?@)?(?:(?:25[0-5]" \
-                                               r"|2[0-4]\d|[0-1]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}|" \
-                                               r"\[[0-9a-f:\.]+\]|([a-z¡-￿0-9](?:[a-z¡-￿0-9-]{0,61}[a-z¡-￿0-9])?" \
-                                               r"(?:\.(?!-)[a-z¡-￿0-9-]{1,63}(?<!-))*\.(?!-)(?:[a-z¡-￿-]{2,63}|" \
-                                               r"xn--[a-z0-9]{1,59})(?<!-)\.?|localhost))(?::\d{2,5})?(?:[/?#][^\s]*)" \
-                                               r"?\z"
+        assert '\\Z' not in properties['url']['pattern']
 
         assert properties['uuid']['type'] == 'string'
         assert properties['uuid']['format'] == 'uuid'


### PR DESCRIPTION
Fixes #7204

`\Z` is `\z` for non-python regex implementation. See: https://stackoverflow.com/questions/53283160/the-z-anchor-not-working-in-python-regex