### PR TITLE
Handle composition of unimplemented permission methods correctly

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -1,4 +1,4 @@
----
+﻿---
 source:
     - permissions.py
 ---
@@ -212,7 +212,8 @@ To implement a custom permission, override `BasePermission` and implement either
 * `.has_permission(self, request, view)`
 * `.has_object_permission(self, request, view, obj)`
 
-The methods should return `True` if the request should be granted access, and `False` otherwise.
+The methods should return `True` if the request should be granted access, and `False` if it should be denied. Most permission classes will only need to implement one of these methods. The base class implementations return a special truthy value called `Deferred` which is used to make and/or/not composition work correctly where `has_permission` should always
+succeed in order to let object permissions be checked and `has_object_permission` should defer to the view-level permission.
 
 If you need to test if a request is a read operation or a write operation, you should check the request method against the constant `SAFE_METHODS`, which is a tuple containing `'GET'`, `'OPTIONS'` and `'HEAD'`.  For example:
 

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -77,7 +77,7 @@ class OR:
         if hasperm1 and hasperm1 is not NotImplemented:
             return hasperm1
         hasperm2 = self.op2.has_permission(request, view)
-        return hasperm1 if hasperm2 is NotImplemented else hasperm2
+        return hasperm2 or hasperm1
 
     def has_object_permission(self, request, view, obj):
         hasperm1 = self.op1.has_object_permission(request, view, obj)
@@ -88,7 +88,7 @@ class OR:
         hasperm2 = self.op2.has_object_permission(request, view, obj)
         if hasperm2 is NotImplemented:
             hasperm2 = self.op2.has_permission(request, view)
-        return hasperm1 if hasperm2 is NotImplemented else hasperm2
+        return hasperm2 or hasperm1
 
 
 class NOT:

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -81,9 +81,13 @@ class OR:
 
     def has_object_permission(self, request, view, obj):
         hasperm1 = self.op1.has_object_permission(request, view, obj)
+        if hasperm1 is NotImplemented:
+            hasperm1 = self.op1.has_permission(request, view)
         if hasperm1 and hasperm1 is not NotImplemented:
             return hasperm1
         hasperm2 = self.op2.has_object_permission(request, view, obj)
+        if hasperm2 is NotImplemented:
+            hasperm2 = self.op2.has_permission(request, view)
         return hasperm1 if hasperm2 is NotImplemented else hasperm2
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -528,6 +528,12 @@ class PermissionsCompositionTests(TestCase):
             self.password
         )
         self.client.login(username=self.username, password=self.password)
+        self.admin_user = User.objects.create_user(
+            'paul',
+            'mccartney@thebeatles.com',
+            'password',
+            is_staff=True,
+        )
 
     def test_and_false(self):
         request = factory.get('/1', format='json')
@@ -685,7 +691,7 @@ class PermissionsCompositionTests(TestCase):
         assert composed_perm().has_permission(request, None) is NotImplemented
         assert composed_perm().has_object_permission(request, None, None) is True
 
-    def test_has_object_permission_not_implemented(self):
+    def test_has_object_permission_not_implemented_false(self):
         request = factory.get('/1', format='json')
         request.user = self.user
         composed_perm = (
@@ -695,3 +701,12 @@ class PermissionsCompositionTests(TestCase):
         assert composed_perm().has_permission(request, None) is False
         assert composed_perm().has_object_permission(request, None, None) is False
 
+    def test_has_object_permission_not_implemented_true(self):
+        request = factory.get('/1', format='json')
+        request.user = self.admin_user
+        composed_perm = (
+            permissions.IsAdminUser |
+            BasicObjectPerm
+        )
+        assert composed_perm().has_permission(request, None) is True
+        assert composed_perm().has_object_permission(request, None, None) is True

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -698,7 +698,7 @@ class PermissionsCompositionTests(TestCase):
             permissions.IsAdminUser |
             BasicObjectPerm
         )
