### PR TITLE
Respect model error_messages for relation

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -217,15 +217,9 @@ def get_field_kwargs(field_name, model_field):
         ]
 
     if getattr(model_field, 'unique', False):
-        unique_error_message = model_field.error_messages.get('unique', None)
-        if unique_error_message:
-            unique_error_message = unique_error_message % {
-                'model_name': model_field.model._meta.verbose_name,
-                'field_label': model_field.verbose_name
-            }
         validator = UniqueValidator(
             queryset=model_field.model._default_manager,
-            message=unique_error_message)
+            message=get_unique_error_message(model_field))
         validator_kwarg.append(validator)
 
     if validator_kwarg:
@@ -281,7 +275,9 @@ def get_relation_kwargs(field_name, relation_info):
         if model_field.validators:
             kwargs['validators'] = model_field.validators
         if getattr(model_field, 'unique', False):
-            validator = UniqueValidator(queryset=model_field.model._default_manager)
+            validator = UniqueValidator(
+                queryset=model_field.model._default_manager,
+                message=get_unique_error_message(model_field))
             kwargs['validators'] = kwargs.get('validators', []) + [validator]
         if to_many and not model_field.blank:
             kwargs['allow_empty'] = False
@@ -300,3 +296,13 @@ def get_url_kwargs(model_field):
     return {
         'view_name': get_detail_view_name(model_field)
     }
+
+
+def get_unique_error_message(model_field):
+    unique_error_message = model_field.error_messages.get('unique', None)
+    if unique_error_message:
+        unique_error_message = unique_error_message % {
+            'model_name': model_field.model._meta.verbose_name,
+            'field_label': model_field.verbose_name
+        }
+    return unique_error_message

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -43,6 +43,12 @@ class RelatedModelSerializer(serializers.ModelSerializer):
         fields = ('username', 'email')
 
 
+class RelatedModelUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RelatedModel
+        fields = ('user',)
+
+
 class AnotherUniquenessModel(models.Model):
     code = models.IntegerField(unique=True)
 
@@ -83,6 +89,13 @@ class TestUniquenessValidation(TestCase):
         serializer = UniquenessSerializer(data=data)
         assert not serializer.is_valid()
         assert serializer.errors == {'username': ['uniqueness model with this username already exists.']}
+
+    def test_relation_is_not_unique(self):
+        RelatedModel.objects.create(user=self.instance)
+        data = {'user': self.instance.pk}
+        serializer = RelatedModelUserSerializer(data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {'user': ['related model with this user already exists.']}
 
     def test_is_unique(self):
         data = {'username': 'other'}


### PR DESCRIPTION
The same as #3435, but for relation.
Use error_messages from model instead of the default UniqueValidator message.