### PR TITLE
Overlooked translation in search.html

### DIFF
--- a/rest_framework/templates/rest_framework/filters/search.html
+++ b/rest_framework/templates/rest_framework/filters/search.html
@@ -5,7 +5,7 @@
     <div class="input-group">
       <input type="text" class="form-control" style="width: 350px" name="{{ param }}" value="{{ term }}">
       <span class="input-group-btn">
-        <button class="btn btn-default" type="submit"><span class="glyphicon glyphicon-search" aria-hidden="true"></span> Search</button>
+        <button class="btn btn-default" type="submit"><span class="glyphicon glyphicon-search" aria-hidden="true"></span> {% trans "Search" %}</button>
       </span>
     </div>
   </div>


### PR DESCRIPTION
Missing `trans` in the template for `SearchFilter`