### PR TITLE
Bumped Markdown version to 3.3

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,6 +1,7 @@
 # Optional packages which may be used with REST framework.
 psycopg2-binary>=2.8.5, <2.9
-markdown==3.1.1
+markdown==3.3;python_version>="3.6"
+markdown==3.2.2;python_version=="3.5"
 pygments==2.4.2
 django-guardian==2.2.0
 django-filter>=2.2.0, <2.3

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import TestCase
 
 from rest_framework.compat import apply_markdown
@@ -30,36 +31,7 @@ indented
 
 # If markdown is installed we also test it's working
 # (and that our wrapped forces '=' to h2 and '-' to h3)
-MARKED_DOWN_HILITE = """
-<div class="highlight"><pre><span></span><span \
-class="p">[{</span><br />    <span class="nt">&quot;alpha&quot;</span><span\
- class="p">:</span> <span class="mi">1</span><span class="p">,</span><br />\
-    <span class="nt">&quot;beta: &quot;</span><span class="err">this</span>\
- <span class="err">is</span> <span class="err">a</span> <span class="err">\
-string&quot;</span><br /><span class="p">}]</span><br /></pre></div>
-
-<p><br /></p>"""
-
-MARKED_DOWN_NOT_HILITE = """
-<p><code>json
-[{
-    "alpha": 1,
-    "beta: "this is a string"
-}]</code></p>"""
-
-# We support markdown < 2.1 and markdown >= 2.1
-MARKED_DOWN_lt_21 = """<h2>an example docstring</h2>
-<ul>
-<li>list</li>
-<li>list</li>
-</ul>
-<h3>another header</h3>
-<pre><code>code block
-</code></pre>
-<p>indented</p>
-<h2 id="hash_style_header">hash style header</h2>%s"""
-
-MARKED_DOWN_gte_21 = """<h2 id="an-example-docstring">an example docstring</h2>
+MARKED_DOWN_HILITE = """<h2 id="an-example-docstring">an example docstring</h2>
 <ul>
 <li>list</li>
 <li>list</li>
@@ -68,7 +40,15 @@ MARKED_DOWN_gte_21 = """<h2 id="an-example-docstring">an example docstring</h2>
 <pre><code>code block
 </code></pre>
 <p>indented</p>
-<h2 id="hash-style-header">hash style header</h2>%s"""
+<h2 id="hash-style-header">hash style header</h2>
+<div class="highlight"><pre><span></span><span class="p">[{</span><br />\
+    <span class="nt">&quot;alpha&quot;</span><span class="p">:</span>\
+ <span class="mi">1</span><span class="p">,</span><br />\
+    <span class="nt">&quot;beta: &quot;</span><span class="err">this\
+</span> <span class="err">is</span> <span class="err">a</span> \
+<span class="err">string&quot;</span><br /><span class="p">}]</span>\
+<br /></pre></div>
+<p><br /></p>"""
 
 
 class TestViewNamesAndDescriptions(TestCase):
@@ -165,23 +145,12 @@ class TestViewNamesAndDescriptions(TestCase):
 
         assert MockView().get_view_description() == 'a gettext string'
 
+    @pytest.mark.skipif(not apply_markdown, reason="Markdown is not installed")
     def test_markdown(self):
         """
         Ensure markdown to HTML works as expected.
         """
-        if apply_markdown:
-            md_applied = apply_markdown(DESCRIPTION)
-            gte_21_match = (
-                md_applied == (
-                    MARKED_DOWN_gte_21 % MARKED_DOWN_HILITE) or
-                md_applied == (
-                    MARKED_DOWN_gte_21 % MARKED_DOWN_NOT_HILITE))
-            lt_21_match = (
-                md_applied == (
-                    MARKED_DOWN_lt_21 % MARKED_DOWN_HILITE) or
-                md_applied == (
-                    MARKED_DOWN_lt_21 % MARKED_DOWN_NOT_HILITE))
-            assert gte_21_match or lt_21_match
+        assert apply_markdown(DESCRIPTION) == MARKED_DOWN_HILITE
 
 
 def test_dedent_tabs():

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from django.test import TestCase
 
@@ -31,7 +33,7 @@ indented
 
 # If markdown is installed we also test it's working
 # (and that our wrapped forces '=' to h2 and '-' to h3)
-MARKED_DOWN_HILITE = """<h2 id="an-example-docstring">an example docstring</h2>
+MARKDOWN_BASE = """<h2 id="an-example-docstring">an example docstring</h2>
 <ul>
 <li>list</li>
 <li>list</li>
@@ -40,7 +42,9 @@ MARKED_DOWN_HILITE = """<h2 id="an-example-docstring">an example docstring</h2>
 <pre><code>code block
 </code></pre>
 <p>indented</p>
-<h2 id="hash-style-header">hash style header</h2>
+<h2 id="hash-style-header">hash style header</h2>%s"""
+
+MARKDOWN_gte_33 = """
 <div class="highlight"><pre><span></span><span class="p">[{</span><br />\
     <span class="nt">&quot;alpha&quot;</span><span class="p">:</span>\
  <span class="mi">1</span><span class="p">,</span><br />\
@@ -48,6 +52,17 @@ MARKED_DOWN_HILITE = """<h2 id="an-example-docstring">an example docstring</h2>
 </span> <span class="err">is</span> <span class="err">a</span> \
 <span class="err">string&quot;</span><br /><span class="p">}]</span>\
 <br /></pre></div>
+<p><br /></p>"""
+
+MARKDOWN_lt_33 = """
+<div class="highlight"><pre><span></span><span class="p">[{</span><br />\
+    <span class="nt">&quot;alpha&quot;</span><span class="p">:</span>\
+ <span class="mi">1</span><span class="p">,</span><br />\
+    <span class="nt">&quot;beta: &quot;</span><span class="err">this\
+</span> <span class="err">is</span> <span class="err">a</span>\
+ <span class="err">string&quot;</span><br /><span class="p">}]</span>\
+<br /></pre></div>
+
 <p><br /></p>"""
 
 
@@ -150,7 +165,11 @@ class TestViewNamesAndDescriptions(TestCase):
         """
         Ensure markdown to HTML works as expected.
         """
-        assert apply_markdown(DESCRIPTION) == MARKED_DOWN_HILITE
+        # Markdown 3.3 is only supported on Python 3.6 and higher
+        if sys.version_info >= (3, 6):
+            assert apply_markdown(DESCRIPTION) == MARKDOWN_BASE % MARKDOWN_gte_33
+        else:
+            assert apply_markdown(DESCRIPTION) == MARKDOWN_BASE % MARKDOWN_lt_33
 
 
 def test_dedent_tabs():


### PR DESCRIPTION
Markdown version 3.3 changes the whitespace of the output. 

Looking at the failing test it is suited to pass on multiple versions of Markdown. However, the tests are only run against the pinned dependency. Therefore I've simplified the test to only test against this one version. 

Secondly, I've also added a `pytest` skip mark so it skips the test 'loudly'. 

Final note, and more of a question really, most of the tests here are under a class which is subclass from `TestCase` however, all of the tests are written `pytest` style. Is there a reason for this, I guess it allows categorisation of the tests? 