### PR TITLE
Remove tox-venv from Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       - env: DJANGO=master
 
 install:
-    - pip install tox tox-venv tox-travis
+    - pip install tox tox-travis
 
 script:
     - tox


### PR DESCRIPTION
## Description

This was added in #6139. However it seems [tox-venv is no longer maintained](https://github.com/tox-dev/tox-venv), the related [virtualenv issue has been closed](https://github.com/pypa/virtualenv/issues/355), and I suspect with the virtualenv rewrite fixed the problem with site.py and the warnings referred to for the DRF tests.
