### PR TITLE
Adding `params` to ErrorDetails

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -93,10 +93,10 @@ class ErrorDetail(str):
     def __repr__(self):
         if self.params:
             return 'ErrorDetail(string=%r, code=%r, params=%s)' % (
-            str(self),
-            self.code,
-            self.params
-        )
+                str(self),
+                self.code,
+                self.params
+            )
 
         return 'ErrorDetail(string=%r, code=%r)' % (
             str(self),

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -91,12 +91,17 @@ class ErrorDetail(str):
         return not self.__eq__(other)
 
     def __repr__(self):
-        base = 'ErrorDetail(string=%r, code=%r' % (
+        if self.params:
+            return 'ErrorDetail(string=%r, code=%r, params=%s)' % (
+            str(self),
+            self.code,
+            self.params
+        )
+
+        return 'ErrorDetail(string=%r, code=%r)' % (
             str(self),
             self.code,
         )
-
-        return base + ', params=%r)' % self.params if self.params else base + ')'
 
     def __hash__(self):
         return hash(str(self))

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -236,12 +236,14 @@ def get_error_detail(exc_info):
     except AttributeError:
         return [
             ErrorDetail((error.message % error.params) if error.params else error.message,
-                        code=error.code if error.code else code)
+                        code=error.code if error.code else code,
+                        params=error.params)
             for error in exc_info.error_list]
     return {
         k: [
             ErrorDetail((error.message % error.params) if error.params else error.message,
-                        code=error.code if error.code else code)
+                        code=error.code if error.code else code,
+                        params=error.params)
             for error in errors
         ] for k, errors in error_dict.items()
     }
@@ -599,6 +601,7 @@ class Field:
                     raise
                 errors.extend(exc.detail)
             except DjangoValidationError as exc:
+                print("YOOOOOOOOOO", exc, exc.code, exc.params)
                 errors.extend(get_error_detail(exc))
         if errors:
             raise ValidationError(errors)

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -601,7 +601,6 @@ class Field:
                     raise
                 errors.extend(exc.detail)
             except DjangoValidationError as exc:
-                print("YOOOOOOOOOO", exc, exc.code, exc.params)
                 errors.extend(get_error_detail(exc))
         if errors:
             raise ValidationError(errors)

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -12,17 +12,17 @@ factory = APIRequestFactory()
 
 class ExampleSerializer(serializers.Serializer):
     char = serializers.CharField()
-    integer = serializers.IntegerField()
+    integer = serializers.IntegerField(min_value=1, required=False)
 
 
 class ErrorView(APIView):
     def get(self, request, *args, **kwargs):
-        ExampleSerializer(data={}).is_valid(raise_exception=True)
+        ExampleSerializer(data={"integer": 0}).is_valid(raise_exception=True)
 
 
 @api_view(['GET'])
 def error_view(request):
-    ExampleSerializer(data={}).is_valid(raise_exception=True)
+    ExampleSerializer(data={"integer": 0}).is_valid(raise_exception=True)
 
 
 class TestValidationErrorWithFullDetails(TestCase):
@@ -41,8 +41,13 @@ class TestValidationErrorWithFullDetails(TestCase):
                 'code': 'required',
             }],
             'integer': [{
-                'message': 'This field is required.',
-                'code': 'required'
+                'message': 'Ensure this value is greater than or equal to 1.',
+                'code': 'min_value',
+                'params': {
+                    'limit_value': 1,
+                    'show_value': 0,
+                    'value': 0
+                }
             }],
         }
 
@@ -78,7 +83,7 @@ class TestValidationErrorWithCodes(TestCase):
 
         self.expected_response_data = {
             'char': ['required'],
-            'integer': ['required'],
+            'integer': ['min_value'],
         }
 
     def tearDown(self):


### PR DESCRIPTION
When throwing a ValidationError, it'd be nice to return Exception's [parameters](https://github.com/django/django/blob/master/django/core/exceptions.py#L121) details to allow "consumer" customized error display.

Current implementation adapted in `test_validation_error.py`


