### PR TITLE
default_app_config application variable is deprecated in Django 3.2

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -7,6 +7,8 @@ ______ _____ _____ _____    __
 \_| \_\____/\____/  \_/   |_| |_|  \__,_|_| |_| |_|\___| \_/\_/ \___/|_|  |_|\_|
 """
 
+import django
+
 __title__ = 'Django REST framework'
 __version__ = '3.11.0'
 __author__ = 'Tom Christie'
@@ -22,7 +24,9 @@ HTTP_HEADER_ENCODING = 'iso-8859-1'
 # Default datetime input and output formats
 ISO_8601 = 'iso-8601'
 
-default_app_config = 'rest_framework.apps.RestFrameworkConfig'
+
+if django.VERSION < (3, 2):
+    default_app_config = 'rest_framework.apps.RestFrameworkConfig'
 
 
 class RemovedInDRF313Warning(DeprecationWarning):

--- a/rest_framework/authtoken/__init__.py
+++ b/rest_framework/authtoken/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'rest_framework.authtoken.apps.AuthTokenConfig'
+import django
+
+if django.VERSION < (3, 2):
+    default_app_config = 'rest_framework.authtoken.apps.AuthTokenConfig'


### PR DESCRIPTION
`default_app_config` is deprecated in Django 3.2. 

https://code.djangoproject.com/ticket/31180
