### PR TITLE
Return NotImplemented sooner for ErrorDetail equality test

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -73,6 +73,8 @@ class ErrorDetail(str):
 
     def __eq__(self, other):
         r = super().__eq__(other)
+        if r is NotImplemented:
+            return NotImplemented
         try:
             return r and self.code == other.code
         except AttributeError:


### PR DESCRIPTION
The test suite raises warnings when tested against Python 3.9.
`DeprecationWarning: NotImplemented should not be used in a boolean context`

In `__eq__` for `ErrorDetail` is where the warning is being raised. This is due to `r` potentially returning `NotImplemented`. This PR captures when this takes place and returns `NotImplemented` sooner.