### PR TITLE
Save reverse OneToOne relations, possible fix for issue #5996 

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -933,12 +933,12 @@ class ModelSerializer(Serializer):
         # instance is created
         info = model_meta.get_field_info(ModelClass)
         many_to_many = {}
-        reverse = []
+        reverse = {}
         for field_name, relation_info in info.relations.items():
             if relation_info.to_many and (field_name in validated_data):
                 many_to_many[field_name] = validated_data.pop(field_name)
             elif relation_info.reverse and (field_name in validated_data):
-                reverse.append(field_name)
+                reverse[field_name] = validated_data[field_name]
 
         try:
             instance = ModelClass._default_manager.create(**validated_data)
@@ -970,8 +970,9 @@ class ModelSerializer(Serializer):
 
         # Save the reverse relations
         if reverse:
-            for field_name in reverse:
-                getattr(instance, field_name).save()
+            for field_name, value in reverse.items():
+                setattr(instance, field_name, value)
+                value.save()
 
         return instance
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -85,7 +85,7 @@ class NullableForeignKeySource(RESTFrameworkModel):
 class NullableUUIDForeignKeySource(RESTFrameworkModel):
     name = models.CharField(max_length=100)
     target = models.ForeignKey(ForeignKeyTarget, null=True, blank=True,
-                               related_name='nullable_sources',
+                               related_name='nullable_uuid_sources',
                                verbose_name='Optional target object',
                                on_delete=models.CASCADE)
 

--- a/tests/test_relations_slug.py
+++ b/tests/test_relations_slug.py
@@ -350,9 +350,30 @@ class SlugNullableOneToOneTests(TestCase):
         assert serializer.data == data
         assert serializer.data['nullable_source'] == 'source-1'
 
-        # and it even says the instance is there:
-        assert serializer.instance.nullable_source
+        # and it says the instance is a NullableOneToOneSource
+        assert isinstance(
+            serializer.instance.nullable_source, NullableOneToOneSource)
 
-        # but it was not saved in the database
+        # make sure it was really updated in the database
+        instance.refresh_from_db()
+        assert instance.nullable_source
+
+    def test_one_to_one_reverse_correctly_created(self):
+        data = {'id': 2, 'name': 'target-2', 'nullable_source': 'source-1'}
+
+        serializer = OneToOneTargetSerializer(data=data)
+        assert serializer.is_valid()
+        serializer.save()
+
+        # the serializer says it updated the nullable_source field
+        assert serializer.data == data
+        assert serializer.data['nullable_source'] == 'source-1'
+
+        # and it says the instance is a NullableOneToOneSource
+        assert isinstance(
+            serializer.instance.nullable_source, NullableOneToOneSource)
+
+        # make sure it was really updated in the database
+        instance = OneToOneTarget.objects.get(pk=2)
         instance.refresh_from_db()
         assert instance.nullable_source


### PR DESCRIPTION
This PR is an idea of how #5996 could be solved. It saves reverse relations in the `create` and `update` methods of `ModelSerializer`, as the serialized data with reverse OneToOne relations can give you the impression that the data was saved in the database while in fact it isn't. 

Example models and serializers (als included in the tests):

models:
```python
class OneToOneTarget(RESTFrameworkModel):
    name = models.CharField(max_length=100)

class NullableOneToOneSource(RESTFrameworkModel):
    name = models.CharField(max_length=100)
    target = models.OneToOneField(
        OneToOneTarget, null=True, blank=True,
        related_name='nullable_source', on_delete=models.CASCADE)
```
serializers:
```python
class OneToOneTargetSerializer(serializers.ModelSerializer):
    nullable_source = serializers.SlugRelatedField(
        slug_field='name',
        queryset=NullableOneToOneSource.objects.all(),
        allow_null=True
    )

    class Meta:
        model = OneToOneTarget
        fields = '__all__'


class NullableOneToOneSourceSerializer(serializers.ModelSerializer):
    target = serializers.SlugRelatedField(
        slug_field='name',
        queryset=OneToOneTarget.objects.all(),
        allow_null=True
    )

    class Meta:
        model = NullableOneToOneSource
        fields = '__all__'
```

Now if you do something like:
```python
data = {'id': 2, 'name': 'target-2', 'nullable_source': 'source-1'}

serializer = OneToOneTargetSerializer(data=data)
serializer.save()

# the serializer says it updated the nullable_source field
assert serializer.data == data
assert serializer.data['nullable_source'] == 'source-1'

# and it says the instance is a NullableOneToOneSource
assert isinstance(
    serializer.instance.nullable_source, NullableOneToOneSource)

# make sure it was really updated in the database
instance = OneToOneTarget.objects.get(pk=2)
instance.refresh_from_db()
assert instance.nullable_source
*** tests.models.OneToOneTarget.nullable_source.RelatedObjectDoesNotExist: OneToOneTarget has no nullable_source.
```

When you would do this with plain Django models:
```python
target = OneToOneTarget(name="target=2", nullable_source=NullableOneToOneSource.objects.get(name="source-1"))
target.save()
target.nullable_source
<NullableOneToOneSource: NullableOneToOneSource object (1)>

target.refresh_from_db()
target.nullable_source
*** tests.models.OneToOneTarget.nullable_source.RelatedObjectDoesNotExist: OneToOneTarget has no nullable_source.
```
The reverse relation for the OneToOne field is not saved either. So this is default behaviour of Django, and debatable if this should be solved by DRF or not (ManyToMany relations get special treatment too, so OneToOne should be supported as well ?)

If this would not be something DRF should solve then the documentation could be extended to explain why this works as it works now and suggest a solution like overriding the save method of the specific model (or connect to the `post_save` signal) to save the reverse relation.
