### PR TITLE
Change Token.generate_key to a Classmethod

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -32,6 +32,7 @@ class Token(models.Model):
             self.key = self.generate_key()
         return super().save(*args, **kwargs)
 
+    @classmethod
     def generate_key(self):
         return binascii.hexlify(os.urandom(20)).decode()
 

--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -33,7 +33,7 @@ class Token(models.Model):
         return super().save(*args, **kwargs)
 
     @classmethod
-    def generate_key(self):
+    def generate_key(cls):
         return binascii.hexlify(os.urandom(20)).decode()
 
     def __str__(self):

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -397,6 +397,10 @@ class TokenAuthTests(BaseTokenAuthTests, TestCase):
         key = token.generate_key()
         assert isinstance(key, str)
 
+    def test_generate_key_accessible_as_classmethod(self):
+        key = self.model.generate_key()
+        assert isinstance(key, str)
+
     def test_token_login_json(self):
         """Ensure token login view using JSON POST works."""
         client = APIClient(enforce_csrf_checks=True)


### PR DESCRIPTION
## Description

Simply adds a classmethod wrapper to Token.generate_key so that it can be called when the `save` method isn't (bulk_create, etc.)

Additionally adds a test to prove that access as a class method works without breaking access from self.

References https://github.com/encode/django-rest-framework/issues/7501
