### PR TITLE
Bump flake8 to 3.8.3

### DIFF
--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,7 +1,7 @@
 # PEP8 code linting, which we run on all commits.
-flake8==3.7.9
+flake8==3.8.3
 flake8-tidy-imports==4.1.0
-pycodestyle==2.5.0
+pycodestyle==2.6.0
 
 # Sort and lint imports
 isort==5.4.2

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -856,8 +856,8 @@ class DocumentationRenderer(BaseRenderer):
         return {
             'document': data,
             'langs': self.languages,
-            'lang_htmls': ["rest_framework/docs/langs/%s.html" % l for l in self.languages],
-            'lang_intro_htmls': ["rest_framework/docs/langs/%s-intro.html" % l for l in self.languages],
+            'lang_htmls': ["rest_framework/docs/langs/%s.html" % language for language in self.languages],
+            'lang_intro_htmls': ["rest_framework/docs/langs/%s-intro.html" % language for language in self.languages],
             'code_style': pygments_css(self.code_style),
             'request': request
         }

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -58,7 +58,6 @@ def get_detail_view_name(model):
     that refer to instances of the model.
     """
     return '%(model_name)s-detail' % {
-        'app_label': model._meta.app_label,
         'model_name': model._meta.object_name.lower()
     }
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -669,7 +669,7 @@ class TestBooleanField(FieldValues):
         for input_value in inputs:
             with pytest.raises(serializers.ValidationError) as exc_info:
                 field.run_validation(input_value)
-            expected = ['Must be a valid boolean.'.format(input_value)]
+            expected = ['Must be a valid boolean.']
             assert exc_info.value.detail == expected
 
 


### PR DESCRIPTION
This pull request increases `flake8` to version 3.8.3, and `pycodestyle` to 2.6.0. 

The new version of `flake8` raises a few new errors which I've also fixed. 