### PR TITLE
Run tests against Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
       - { python: "3.8", env: DJANGO=3.1 }
       - { python: "3.8", env: DJANGO=master }
 
+      - { python: "3.9-dev", env: DJANGO=3.1 }
+      - { python: "3.9-dev", env: DJANGO=master }
+
       - { python: "3.8", env: TOXENV=base }
       - { python: "3.8", env: TOXENV=lint }
       - { python: "3.8", env: TOXENV=docs }

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ There is a live example API for testing purposes, [available here][sandbox].
 
 # Requirements
 
-* Python (3.5, 3.6, 3.7, 3.8)
-* Django (2.2, 3.0)
+* Python (3.5, 3.6, 3.7, 3.8, 3.9)
+* Django (2.2, 3.0, 3.1)
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,8 +83,8 @@ continued development by **[signing up for a paid plan][funding]**.
 
 REST framework requires the following:
 
-* Python (3.5, 3.6, 3.7, 3.8)
-* Django (2.2, 3.0)
+* Python (3.5, 3.6, 3.7, 3.8, 3.9)
+* Django (2.2, 3.0, 3.1)
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
        {py35,py36,py37}-django22,
        {py36,py37,py38}-django30,
-       {py36,py37,py38}-django31,
-       {py36,py37,py38}-djangomaster,
+       {py36,py37,py38,py39}-django31,
+       {py36,py37,py38,py39}-djangomaster,
        base,dist,lint,docs,
 
 [travis:env]
@@ -22,7 +22,7 @@ setenv =
 deps =
         django22: Django>=2.2,<3.0
         django30: Django>=3.0,<3.1
-        django31: Django>=3.1a1,<3.2
+        django31: Django>=3.1,<3.2
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
Run test against Python 3.9, mention compatibility and also add the trove classifier. Also mention Django 3.1 compatibility where missing.

3.9.0 final is [expected](https://www.python.org/dev/peps/pep-0596/#schedule) on Monday, 2020-10-05.  I'm pretty sure that Django 3.1 will gain Python 3.9 compatibility because the same thing happened for [Django 2.2 and Python 3.8](https://docs.djangoproject.com/en/3.1/releases/2.2/#python-compatibility).

I've no idea if Django 2.2 (the current LTS release) will gain Python 3.9 compatibility.  But I think it's unlikely that someone running an LTS release will switch to Python 3.9 soon. :shrug: 

Issue for Python 3.9 compatibility in Django: https://code.djangoproject.com/ticket/31040
