### PR TITLE
Don't catch exceptions in get_queryset

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -252,8 +252,9 @@ class PrimaryKeyRelatedField(RelatedField):
     def to_internal_value(self, data):
         if self.pk_field is not None:
             data = self.pk_field.to_internal_value(data)
+        queryset = self.get_queryset()
         try:
-            return self.get_queryset().get(pk=data)
+            return queryset.get(pk=data)
         except ObjectDoesNotExist:
             self.fail('does_not_exist', pk_value=data)
         except (TypeError, ValueError):
@@ -449,8 +450,9 @@ class SlugRelatedField(RelatedField):
         super().__init__(**kwargs)
 
     def to_internal_value(self, data):
+        queryset = self.get_queryset()
         try:
-            return self.get_queryset().get(**{self.slug_field: data})
+            return queryset.get(**{self.slug_field: data})
         except ObjectDoesNotExist:
             self.fail('does_not_exist', slug_name=self.slug_field, value=smart_str(data))
         except (TypeError, ValueError):


### PR DESCRIPTION
In the `to_internal_value` method of the primary key and slug related fields, `TypeError`s and `ValueError`s are caught from `self.get_queryset().get(...)` and presented to the user. This works fine for most cases, but can cause problems if the exception is coming from `self.get_queryset()` rather than from the `.get(...)`.

It means errors in the `get_queryset` method can be hidden and presented back to the user as though, for example, the input provided to the `to_internal_value` was the wrong type, whereas in reality there's a bug in the `get_queryset` method and therefore it should bubble up and be exposed as a server error.

I've decided to fix this because twice now I've had to debug why I'm seeing `invalid_type` errors from my serializer (errors like `wrong pk type - int` when the `pk` type on my model is `int`) when the real problem was a bug in my custom `get_queryset` method.