### PR TITLE
'PrimaryKeySerializerField' introduced

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -265,6 +265,18 @@ class PrimaryKeyRelatedField(RelatedField):
         return value.pk
 
 
+class PrimaryKeySerializerField(PrimaryKeyRelatedField):
+    def __init__(self, serializer, **kwargs):
+        self.serializer = serializer
+        super().__init__(**kwargs)
+
+    def use_pk_only_optimization(self):
+        return False
+
+    def to_representation(self, instance):
+        return self.serializer(instance, context=self.context).data
+
+
 class HyperlinkedRelatedField(RelatedField):
     lookup_field = 'pk'
     view_name = None

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -57,7 +57,8 @@ from rest_framework.fields import (  # NOQA # isort:skip
 )
 from rest_framework.relations import (  # NOQA # isort:skip
     HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField,
-    PrimaryKeyRelatedField, RelatedField, SlugRelatedField, StringRelatedField,
+    PrimaryKeyRelatedField, PrimaryKeySerializerField, RelatedField, SlugRelatedField,
+    StringRelatedField,
 )
 
 # Non-field imports, but public API


### PR DESCRIPTION
Resolves [simple foreign key assignment with serializers #7414](https://github.com/encode/django-rest-framework/issues/7414) by adding new PK related serializer field.