### PR TITLE
Not include charset when charset is None

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -179,9 +179,11 @@ class APIRequestFactory(DjangoRequestFactory):
             ret = renderer.render(data)
 
             # Determine the content-type header from the renderer
-            content_type = "{}; charset={}".format(
-                renderer.media_type, renderer.charset
-            )
+            content_type = renderer.media_type
+            if renderer.charset:
+                content_type = "{}; charset={}".format(
+                    content_type, renderer.charset
+                )
 
             # Coerce text to bytes if required.
             if isinstance(ret, str):


### PR DESCRIPTION
This occurred when APIClient was used in the test code.
When the charset of the renderer is None, such as JSONRender, we will receive `application/json; charset=None` as the content-type of the request.
So I modified not to include the charset in the content-type if the charset of the renderer is None. As a result of the modified code, the content-type can receive `application/json`.
