### PR TITLE
[OAS3] Schemas Generator minor improvements

### DIFF
--- a/rest_framework/schemas/__init__.py
+++ b/rest_framework/schemas/__init__.py
@@ -32,7 +32,7 @@ def get_schema_view(
         public=False, patterns=None, generator_class=None,
         authentication_classes=api_settings.DEFAULT_AUTHENTICATION_CLASSES,
         permission_classes=api_settings.DEFAULT_PERMISSION_CLASSES,
-        version=None):
+        version=None, **kwargs):
     """
     Return a schema view.
     """
@@ -44,7 +44,7 @@ def get_schema_view(
 
     generator = generator_class(
         title=title, url=url, description=description,
-        urlconf=urlconf, patterns=patterns, version=version
+        urlconf=urlconf, patterns=patterns, version=version, **kwargs
     )
 
     # Avoid import cycle on APIView

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -151,7 +151,9 @@ class BaseSchemaGenerator:
     # Set by 'SCHEMA_COERCE_PATH_PK'.
     coerce_path_pk = None
 
-    def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
+    def __init__(self, title=None, url=None, description=None,
+                 patterns=None, urlconf=None, version=None, **kwargs):
+
         if url and not url.endswith('/'):
             url += '/'
 
@@ -164,6 +166,9 @@ class BaseSchemaGenerator:
         self.version = version
         self.url = url
         self.endpoints = None
+
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
     def _initialise_endpoints(self):
         if self.endpoints is None:

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -113,9 +113,8 @@ class SchemaGenerator(BaseSchemaGenerator):
 
         return schema
 
+
 # View Inspectors
-
-
 class AutoSchema(ViewInspector):
 
     def __init__(self, tags=None, operation_id_base=None, component_name=None):


### PR DESCRIPTION
Better generalization for third-party integrations.

Added **kwargs in schema contructors and related callables that initialize it.
The goal: have a better generalization for third-party schema generators that would need more arguments in BaseGenerator. __init__

Derived from this:
https://github.com/encode/django-rest-framework/pull/7461