### PR TITLE
Fix #7612 (`data` used instead of `validated_data` in API guide)

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -152,7 +152,7 @@ A more complete example of extra actions:
             user = self.get_object()
             serializer = PasswordSerializer(data=request.data)
             if serializer.is_valid():
-                user.set_password(serializer.data['password'])
+                user.set_password(serializer.validated_data['password'])
                 user.save()
                 return Response({'status': 'password set'})
             else:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
