### PR TITLE
corrects typographical error in serializers.py 

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -115,7 +115,7 @@ class BaseSerializer(Field):
         super().__init__(**kwargs)
 
     def __new__(cls, *args, **kwargs):
-        # We override this method in order to automagically create
+        # We override this method in order to automatically create
         # `ListSerializer` classes instead when `many=True` is set.
         if kwargs.pop('many', False):
             return cls.many_init(*args, **kwargs)


### PR DESCRIPTION
## Description
correct typo in  line 118 of serializer.py
from  **automagically** to **automatically**
