### PR TITLE
[OpenAPI] Schemas Generator minor improvements

### DIFF
--- a/rest_framework/schemas/__init__.py
+++ b/rest_framework/schemas/__init__.py
@@ -32,7 +32,7 @@ def get_schema_view(
         public=False, patterns=None, generator_class=None,
         authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
         permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES,
-        version=None):
+        version=None, **kwargs):
     """
     Return a schema view.
     """
@@ -44,7 +44,7 @@ def get_schema_view(
 
     generator = generator_class(
         title=title, url=url, description=description,
-        urlconf=urlconf, patterns=patterns, version=version
+        urlconf=urlconf, patterns=patterns, version=version, **kwargs
     )
 
     # Avoid import cycle on APIView

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -151,7 +151,9 @@ class BaseSchemaGenerator:
     # Set by 'SCHEMA_COERCE_PATH_PK'.
     coerce_path_pk = None
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
+    def __init__(self, title=None, url=None, description=None,
+                 patterns=None, urlconf=None, version=None, **kwargs):
+
         if url and not url.endswith('/'):
             url += '/'
 
@@ -164,6 +166,9 @@ class BaseSchemaGenerator:
         self.version = version
         self.url = url
         self.endpoints = None
+
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
     def _initialise_endpoints(self):
         if self.endpoints is None:

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -113,9 +113,8 @@ class SchemaGenerator(BaseSchemaGenerator):
 
         return schema
 
+
 # View Inspectors
-
-
 class AutoSchema(ViewInspector):
 
     def __init__(self, tags=None, operation_id_base=None, component_name=None):
@@ -471,13 +470,15 @@ class AutoSchema(ViewInspector):
         if isinstance(field, serializers.FloatField):
             content = {
                 'type': 'number',
+                'format': 'float'
             }
             self._map_min_max(field, content)
             return content
 
         if isinstance(field, serializers.IntegerField):
             content = {
-                'type': 'integer'
+                'type': 'integer',
+                'format': 'int64'
             }
             self._map_min_max(field, content)
             # 2147483647 is max for int32_size, so we use int64 for format

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -54,7 +54,7 @@ class TestFieldMapping(TestCase):
         cases = [
             (serializers.ListField(), {'items': {}, 'type': 'array'}),
             (serializers.ListField(child=serializers.BooleanField()), {'items': {'type': 'boolean'}, 'type': 'array'}),
-            (serializers.ListField(child=serializers.FloatField()), {'items': {'type': 'number'}, 'type': 'array'}),
+            (serializers.ListField(child=serializers.FloatField()), {'items': {'type': 'number', 'format': 'float'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.CharField()), {'items': {'type': 'string'}, 'type': 'array'}),
             (serializers.ListField(child=serializers.IntegerField(max_value=4294967295)),
              {'items': {'type': 'integer', 'maximum': 4294967295, 'format': 'int64'}, 'type': 'array'}),


### PR DESCRIPTION
This PR would introduce a better generalization for third-party integrations.
SchemaGenerator now handles `**kwargs` to permit the initialization of variables like `x-api-id`. These, if not passed as key dict would raises SyntaxError because of the kebab-case. 

It also introduce type format for number and integer.

A reference about the born of this PR is here:
https://github.com/encode/django-rest-framework/pull/7457