### PR TITLE
add OAS securitySchemes and security objects

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -389,6 +389,26 @@ differentiate between request and response objects.
 By default returns `get_serializer()` but can be overridden to
 differentiate between request and response objects.
 
+#### `get_security_schemes()`
+
+Generates the OpenAPI `securitySchemes` components based on:
+- Your default `authentication_classes` (`settings.DEFAULT_AUTHENTICATION_CLASSES`)
+- Per-view non-default `authentication_classes`
+
+These are generated using the authentication classes' `openapi_security_scheme()` class method. If you
+extend `BaseAuthentication` with your own authentication class, you can add this class method to return
+the appropriate security scheme object.
+
+#### `get_security_requirements()`
+
+Root-level security requirements (the top-level `security` object) are generated based on the
+default authentication classes.  Operation-level security requirements are generated only if the given view's 
+`authentication_classes` differ from the defaults. 
+
+These are generated using the authentication classes' `openapi_security_requirement()` class
+method. If you extended `BaseAuthentication` with your own authentication class, you can add this
+class method to return the appropriate list of security requirements objects.
+
 ### `AutoSchema.__init__()` kwargs
 
 `AutoSchema` provides a number of `__init__()` kwargs that can be used for


### PR DESCRIPTION
## Description

adds openapi `securitySchemes` component and `security` objects both root level and to operations if needed.

For example: 
```yaml
components:
  ...
  securitySchemes:
    basicAuth:
      type: http
      scheme: basic
      description: Basic Authentication
    sessionAuth:
      type: apiKey
      in: cookie
      name: JSESSIONID
      description: Session authentication

...
paths:
  /v1/courses/:
    get:
      operationId: List/v1/courses/
      description: A course of instruction. e.g. COMSW1002 Computing in Context
      security:
      - basicAuth: []
      - sessionAuth: []
```

Adds two new classmethods to authentication:
- openapi_security_scheme: returns an OAS securityScheme object
- openapi_security_requirement: returns an OAS security requirements object

The logic behind doing it this way is that anyone that extends `BaseAuthentication` will be able to add their own OAS securitySchemes and security objects, for example, for OAuth 2.0 in [django-oauth-toolkit's TokenMatchesOASRequirements()](https://django-oauth-toolkit.readthedocs.io/en/latest/rest-framework/permissions.html#tokenmatchesoasrequirements)...

Tests and documentation still need updating but I wanted to get feedback on the general approach before proceeding.