-        assert composed_perm().has_permission(request, None) is False
+        assert composed_perm().has_permission(request, None) is NotImplemented
         assert composed_perm().has_object_permission(request, None, None) is False
 
     def test_has_object_permission_not_implemented_true(self):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -677,3 +677,21 @@ class PermissionsCompositionTests(TestCase):
                 assert hasperm is False
                 assert mock_deny.call_count == 1
                 mock_allow.assert_not_called()
+
+    def test_has_permission_not_implemented(self):
+        request = factory.get('/1', format='json')
+        request.user = self.user
+        composed_perm = ~BasicObjectPerm
+        assert composed_perm().has_permission(request, None) is NotImplemented
+        assert composed_perm().has_object_permission(request, None, None) is True
+
+    def test_has_object_permission_not_implemented(self):
+        request = factory.get('/1', format='json')
+        request.user = self.user
+        composed_perm = (
+            permissions.IsAdminUser |
+            BasicObjectPerm
+        )
+        assert composed_perm().has_permission(request, None) is False
+        assert composed_perm().has_object_permission(request, None, None) is False
+

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -12,6 +12,7 @@ from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
     status, views
 )
+from rest_framework.permissions import Deferred
 from rest_framework.routers import DefaultRouter
 from rest_framework.test import APIRequestFactory
 from tests.models import BasicModel
@@ -688,7 +689,7 @@ class PermissionsCompositionTests(TestCase):
         request = factory.get('/1', format='json')
         request.user = self.user
         composed_perm = ~BasicObjectPerm
-        assert composed_perm().has_permission(request, None) is NotImplemented
+        assert composed_perm().has_permission(request, None) is Deferred
         assert composed_perm().has_object_permission(request, None, None) is True
 
     def test_has_object_permission_not_implemented_false(self):
@@ -698,7 +699,7 @@ class PermissionsCompositionTests(TestCase):
             permissions.IsAdminUser |
             BasicObjectPerm
         )
-        assert composed_perm().has_permission(request, None) is NotImplemented
+        assert composed_perm().has_permission(request, None) is Deferred
         assert composed_perm().has_object_permission(request, None, None) is False
 
     def test_has_object_permission_not_implemented_true(self):


### PR DESCRIPTION
## Description

This is a fix for issues #7117 and #6598.

Previously `has_object_permission` defaulted to returning `True` when unimplemented because it was assumed that `has_permission` had already returned true, but when composed with OR, this might not be the case. Take for example the case where you want an object to be accessible by the user that created it or any admin. If you have a permission `IsOwner` that implements `has_object_permissions` and `IsAdminUser` which doesn't, then if you OR them together and have a user that is neither the owner nor the admin they should get denied but instead `IsOwner` will pass `has_permission` and `IsAdminUser` will pass `has_object_permission` even though it wouldn't have passed `has_permission`.

One solution would be to default `has_object_permission` to calling `has_permission`. This will return the expected value in all cases, but would potentially cause redundant database lookups even when no composition is used. Alternatively this could be done only in the OR class as with PR #7155 , but the redundant calls will still happen and incorrect behavior can still occur using more complicated compositions including NOT (See issue #6598). For example, the `IsOwner` permission above only implemented `has_object_permission` and not `has_permission`, but `~IsOwner` will always fail, even on objects that the authenticated user doesn't own, because the default `True` from `BasePermission.has_permission()` will also be inverted.

My solution is to be more explicit about when a permission subclass doesn't implement `has_permission` or `has_object_permission` by returning `NotImplemented`. `NotImplemented` is truthy in a boolean context, so by default everything will continue to work the same as long as code is not expecting the result to literally be `True` or `False`. I modified `AND` and `OR` so that if one side returns `NotImplemented`, it defers to the other. If both sides return `NotImplemented`, `NotImplemented` will be returned to propagate upwards. NOT will also propagate `NotImplemented` instead of inverting it. If `NotImplemented` propagates all the way up to `APIView.check_permissions` or `APIView.check_object_permissions`, it is considered a pass (truthy).