### PR TITLE
Pluralize list operations ending in "y" appropriately for OpenAPI schema generation

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -241,7 +241,10 @@ class AutoSchema(ViewInspector):
                 name = name[:-len(action)]
 
         if action == 'list' and not name.endswith('s'):  # listThings instead of listThing
-            name += 's'
+            if name.endswith('y'):
+                name = name[:-1] + 'ies'
+            else:
+                name += 's'
 
         return name
 

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -666,6 +666,21 @@ class TestOperationIntrospection(TestCase):
         operationId = inspector.get_operation_id(path, method)
         assert operationId == 'listUlysses'
 
+    def test_operation_id_ies_plural(self):
+        path = '/'
+        method = 'GET'
+
+        view = create_view(
+            views.ExampleGenericAPIView,
+            method,
+            create_request(path),
+        )
+        inspector = AutoSchema(operation_id_base='Entry')
+        inspector.view = view
+
+        operationId = inspector.get_operation_id(path, method)
+        assert operationId == 'listEntries'
+
     def test_operation_id_override_get(self):
         class CustomSchema(AutoSchema):
             def get_operation_id(self, path, method):


### PR DESCRIPTION
## Description

Words ending with "y" should have an "ies" plural form in English. I was debating including some sort of `pluralize` method, but it seems like we assume (for now) that English is being used, based on the default behavior with adding "s". I see that one could set `operation_id_base='Entrie'`, but it seems so commonplace to want to substitute the final "y" that I would argue it should be done automatically.