### PR TITLE
get_object_or_404: Catch OverflowError

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -17,7 +17,7 @@ def get_object_or_404(queryset, *filter_args, **filter_kwargs):
     """
     try:
         return _get_object_or_404(queryset, *filter_args, **filter_kwargs)
-    except (TypeError, ValueError, ValidationError):
+    except (OverflowError, TypeError, ValueError, ValidationError):
         raise Http404
 
 


### PR DESCRIPTION
`get_object_or_404`: Catch OverflowError

This is one of the larger sets of OverflowError that I am encountering.

Related to https://github.com/encode/django-rest-framework/issues/7448