### PR TITLE
Update an example to not use oppressive language

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -243,19 +243,19 @@ Custom permissions will raise a `PermissionDenied` exception if the test fails. 
 
 ## Examples
 
-The following is an example of a permission class that checks the incoming request's IP address against a blocklist, and denies the request if the IP has been blocklisted.
+The following is an example of a permission class that checks the incoming request's IP address against a blocklist, and denies the request if the IP has been blocked.
 
     from rest_framework import permissions
 
     class BlocklistPermission(permissions.BasePermission):
         """
-        Global permission check for blocklisted IPs.
+        Global permission check for blocked IPs.
         """
 
         def has_permission(self, request, view):
             ip_addr = request.META['REMOTE_ADDR']
-            blocklisted = Blocklist.objects.filter(ip_addr=ip_addr).exists()
-            return not blocklisted
+            blocked = Blocklist.objects.filter(ip_addr=ip_addr).exists()
+            return not blocked
 
 As well as global permissions, that are run against all incoming requests, you can also create object-level permissions, that are only run against operations that affect a particular object instance.  For example:
 

--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -243,19 +243,19 @@ Custom permissions will raise a `PermissionDenied` exception if the test fails. 
 
 ## Examples
 
-The following is an example of a permission class that checks the incoming request's IP address against a blacklist, and denies the request if the IP has been blacklisted.
+The following is an example of a permission class that checks the incoming request's IP address against a blocklist, and denies the request if the IP has been blocklisted.
 
     from rest_framework import permissions
 
-    class BlacklistPermission(permissions.BasePermission):
+    class BlocklistPermission(permissions.BasePermission):
         """
-        Global permission check for blacklisted IPs.
+        Global permission check for blocklisted IPs.
         """
 
         def has_permission(self, request, view):
             ip_addr = request.META['REMOTE_ADDR']
-            blacklisted = Blacklist.objects.filter(ip_addr=ip_addr).exists()
-            return not blacklisted
+            blocklisted = Blocklist.objects.filter(ip_addr=ip_addr).exists()
+            return not blocklisted
 
 As well as global permissions, that are run against all incoming requests, you can also create object-level permissions, that are only run against operations that affect a particular object instance.  For example:
 


### PR DESCRIPTION
## Description

> Blacklist-whitelist is not a metaphor for lightness or darkness, it is a good-evil metaphor and therefore entirely based in racism.  This trope has significant impact on how people are seen and treated.

https://tools.ietf.org/id/draft-knodel-terminology-00.html
