### PR TITLE
Remove unnecessary type conversions

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -80,7 +80,7 @@ def _get_displayed_page_numbers(current, final):
 
     # Now sort the page numbers and drop anything outside the limits.
     included = [
-        idx for idx in sorted(list(included))
+        idx for idx in sorted(included)
         if 0 < idx <= final
     ]
 

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -329,7 +329,7 @@ class HTMLFormRenderer(BaseRenderer):
         if isinstance(field._field, serializers.HiddenField):
             return ''
 
-        style = dict(self.default_style[field])
+        style = self.default_style[field].copy()
         style.update(field.style)
         if 'template_pack' not in style:
             style['template_pack'] = parent_style.get('template_pack', self.template_pack)

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -194,10 +194,7 @@ class BaseSerializer(Field):
             "inspect 'serializer.validated_data' instead. "
         )
 
-        validated_data = dict(
-            list(self.validated_data.items()) +
-            list(kwargs.items())
-        )
+        validated_data = {**self.validated_data, **kwargs}
 
         if self.instance is not None:
             self.instance = self.update(self.instance, validated_data)
@@ -699,8 +696,7 @@ class ListSerializer(BaseSerializer):
         )
 
         validated_data = [
-            dict(list(attrs.items()) + list(kwargs.items()))
-            for attrs in self.validated_data
+            {**attrs, **kwargs} for attrs in self.validated_data
         ]
 
         if self.instance is not None:
@@ -1410,7 +1406,7 @@ class ModelSerializer(Serializer):
         # so long as all the field names are included on the serializer.
         for parent_class in [model] + list(model._meta.parents):
             for unique_together_list in parent_class._meta.unique_together:
-                if set(field_names).issuperset(set(unique_together_list)):
+                if set(field_names).issuperset(unique_together_list):
                     unique_constraint_names |= set(unique_together_list)
 
         # Now we have all the field names that have uniqueness constraints
@@ -1541,7 +1537,7 @@ class ModelSerializer(Serializer):
         for parent_class in model_class_inheritance_tree:
             for unique_together in parent_class._meta.unique_together:
                 # Skip if serializer does not map to all unique together sources
-                if not set(source_map).issuperset(set(unique_together)):
+                if not set(source_map).issuperset(unique_together):
                     continue
 
                 for source in unique_together:

--- a/rest_framework/utils/urls.py
+++ b/rest_framework/utils/urls.py
@@ -11,7 +11,7 @@ def replace_query_param(url, key, val):
     (scheme, netloc, path, query, fragment) = parse.urlsplit(force_str(url))
     query_dict = parse.parse_qs(query, keep_blank_values=True)
     query_dict[force_str(key)] = [force_str(val)]
-    query = parse.urlencode(sorted(list(query_dict.items())), doseq=True)
+    query = parse.urlencode(sorted(query_dict.items()), doseq=True)
     return parse.urlunsplit((scheme, netloc, path, query, fragment))
 
 
@@ -23,5 +23,5 @@ def remove_query_param(url, key):
     (scheme, netloc, path, query, fragment) = parse.urlsplit(force_str(url))
     query_dict = parse.parse_qs(query, keep_blank_values=True)
     query_dict.pop(key, None)
-    query = parse.urlencode(sorted(list(query_dict.items())), doseq=True)
+    query = parse.urlencode(sorted(query_dict.items()), doseq=True)
     return parse.urlunsplit((scheme, netloc, path, query, fragment))


### PR DESCRIPTION
Since 3.5, it's possible to merge dictionaries with the `**` syntax.
When Python 3.9 is the minimum supported version (2024), we'll be able to do `validated_data = self.validated_data | kwargs `.