### PR TITLE
Fix example override of SchemaGenerator.get_schema()

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -182,7 +182,7 @@ dictionary For example you might wish to add terms of service to the [top-level
 ```
 class TOSSchemaGenerator(SchemaGenerator):
     def get_schema(self, *args, **kwargs):
-        schema = super().get_schema()
+        schema = super().get_schema(*args, **kwargs)
         schema["info"]["termsOfService"] = "https://example.com/tos.html"
         return schema
 ```

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -181,7 +181,7 @@ dictionary For example you might wish to add terms of service to the [top-level
 
 ```
 class TOSSchemaGenerator(SchemaGenerator):
-    def get_schema(self):
+    def get_schema(self, *args, **kwargs):
         schema = super().get_schema()
         schema["info"]["termsOfService"] = "https://example.com/tos.html"
         return schema


### PR DESCRIPTION
Fixed error:

ERROR Internal Server Error: /v1/openapi.json

TypeError at /v1/openapi.json
Exception Value: get_schema() takes 1 positional argument but 3 were given