### PR TITLE
Drop urlize_quoted_links

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -418,7 +418,7 @@ class BrowsableAPIRenderer(BaseRenderer):
         if render_style == 'binary':
             return '[%d bytes of binary content]' % len(content)
 
-        return content
+        return content.decode('utf-8') if isinstance(content, bytes) else content
 
     def show_form_for_method(self, view, method, request, obj):
         """

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -77,7 +77,7 @@
 
           <div class="region"  aria-label="{% trans "request form" %}">
           {% block request_forms %}
-          
+
           {% if 'GET' in allowed_methods %}
             <form id="get-form" class="pull-right">
               <fieldset>
@@ -176,9 +176,9 @@
 
               <div class="response-info" aria-label="{% trans "response info" %}">
                 <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% for key, val in response_headers|items %}
-<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
+<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize }}</span>{% endfor %}
 
-</span>{{ content|urlize_quoted_links }}</pre>
+</span>{{ content|urlize }}</pre>
               </div>
             </div>
 


### PR DESCRIPTION
We no longer need our `urlize_quoted_links` filter, since Django's `urlize` handles our use-case just fine, now.