### PR TITLE
Add support for Django 3.1 JSONField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1758,6 +1758,7 @@ class JSONField(Field):
     def __init__(self, *args, **kwargs):
         self.binary = kwargs.pop('binary', False)
         self.encoder = kwargs.pop('encoder', None)
+        self.decoder = kwargs.pop('decoder', None)
         super().__init__(*args, **kwargs)
 
     def get_value(self, dictionary):
@@ -1777,7 +1778,7 @@ class JSONField(Field):
             if self.binary or getattr(data, 'is_json_string', False):
                 if isinstance(data, bytes):
                     data = data.decode()
-                return json.loads(data)
+                return json.loads(data, cls=self.decoder)
             else:
                 json.dumps(data, cls=self.encoder)
         except (TypeError, ValueError):

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -92,7 +92,8 @@ def get_field_kwargs(field_name, model_field):
         kwargs['allow_unicode'] = model_field.allow_unicode
 
     if isinstance(model_field, models.TextField) and not model_field.choices or \
-            (postgres_fields and isinstance(model_field, postgres_fields.JSONField)):
+            (postgres_fields and isinstance(model_field, postgres_fields.JSONField)) or \
+            (hasattr(models, 'JSONField') and isinstance(model_field, models.JSONField)):
         kwargs['style'] = {'base_template': 'textarea.html'}
 
     if isinstance(model_field, models.AutoField) or not model_field.editable:


### PR DESCRIPTION
## Description

Django 3.1 adds a new generic JSONField to replace the PostgreSQL-specific one. This adds support for the new field type, which should behave the same as the existing PostgreSQL field.

Fixes #7466 
