### PR TITLE
Add support for Meta.field_classes on ModelSerializer

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -527,6 +527,21 @@ You can add extra fields to a `ModelSerializer` or override the default fields b
 
 Extra fields can correspond to any property or callable on the model.
 
+## Specifying field classes
+
+In order to override the field class only, and still get the field kwargs set dynamically, you may use the `field_classes`
+Meta option.
+
+    class AccountSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = Account
+            fields = ['account_name']
+            field_classes = {'account_name': AccountNameField}
+
+Note that the field class that you use needs to support whatever kwargs the serializer determines to use for this field.
+Typically, you want your custom field class to inherit from the appropriate built in field class.
+For example, the custom `AccountNameField` could inherit from the built in `CharField`.
+
 ## Specifying read only fields
 
 You may wish to specify multiple fields as read-only. Instead of adding each field explicitly with the `read_only=True` attribute, you may use the shortcut Meta option, `read_only_fields`.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1054,6 +1054,11 @@ class ModelSerializer(Serializer):
                 source, info, model, depth
             )
 
+            # Override field_class by classes defined in `Meta.field_classes`.
+            field_class = self.get_field_class(
+                source, info, model, field_class
+            )
+
             # Include any kwargs defined in `Meta.extra_kwargs`
             field_kwargs = self.include_extra_kwargs(
                 field_kwargs, extra_field_kwargs
@@ -1318,6 +1323,17 @@ class ModelSerializer(Serializer):
             'Field name `%s` is not valid for model `%s`.' %
             (field_name, model_class.__name__)
         )
+
+    def get_field_class(self, field_name, info, model_class, field_class):
+        """
+        Get field class from 'field_classes', or use the default.
+        """
+        field_classes = getattr(self.Meta, 'field_classes', {})
+
+        if field_name in field_classes:
+            return field_classes[field_name]
+
+        return field_class
 
     def include_extra_kwargs(self, kwargs, extra_kwargs):
         """

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -271,6 +271,26 @@ class TestRegularFieldMappings(TestCase):
         """)
         self.assertEqual(repr(TestSerializer()), expected)
 
+    def test_field_classes(self):
+        """
+        Ensure `field_classes` do override the field class.
+        """
+        class CustomCharField(serializers.CharField):
+            pass
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = RegularFieldsModel
+                fields = ('auto_field', 'char_field')
+                field_classes = {'char_field': CustomCharField}
+
+        expected = dedent("""
+            TestSerializer():
+                auto_field = IntegerField(read_only=True)
+                char_field = CustomCharField(max_length=100)
+        """)
+        self.assertEqual(repr(TestSerializer()), expected)
+
     def test_extra_field_kwargs(self):
         """
         Ensure `extra_kwargs` are passed to generated fields.


### PR DESCRIPTION
## What?

Add support for `Meta.field_classes` on ModelSerializer to override the field class dynamically. Similar to `Meta.extra_kwargs`.

Example usage:

```python
class BookSerializer(serializers.ModelSerializer):
    class Meta:
        model = Book
        fields = ["isbn"]
        field_classes = {"isbn": ISBNField}
```

## Why?

It is already possible to do a "hard override" of a field by specifying it as an attribute on the class.

```python
class BookSerializer(serializers.ModelSerializer):
    class Meta:
        model = Book
        fields = ["isbn"]

    isbn = ISBNField()
```

However, this is not nearly as good, since it will result in all dynamically fetched kwargs to be ignored. For example the `help_text` from the model will not be included, it would be very nice to retain that, while still providing a custom class.

There are of course several other kwargs that can be useful to retain as well, `help_text` is just one example.