### PR TITLE
Error on deprecation and pending deprecation warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ DJANGO =
     master: djangomaster
 
 [testenv]
-commands = ./runtests.py --fast --coverage {posargs}
+commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning runtests.py --fast --coverage {posargs}
 envdir = {toxworkdir}/venvs/{envname}
 setenv =
        PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
## Description

Erroring on deprecation or pending deprecation warnings means they are caught early. This will avoid the cycle of releasing with 'support for Django X', then chasing all the deprecation warnings one-by-one. Instead, when a new Django version is added to the test matrix, it will fail until all the relevant warnings are fixed. This avoids passing these warnings on to users, some of whom don't upgrade until they are all fixed.
