### PR TITLE
Update get_schema in docs

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -165,7 +165,7 @@ In order to customize the top-level schema, subclass
 as an argument to the `generateschema` command or `get_schema_view()` helper
 function.
 
-### get_schema(self, request)
+### get_schema(self, request=None, public=False)
 
 Returns a dictionary that represents the OpenAPI schema:
 


### PR DESCRIPTION

## Description

This solves an issue I ran into when following the docs to customize schema creation. You also have to add `public` when you subclass `SchemaGenerator`.
