### PR TITLE
Documentation: use retrieve instead of read for Viewset

### DIFF
--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -2,7 +2,7 @@
 
 REST framework includes an abstraction for dealing with `ViewSets`, that allows the developer to concentrate on modeling the state and interactions of the API, and leave the URL construction to be handled automatically, based on common conventions.
 
-`ViewSet` classes are almost the same thing as `View` classes, except that they provide operations such as `read`, or `update`, and not method handlers such as `get` or `put`.
+`ViewSet` classes are almost the same thing as `View` classes, except that they provide operations such as `retrieve`, or `update`, and not method handlers such as `get` or `put`.
 
 A `ViewSet` class is only bound to a set of method handlers at the last moment, when it is instantiated into a set of views, typically by using a `Router` class which handles the complexities of defining the URL conf for you.
 


### PR DESCRIPTION
Currently in the documentation, it says :
`Viewsets [...] provide operations such as read, or update`

but the word `retrieve` is used for read operations in DRF.

Actually, from what I understand actions can take any custom name in Viewsets, but I think it would be cool to have consistent naming for this introductory sentence.
