### PR TITLE
Add missing quoting for `data` keyword argument in serializer doc

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -251,7 +251,7 @@ For more information see the [validators documentation](validators.md).
 
 When passing an initial object or queryset to a serializer instance, the object will be made available as `.instance`. If no initial object is passed then the `.instance` attribute will be `None`.
 
-When passing data to a serializer instance, the unmodified data will be made available as `.initial_data`. If the data keyword argument is not passed then the `.initial_data` attribute will not exist.
+When passing data to a serializer instance, the unmodified data will be made available as `.initial_data`. If the `data` keyword argument is not passed then the `.initial_data` attribute will not exist.
 
 ## Partial updates
 


### PR DESCRIPTION
## Description

Add missing quoting for `data` keyword argument in serializer doc