### PR TITLE
Updated tests -- Django 2.2 is minimum supported version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,22 +67,19 @@ def pytest_configure(config):
     )
 
     # guardian is optional
-    # Note that for the test cases we're installing a version of django-guardian
-    # that's only compatible with Django 2.0+.
-    if django.VERSION >= (2, 0, 0):
-        try:
-            import guardian  # NOQA
-        except ImportError:
-            pass
-        else:
-            settings.ANONYMOUS_USER_ID = -1
-            settings.AUTHENTICATION_BACKENDS = (
-                'django.contrib.auth.backends.ModelBackend',
-                'guardian.backends.ObjectPermissionBackend',
-            )
-            settings.INSTALLED_APPS += (
-                'guardian',
-            )
+    try:
+        import guardian  # NOQA
+    except ImportError:
+        pass
+    else:
+        settings.ANONYMOUS_USER_ID = -1
+        settings.AUTHENTICATION_BACKENDS = (
+            'django.contrib.auth.backends.ModelBackend',
+            'guardian.backends.ObjectPermissionBackend',
+        )
+        settings.INSTALLED_APPS += (
+            'guardian',
+        )
 
     if config.getoption('--no-pkgroot'):
         sys.path.pop(0)

--- a/tests/schemas/test_coreapi.py
+++ b/tests/schemas/test_coreapi.py
@@ -456,7 +456,6 @@ class TestSchemaGenerator(TestCase):
 
 
 @unittest.skipUnless(coreapi, 'coreapi is not installed')
-@unittest.skipUnless(path, 'needs Django 2')
 @override_settings(REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.AutoSchema'})
 class TestSchemaGeneratorDjango2(TestCase):
     def setUp(self):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -12,7 +12,6 @@ import sys
 import tempfile
 from collections import OrderedDict
 
-import django
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
@@ -63,7 +62,7 @@ class RegularFieldsModel(models.Model):
     email_field = models.EmailField(max_length=100)
     float_field = models.FloatField()
     integer_field = models.IntegerField()
-    null_boolean_field = models.NullBooleanField()
+    null_boolean_field = models.BooleanField(null=True, default=False)
     positive_integer_field = models.PositiveIntegerField()
     positive_small_integer_field = models.PositiveSmallIntegerField()
     slug_field = models.SlugField(max_length=100)
@@ -217,25 +216,6 @@ class TestRegularFieldMappings(TestCase):
                 text_choices_field = ChoiceField(choices=(('red', 'Red'), ('blue', 'Blue'), ('green', 'Green')))
         """)
         self.assertEqual(repr(TestSerializer()), expected)
-
-    # merge this into test_regular_fields / RegularFieldsModel when
-    # Django 2.1 is the minimum supported version
-    @pytest.mark.skipif(django.VERSION < (2, 1), reason='Django version < 2.1')
-    def test_nullable_boolean_field(self):
-        class NullableBooleanModel(models.Model):
-            field = models.BooleanField(null=True, default=False)
-
-        class NullableBooleanSerializer(serializers.ModelSerializer):
-            class Meta:
-                model = NullableBooleanModel
-                fields = ['field']
-
-        expected = dedent("""
-            NullableBooleanSerializer():
-                field = BooleanField(allow_null=True, required=False)
-        """)
-
-        self.assertEqual(repr(NullableBooleanSerializer()), expected)
 
     def test_nullable_boolean_field_choices(self):
         class NullableBooleanChoicesModel(models.Model):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -2,7 +2,6 @@ import base64
 import unittest
 from unittest import mock
 
-import django
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Group, Permission, User
 from django.db import models
@@ -247,12 +246,6 @@ class BasicPermModel(models.Model):
 
     class Meta:
         app_label = 'tests'
-
-        if django.VERSION < (2, 1):
-            permissions = (
-                ('view_basicpermmodel', 'Can view basic perm model'),
-                # add, change, delete built in to django
-            )
 
 
 class BasicPermSerializer(serializers.ModelSerializer):

--- a/tests/test_urlpatterns.py
+++ b/tests/test_urlpatterns.py
@@ -1,4 +1,3 @@
-import unittest
 from collections import namedtuple
 
 from django.conf.urls import include, url
@@ -66,7 +65,6 @@ class FormatSuffixTests(TestCase):
         ]
         self._test_trailing_slash(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_trailing_slash_django2(self):
         urlpatterns = [
             path('test/', dummy_view),
@@ -87,14 +85,12 @@ class FormatSuffixTests(TestCase):
         ]
         self._test_format_suffix(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_format_suffix_django2(self):
         urlpatterns = [
             path('test', dummy_view),
         ]
         self._test_format_suffix(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_format_suffix_django2_args(self):
         urlpatterns = [
             path('convtest/<int:pk>', dummy_view),
@@ -124,7 +120,6 @@ class FormatSuffixTests(TestCase):
         ]
         self._test_default_args(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_default_args_django2(self):
         urlpatterns = [
             path('test', dummy_view, {'foo': 'bar'}),
@@ -148,7 +143,6 @@ class FormatSuffixTests(TestCase):
         ]
         self._test_included_urls(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_included_urls_django2(self):
         nested_patterns = [
             path('path', dummy_view)
@@ -158,7 +152,6 @@ class FormatSuffixTests(TestCase):
         ]
         self._test_included_urls(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_included_urls_django2_mixed(self):
         nested_patterns = [
             path('path', dummy_view)
@@ -168,7 +161,6 @@ class FormatSuffixTests(TestCase):
         ]
         self._test_included_urls(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_included_urls_django2_mixed_args(self):
         nested_patterns = [
             path('path/<int:child>', dummy_view),
@@ -216,7 +208,6 @@ class FormatSuffixTests(TestCase):
         ]
         self._test_allowed_formats(urlpatterns)
 
-    @unittest.skipUnless(path, 'needs Django 2')
     def test_allowed_formats_django2(self):
         urlpatterns = [
             path('test', dummy_view),


### PR DESCRIPTION
This PR removes elements in the test suite which enabled compatibility with Django versions lower than 2.2.