### PR TITLE
Fix: authtoken.TokenProxy cannot be proxy when not installed #7442 

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -49,5 +49,6 @@ class TokenProxy(Token):
         return self.user.pk
 
     class Meta:
-        proxy = True
+        proxy = 'rest_framework.authtoken' in settings.INSTALLED_APPS
+        abstract = 'rest_framework.authtoken' not in settings.INSTALLED_APPS
         verbose_name = "token"

--- a/tests/test_authtoken.py
+++ b/tests/test_authtoken.py
@@ -1,10 +1,11 @@
+import importlib
 from io import StringIO
 
 import pytest
 from django.contrib.admin import site
 from django.contrib.auth.models import User
 from django.core.management import CommandError, call_command
-from django.test import TestCase
+from django.test import TestCase, modify_settings
 
 from rest_framework.authtoken.admin import TokenAdmin
 from rest_framework.authtoken.management.commands.drf_create_token import \
@@ -20,6 +21,14 @@ class AuthTokenTests(TestCase):
         self.site = site
         self.user = User.objects.create_user(username='test_user')
         self.token = Token.objects.create(key='test token', user=self.user)
+
+    def test_authtoken_can_be_imported_when_not_included_in_installed_apps(self):
+        import rest_framework.authtoken.models
+        with modify_settings(INSTALLED_APPS={'remove': 'rest_framework.authtoken'}):
+            importlib.reload(rest_framework.authtoken.models)
+        # Set the proxy and abstract properties back to the version,
+        # where authtoken is among INSTALLED_APPS.
+        importlib.reload(rest_framework.authtoken.models)
 
     def test_model_admin_displayed_fields(self):
         mock_request = object()


### PR DESCRIPTION
Used the first of solutions @kalekseev proposed in https://github.com/encode/django-rest-framework/issues/7442#issuecomment-666264890
