### PR TITLE
Openapi one component per serializer

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -512,7 +512,7 @@ class AutoSchema(ViewInspector):
         properties = {}
 
         try:
-            return serializer.get_object_openapi_schema()
+            return serializer.get_object_openapi_schema(autoschema=self)
         except AttributeError:
             pass
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -511,6 +511,11 @@ class AutoSchema(ViewInspector):
         required = []
         properties = {}
 
+        try:
+            return serializer.get_object_openapi_schema()
+        except AttributeError:
+            pass
+
         for field in serializer.fields.values():
             if isinstance(field, serializers.HiddenField):
                 continue

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -360,10 +360,11 @@ class AutoSchema(ViewInspector):
 
         # Nested Serializers, `many` or not.
         if isinstance(field, serializers.ListSerializer):
+            ref, components = self.map_serializer(field.child)
             return {
                 'type': 'array',
-                'items': self.map_serializer(field.child)
-            }, {}
+                'items': ref
+            }, components
         if isinstance(field, serializers.Serializer):
             data, components = self.map_serializer(field)
             return data, components

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -512,11 +512,6 @@ class AutoSchema(ViewInspector):
         required = []
         properties = {}
 
-        try:
-            return serializer.get_object_openapi_schema(autoschema=self)
-        except AttributeError:
-            pass
-
         component_name = self.get_component_name(serializer)
         components = {}
 


### PR DESCRIPTION
As of now the open api generator makes one component per endpoint. For nested serializers this component becomes very large and nested. This PR proposes a method so that a openapi component is generated for each serializer. 
