### PR TITLE
Updated dependencies

### DIFF
--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,7 +1,6 @@
 # PEP8 code linting, which we run on all commits.
-flake8==3.8.3
-flake8-tidy-imports==4.1.0
-pycodestyle==2.6.0
+flake8>=3.8.4,<3.9
+flake8-tidy-imports>=4.1.0,<4.2
 
 # Sort and lint imports
-isort==5.4.2
+isort>=5.6.2,<6.0

--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -1,2 +1,2 @@
 # MkDocs to build our documentation.
-mkdocs==1.1
+mkdocs>=1.1.2,<1.2

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,10 +1,10 @@
 # Optional packages which may be used with REST framework.
-psycopg2-binary>=2.8.5, <2.9
-markdown==3.3;python_version>="3.6"
-markdown==3.2.2;python_version=="3.5"
-pygments==2.7.4
-django-guardian==2.2.0
-django-filter>=2.2.0, <2.3
 coreapi==2.3.1
 coreschema==0.0.4
-pyyaml>=5.1
+django-filter>=2.4.0,<3.0
+django-guardian>=2.3.0,<2.4
+markdown==3.3;python_version>="3.6"
+markdown==3.2.2;python_version=="3.5"
+psycopg2-binary>=2.8.5,<2.9
+pygments>=2.7.1,<2.8
+pyyaml>=5.3.1,<5.4

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -1,8 +1,8 @@
 # Wheel for PyPI installs.
-wheel==0.34.2
+wheel>=0.35.1,<0.36
 
 # Twine for secured PyPI uploads.
-twine==3.1.1
+twine>=3.2.0,<3.3
 
 # Transifex client for managing translation resources.
-transifex-client==0.13.9
+transifex-clien>=0.13.12,<0.14

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,4 +1,4 @@
 # Pytest for running the tests.
-pytest>=6.1.1,<6.2
-pytest-django>=4.1.0,<4.2
-pytest-cov>=2.10.1
+pytest>=6.1,<7.0
+pytest-cov>=2.10.1,<3.0
+pytest-django>=4.1.0,<5.0

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
 
 from rest_framework.status import (
-    is_client_error, is_informational, is_redirect, is_server_error,
-    is_success
+    is_client_error, is_informational, is_redirect, is_server_error, is_success
 )
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,8 +7,7 @@ from django.test import TestCase
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.validators import (
-    BaseUniqueForValidator, UniqueTogetherValidator, UniqueValidator,
-    qs_exists
+    BaseUniqueForValidator, UniqueTogetherValidator, UniqueValidator, qs_exists
 )
 
 


### PR DESCRIPTION
I've bumped all the dependency versions with the exception of Markdown. Bumping that version causes a test fail (separate PR incoming shortly). 

The main change here is bumping Pytest to version 6. 