### PR TITLE
set view.instance to object in detailview, like in [django]

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -97,6 +97,7 @@ class GenericAPIView(views.APIView):
 
         # May raise a permission denied
         self.check_object_permissions(self.request, obj)
+        self.instance = obj
 
         return obj
 


### PR DESCRIPTION
Add a feature. When the `get_object` is called and object return, Set the obj attribute to the view.
```
class GenericAPIView

    def get_object(self):
        ...
        self.instance = obj
        return obj
```

For example:  
You have an model named Progress:
```
Class Progress(models.Model):
    step = models.IntegerField()
    stepinfo0 = models.TextField()
    stepinfo1 = models.TextField()
```
If the progress is in step0, you can only change the stepinfo0 field. If the progress is in step1, you can only change the stepinfo1 field. 
So if the obj is set to the view, you can change the `get_serializer_class` directly like this:
```
class UpdateAPIView:
    def get_serializer_class(self):
        if self.instance.step == 0:
            return SerializerOnlyWithInfo0Field
        elif self.instance.step == 1:
            return SerializerOnlyWithInfo1Field
```

I think it is very convenient because [django use the kind of code](https://github.com/django/django/blob/master/django/views/generic/detail.py#L106) and I often use it in django view.