### PR TITLE
Make it more clear to add django_filters to INSTALLED_APPS

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -149,7 +149,7 @@ To use `DjangoFilterBackend`, first install `django-filter`.
 
     pip install django-filter
 
-Then add `django_filters` to Django's `INSTALLED_APPS`:
+Then add `'django_filters'` to Django's `INSTALLED_APPS`:
 
     INSTALLED_APPS = [
         ...

--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -145,9 +145,17 @@ Note that you can use both an overridden `.get_queryset()` and generic filtering
 The [`django-filter`][django-filter-docs] library includes a `DjangoFilterBackend` class which
 supports highly customizable field filtering for REST framework.
 
-To use `DjangoFilterBackend`, first install `django-filter`. Then add `django_filters` to Django's `INSTALLED_APPS`
+To use `DjangoFilterBackend`, first install `django-filter`.
 
     pip install django-filter
+
+Then add `django_filters` to Django's `INSTALLED_APPS`:
+
+    INSTALLED_APPS = [
+        ...
+        'django_filters',
+        ...
+    ]
 
 You should now either add the filter backend to your settings:
 


### PR DESCRIPTION
## Description

Make it more clear that `'django_filters'` needs to be installed into `INSTALLED_APPS` to help users avoid this common mistake: https://github.com/carltongibson/django-filter/issues/562#issuecomment-291035404

It's currently easy to breeze past that part in the docs because it is directly before a `pip install` step.