### PR TITLE
Fixes `BrowsableAPIRenderer` for usage with `ListSerializer`.

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -506,6 +506,9 @@ class BrowsableAPIRenderer(BaseRenderer):
             return self.render_form_for_serializer(serializer)
 
     def render_form_for_serializer(self, serializer):
+        if isinstance(serializer, serializers.ListSerializer):
+            return None
+
         if hasattr(serializer, 'initial_data'):
             serializer.is_valid()
 
@@ -555,10 +558,13 @@ class BrowsableAPIRenderer(BaseRenderer):
                 context['indent'] = 4
 
                 # strip HiddenField from output
+                is_list_serializer = isinstance(serializer, serializers.ListSerializer)
+                serializer = serializer.child if is_list_serializer else serializer
                 data = serializer.data.copy()
                 for name, field in serializer.fields.items():
                     if isinstance(field, serializers.HiddenField):
                         data.pop(name, None)
+                data = [data] if is_list_serializer else data
                 content = renderer.render(data, accepted, context)
                 # Renders returns bytes, but CharField expects a str.
                 content = content.decode()


### PR DESCRIPTION
When using ListSerializer as viewset serializer_class rendering of view in BrowsableAPI fails with:
```
Internal Server Error: /api/snippets/
Traceback (most recent call last):
  File "/home/nz/.local/lib/virtualenvs/django-rest-framework-demo/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/nz/.local/lib/virtualenvs/django-rest-framework-demo/lib/python3.11/site-packages/django/core/handlers/base.py", line 220, in _get_response
    response = response.render()
               ^^^^^^^^^^^^^^^^^
  File "/home/nz/.local/lib/virtualenvs/django-rest-framework-demo/lib/python3.11/site-packages/django/template/response.py", line 114, in render
    self.content = self.rendered_content
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/home/nz/dev/.oss/django-rest-framework/rest_framework/response.py", line 74, in rendered_content
    ret = renderer.render(self.data, accepted_media_type, context)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nz/dev/.oss/django-rest-framework/rest_framework/renderers.py", line 725, in render
    context = self.get_context(data, accepted_media_type, renderer_context)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nz/dev/.oss/django-rest-framework/rest_framework/renderers.py", line 656, in get_context
    raw_data_post_form = self.get_raw_data_form(data, view, 'POST', request)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nz/dev/.oss/django-rest-framework/rest_framework/renderers.py", line 564, in get_raw_data_form
    for name, field in serializer.fields.items():
                       ^^^^^^^^^^^^^^^^^
AttributeError: 'MultipleSnippetSerializer' object has no attribute 'fields'
[12/Jun/2023 08:41:53] "GET /api/snippets/ HTTP/1.1" 500 97475
```

BrowsableAPIRenderer cannot render multiple objects in HTML form and should render list example in Raw data.

This PR fixes the issue described above by rendering list of items in Raw data tab and not rendering HTML data tab while ListSerializer is used for viewset serializer_class.
![image](https://github.com/encode/django-rest-framework/assets/1656940/21be3501-59ab-43d6-a8f8-8dc5b343bcac)
