### PR TITLE
Fix authtoken.TokenProxy error when not installed in Django apps

### DIFF
--- a/tests/test_authtoken.py
+++ b/tests/test_authtoken.py
@@ -1,10 +1,13 @@
+import importlib
 from io import StringIO
 
 import pytest
 from django.contrib.admin import site
 from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management import CommandError, call_command
-from django.test import TestCase
+from django.db import models
+from django.test import TestCase, modify_settings
 
 from rest_framework.authtoken.admin import TokenAdmin
 from rest_framework.authtoken.management.commands.drf_create_token import \
@@ -20,6 +23,31 @@ class AuthTokenTests(TestCase):
         self.site = site
         self.user = User.objects.create_user(username='test_user')
         self.token = Token.objects.create(key='test token', user=self.user)
+
+    def test_authtoken_can_be_imported_when_not_installed(self):
+        try:
+            import rest_framework.authtoken.models
+            authtoken_models = rest_framework.authtoken.models
+            assert issubclass(authtoken_models.Token, models.Model)
+            assert issubclass(authtoken_models.TokenProxy, models.Model)
+            assert not authtoken_models.Token._meta.abstract
+            assert authtoken_models.TokenProxy._meta.proxy
+
+            with modify_settings(INSTALLED_APPS={
+                    'remove': 'rest_framework.authtoken'}):
+                importlib.reload(rest_framework.authtoken.models)
+                authtoken_models = rest_framework.authtoken.models
+                assert issubclass(authtoken_models.Token, models.Model)
+                assert authtoken_models.Token._meta.abstract
+                with pytest.raises(ImproperlyConfigured):
+                    authtoken_models.TokenProxy()
+                with pytest.raises(ImproperlyConfigured):
+                    authtoken_models.TokenProxy.objects
+
+        finally:
+            # Set the proxy and abstract properties back to the version,
+            # where authtoken is among INSTALLED_APPS.
+            importlib.reload(rest_framework.authtoken.models)
 
     def test_model_admin_displayed_fields(self):
         mock_request = object()


### PR DESCRIPTION
## Description

I fixed this issue before I realized it was already reported #7442 and another fix was proposed in #7571. I think this solution is probably better than making the `TokenProxy` become an abstract model and no longer a proxy since an error about the model being abstract might be more confusing than an `ImproperlyConfigured` error. This might also be something to add/change in the `Token` model as that might be more likely where someone would run into creation of an abstract model.

fixes: #7442 