### PR TITLE
url()'s were replaced by path() and re_path()

### DIFF
--- a/rest_framework/documentation.py
+++ b/rest_framework/documentation.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from rest_framework.renderers import (
     CoreJSONRenderer, DocumentationRenderer, SchemaJSRenderer
@@ -82,7 +82,7 @@ def include_docs_urls(
         permission_classes=permission_classes,
     )
     urls = [
-        url(r'^$', docs_view, name='docs-index'),
-        url(r'^schema.js$', schema_js_view, name='schema-js')
+        path('', docs_view, name='docs-index'),
+        path('schema.js', schema_js_view, name='schema-js')
     ]
     return include((urls, 'api-docs'), namespace='api-docs')

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -16,9 +16,8 @@ For example, you might have a `urls.py` that looks something like this:
 import itertools
 from collections import OrderedDict, namedtuple
 
-from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import NoReverseMatch
+from django.urls import NoReverseMatch, re_path
 
 from rest_framework import views
 from rest_framework.response import Response
@@ -265,7 +264,7 @@ class SimpleRouter(BaseRouter):
 
                 view = viewset.as_view(mapping, **initkwargs)
                 name = route.name.format(basename=basename)
-                ret.append(url(regex, view, name=name))
+                ret.append(re_path(regex, view, name=name))
 
         return ret
 
@@ -340,7 +339,7 @@ class DefaultRouter(SimpleRouter):
 
         if self.include_root_view:
             view = self.get_api_root_view(api_urls=urls)
-            root_url = url(r'^$', view, name=self.root_view_name)
+            root_url = re_path(r'^$', view, name=self.root_view_name)
             urls.append(root_url)
 
         if self.include_format_suffixes:

--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -1,5 +1,5 @@
-from django.conf.urls import include, url
-from django.urls import URLResolver, path, register_converter
+from django.conf.urls import include
+from django.urls import URLResolver, path, re_path, register_converter
 from django.urls.resolvers import RoutePattern
 
 from rest_framework.settings import api_settings
@@ -52,7 +52,7 @@ def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required, suffix_r
                 route = str(urlpattern.pattern)
                 new_pattern = path(route, include((patterns, app_name), namespace), kwargs)
             else:
-                new_pattern = url(regex, include((patterns, app_name), namespace), kwargs)
+                new_pattern = re_path(regex, include((patterns, app_name), namespace), kwargs)
 
             ret.append(new_pattern)
         else:
@@ -72,7 +72,7 @@ def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required, suffix_r
                 route = str(urlpattern.pattern).rstrip('$').rstrip('/') + suffix_route
                 new_pattern = path(route, view, kwargs, name)
             else:
-                new_pattern = url(regex, view, kwargs, name)
+                new_pattern = re_path(regex, view, kwargs, name)
 
             ret.append(new_pattern)
 

--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import URLResolver, path, re_path, register_converter
+from django.urls import URLResolver, include, path, re_path, register_converter
 from django.urls.resolvers import RoutePattern
 
 from rest_framework.settings import api_settings

--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -11,11 +11,11 @@ your API requires authentication:
 
 You should make sure your authentication settings include `SessionAuthentication`.
 """
-from django.conf.urls import url
 from django.contrib.auth import views
+from django.urls import path
 
 app_name = 'rest_framework'
 urlpatterns = [
-    url(r'^login/$', views.LoginView.as_view(template_name='rest_framework/login.html'), name='login'),
-    url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
+    path('login/', views.LoginView.as_view(template_name='rest_framework/login.html'), name='login'),
+    path('logout/', views.LogoutView.as_view(), name='logout'),
 ]


### PR DESCRIPTION
Hello, world! Please do not judge strictly, if i made a mistake. It is my first contribution to Open-source.
## Description
url() deprecated since version 3.1:
Alias of django.urls.re_path() for backwards compatibility.