### PR TITLE
Ordering filter bug with model property serializer field

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -226,16 +226,19 @@ class OrderingFilter(BaseFilterBackend):
             )
             raise ImproperlyConfigured(msg % self.__class__.__name__)
 
-        model_field_names = [field.name for field in queryset.model._meta.fields]
+        model_class = queryset.model
+        model_property_names = [
+            # 'pk' is a property added in Django's Model class, however it is valid for ordering.
+            attr for attr in dir(model_class) if isinstance(getattr(model_class, attr), property) and attr != 'pk'
+        ]
 
         return [
             (field.source.replace('.', '__') or field_name, field.label)
             for field_name, field in serializer_class(context=context).fields.items()
             if (
                 not getattr(field, 'write_only', False) and
-                not field.source == '*' and (
-                    field_name in model_field_names or field.source in model_field_names
-                )
+                not field.source == '*' and
+                field.source not in model_property_names
             )
         ]
 

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -226,10 +226,17 @@ class OrderingFilter(BaseFilterBackend):
             )
             raise ImproperlyConfigured(msg % self.__class__.__name__)
 
+        model_field_names = [field.name for field in queryset.model._meta.fields]
+
         return [
             (field.source.replace('.', '__') or field_name, field.label)
             for field_name, field in serializer_class(context=context).fields.items()
-            if not getattr(field, 'write_only', False) and not field.source == '*'
+            if (
+                not getattr(field, 'write_only', False) and
+                not field.source == '*' and (
+                    field_name in model_field_names or field.source in model_field_names
+                )
+            )
         ]
 
     def get_valid_fields(self, queryset, view, context={}):


### PR DESCRIPTION
#### Fixes: #7608

### What is in this PR:
- A model property called `description` added to the `OrderingFilterModel`
- Created `OrderingFilterSerializerWithModelProperty` which includes all fields of `OrderingFilterModel` and the model property `description`.
- Failing test has been added under `test_ordering_without_ordering_fields` with two passing `assert` statements to see using model properties on a serializer with `OrderingFilter` doesn't have any side effect.
- A solution has been added to `OrderingFilter.get_default_valid_fields()` method which basically checks if the ~`field_name` or `field.source` is in `model_field_names`~ `field.source` is in `model_property_names` (c7f8b14).
