### PR TITLE
Reject PrimaryKeyRelatedField bool lookup values

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -259,6 +259,8 @@ class PrimaryKeyRelatedField(RelatedField):
             data = self.pk_field.to_internal_value(data)
         queryset = self.get_queryset()
         try:
+            if isinstance(data, bool):
+                raise TypeError
             return queryset.get(pk=data)
         except ObjectDoesNotExist:
             self.fail('does_not_exist', pk_value=data)

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -107,7 +107,7 @@ class TestPrimaryKeyRelatedField(APISimpleTestCase):
         msg = excinfo.value.detail[0]
         assert msg == 'Incorrect type. Expected pk value, received BadType.'
 
-     def test_pk_related_lookup_bool(self):
+    def test_pk_related_lookup_bool(self):
         with pytest.raises(serializers.ValidationError) as excinfo:
             self.field.to_internal_value(True)
         msg = excinfo.value.detail[0]

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -107,6 +107,12 @@ class TestPrimaryKeyRelatedField(APISimpleTestCase):
         msg = excinfo.value.detail[0]
         assert msg == 'Incorrect type. Expected pk value, received BadType.'
 
+     def test_pk_related_lookup_bool(self):
+        with pytest.raises(serializers.ValidationError) as excinfo:
+            self.field.to_internal_value(True)
+        msg = excinfo.value.detail[0]
+        assert msg == 'Incorrect type. Expected pk value, received bool.'
+
     def test_pk_representation(self):
         representation = self.field.to_representation(self.instance)
         assert representation == self.instance.pk


### PR DESCRIPTION
In case maintainers intend to explicitly forbid `bool` values for `PrimaryKeyRelatedField` lookup.
Closes https://github.com/encode/django-rest-framework/issues/7542