### PR TITLE
Fix names of kwargs in docstring

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -143,9 +143,9 @@ class Request:
 
     Kwargs:
         - request(HttpRequest). The original request instance.
-        - parsers_classes(list/tuple). The parsers to use for parsing the
+        - parsers(list/tuple). The parsers to use for parsing the
           request content.
-        - authentication_classes(list/tuple). The authentications used to try
+        - authenticators(list/tuple). The authenticators used to try
           authenticating the request's user.
     """
 


### PR DESCRIPTION
The kwargs were renamed nearly 8 years ago in commit https://github.com/encode/django-rest-framework/commit/9d8bce8f5b0915223f57d9fe3d4b63029cfc64c2 but in the docstring.  Nobody ever noticed the mismatch.

There are also the newer (kw)args `negotiator` and `parser_context`.  Is it worth documenting them as well?