### PR TITLE
Fix typo (accros -> across)

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -50,7 +50,7 @@ class SchemaGenerator(BaseSchemaGenerator):
                         'You have a duplicated operationId in your OpenAPI schema: {operation_id}\n'
                         '\tRoute: {route1}, Method: {method1}\n'
                         '\tRoute: {route2}, Method: {method2}\n'
-                        '\tAn operationId has to be unique accros your schema. Your schema may not work in other tools.'
+                        '\tAn operationId has to be unique across your schema. Your schema may not work in other tools.'
                         .format(
                             route1=ids[operation_id]['route'],
                             method1=ids[operation_id]['method'],


### PR DESCRIPTION
Perhaps the most useless PR ever, but I ran into this error as I was migrating to the new OpenAPI stuff as part of a Django 3 migration and figured I'd upstream the changes :) 