### PR TITLE
Fix broken links in documenting API section

### DIFF
--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -209,8 +209,8 @@ To implement a hypermedia API you'll need to decide on an appropriate media type
 [cite]: https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven
 
 [hypermedia-docs]: rest-hypermedia-hateoas.md
-[metadata-docs]: ../api-guide/metadata/
-[schemas-examples]: ../api-guide/schemas/#examples
+[metadata-docs]: ../api-guide/metadata.md
+[schemas-examples]: ../api-guide/schemas.md#examples
 
 [image-drf-yasg]: ../img/drf-yasg.png
 [image-self-describing-api]: ../img/self-describing.png


### PR DESCRIPTION
## Description

The changed links were not working on the documentation site. I'm not 100% sure that these changes are correct but they generate working links in the GitHub previews.
