### PR TITLE
Adding Generic support for various classes

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -8,6 +8,7 @@ import uuid
 import warnings
 from collections import OrderedDict
 from collections.abc import Mapping
+from typing import Generic, TypeVar
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -308,8 +309,13 @@ MISSING_ERROR_MESSAGE = (
     'not exist in the `error_messages` dictionary.'
 )
 
+_IN = TypeVar("_IN")  # Instance Type
+_VT = TypeVar("_VT")  # Value Type
+_DT = TypeVar("_DT")  # Data Type
+_RP = TypeVar("_RP")  # Representation Type
 
-class Field:
+
+class Field(Generic[_VT, _DT, _RP, _IN]):
     _creation_counter = 0
 
     default_error_messages = {

--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -5,6 +5,7 @@ They give us a generic way of being able to handle various media types
 on the request, such as form content or json encoded data.
 """
 import codecs
+from typing import Generic, TypeVar
 from urllib import parse
 
 from django.conf import settings
@@ -21,8 +22,11 @@ from rest_framework.exceptions import ParseError
 from rest_framework.settings import api_settings
 from rest_framework.utils import json
 
+_Data = TypeVar("_Data")
+_Files = TypeVar("_Files")
 
-class DataAndFiles:
+
+class DataAndFiles(Generic[_Data, _Files]):
     def __init__(self, data, files):
         self.data = data
         self.files = files

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -1,9 +1,10 @@
 import sys
 from collections import OrderedDict
+from typing import Any, Generic, TypeVar
 from urllib import parse
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
-from django.db.models import Manager
+from django.db.models import Manager, Model
 from django.db.models.query import QuerySet
 from django.urls import NoReverseMatch, Resolver404, get_script_prefix, resolve
 from django.utils.encoding import smart_str, uri_to_iri
@@ -85,8 +86,12 @@ MANY_RELATION_KWARGS = (
     'html_cutoff', 'html_cutoff_text'
 )
 
+_MT = TypeVar("_MT", bound=Model)
+_DT = TypeVar("_DT")  # Data Type
+_PT = TypeVar("_PT")  # Primitive Type
 
-class RelatedField(Field):
+
+class RelatedField(Generic[_MT, _DT, _PT], Field[_MT, _DT, _PT, Any]):
     queryset = None
     html_cutoff = None
     html_cutoff_text = None

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -3,6 +3,7 @@ Helper functions for mapping model fields to a dictionary of default
 keyword arguments that should be used for their equivalent serializer fields.
 """
 import inspect
+from typing import Generic, TypeVar
 
 from django.core import validators
 from django.db import models
@@ -16,7 +17,11 @@ NUMERIC_FIELD_TYPES = (
 )
 
 
-class ClassLookupDict:
+_K = TypeVar("_K", bound=type)
+_V = TypeVar("_V")
+
+
+class ClassLookupDict(Generic[_K, _V]):
     """
     Takes a dictionary with classes as keys.
     Lookups against this object will traverses the object's inheritance

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -14,7 +14,7 @@ from django.utils.timezone import activate, deactivate, override, utc
 import rest_framework
 from rest_framework import exceptions, serializers
 from rest_framework.fields import (
-    BuiltinSignatureError, DjangoImageField, is_simple_callable
+    BuiltinSignatureError, DjangoImageField, Field, is_simple_callable
 )
 
 # Tests for helper functions.
@@ -2380,3 +2380,21 @@ class TestValidationErrorCode:
                 ),
             ]
         }
+
+
+class TestField:
+    def test_type_annotation(self):
+        assert Field[int, int, int, int] is not Field
+
+    def test_multiple_type_params_needed_when_hinting_class(self):
+        with pytest.raises(TypeError):
+            Field[int]
+
+        with pytest.raises(TypeError):
+            Field[int, int]
+
+        with pytest.raises(TypeError):
+            Field[int, int, int]
+
+        with pytest.raises(TypeError):
+            Field[int, int, int, int, int]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import (
-    FileUploadParser, FormParser, JSONParser, MultiPartParser
+    DataAndFiles, FileUploadParser, FormParser, JSONParser, MultiPartParser
 )
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
@@ -176,3 +176,19 @@ class TestPOSTAccessed(TestCase):
         with pytest.raises(RawPostDataException):
             request.POST
             request.data
+
+
+class TestDataAndFiles:
+    def test_type_annotation(self):
+        """
+        This class inherits directly from Generic, so adding type hints to it should
+        yield a different class.
+        """
+        assert DataAndFiles[int, int] is not DataAndFiles
+
+    def test_need_multiple_type_params_when_hinting_class(self):
+        with pytest.raises(TypeError):
+            DataAndFiles[int]
+
+        with pytest.raises(TypeError):
+            DataAndFiles[int, int, int]

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -376,3 +376,18 @@ class TestHyperlink:
         upkled = pickle.loads(pickle.dumps(self.default_hyperlink))
         assert upkled == self.default_hyperlink
         assert upkled.name == self.default_hyperlink.name
+
+
+class TestRelatedField:
+    def test_type_annotation(self):
+        assert relations.RelatedField[int, int, int] is not relations.RelatedField
+
+    def test_multiple_type_params_needed_when_hinting_class(self):
+        with pytest.raises(TypeError):
+            relations.RelatedField[int]
+
+        with pytest.raises(TypeError):
+            relations.RelatedField[int, int]
+
+        with pytest.raises(TypeError):
+            relations.RelatedField[int, int, int, int]

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -209,8 +209,19 @@ class TestSerializer:
         sys.version_info < (3, 7),
         reason="subscriptable classes requires Python 3.7 or higher",
     )
-    def test_serializer_is_subscriptable(self):
-        assert serializers.Serializer is serializers.Serializer["foo"]
+    def test_type_annotation(self):
+        assert serializers.Serializer is not serializers.Serializer["foo"]
+
+    @pytest.mark.skipif(
+        sys.version_info > (3, 5),
+        reason="generic meta class behaviour changed from 3.5 to 3.7",
+    )
+    def test_type_annotation_pre_36(self):
+        """
+        This class does NOT inherit directly from Generic, so adding type hints to it
+        should not yield a different class.
+        """
+        assert serializers.Serializer[int] is not serializers.Serializer
 
 
 class TestValidateMethod:
@@ -321,6 +332,28 @@ class TestBaseSerializer:
             {'id': 1, 'name': 'tom', 'domain': 'example.com'},
             {'id': 2, 'name': 'ann', 'domain': 'example.com'}
         ]
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason="generic meta class behaviour changed from 3.5 to 3.7",
+    )
+    def test_type_annotation(self):
+        """
+        This class does NOT inherit directly from Generic, so adding type hints to it
+        should not yield a different class.
+        """
+        assert serializers.BaseSerializer[int] is not serializers.BaseSerializer
+
+    @pytest.mark.skipif(
+        sys.version_info > (3, 5),
+        reason="generic meta class behaviour changed from 3.5 to 3.7",
+    )
+    def test_type_annotation_pre_36(self):
+        """
+        This class does NOT inherit directly from Generic, so adding type hints to it
+        should not yield a different class.
+        """
+        assert serializers.BaseSerializer[int] is not serializers.BaseSerializer
 
 
 class TestStarredSource:
@@ -740,3 +773,27 @@ class TestDeclaredFieldInheritance:
             'f4': serializers.CharField,
             'f5': serializers.CharField,
         }
+
+
+class TestModelSerializer:
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason="generic meta class behaviour changed from 3.5 to 3.7",
+    )
+    def test_type_annotation(self):
+        """
+        This class does NOT inherit directly from Generic, so adding type hints to it
+        should not yield a different class.
+        """
+        assert serializers.ModelSerializer[int] is not serializers.ModelSerializer
+
+    @pytest.mark.skipif(
+        sys.version_info > (3, 5),
+        reason="generic meta class behaviour changed from 3.5 to 3.7",
+    )
+    def test_type_annotation_pre_36(self):
+        """
+        This class does NOT inherit directly from Generic, so adding type hints to it
+        should not yield a different class.
+        """
+        assert serializers.ModelSerializer[int] is not serializers.ModelSerializer

--- a/tests/test_serializer_lists.py
+++ b/tests/test_serializer_lists.py
@@ -62,7 +62,18 @@ class TestListSerializer:
         reason="subscriptable classes requires Python 3.7 or higher",
     )
     def test_list_serializer_is_subscriptable(self):
-        assert serializers.ListSerializer is serializers.ListSerializer["foo"]
+        assert serializers.ListSerializer is not serializers.ListSerializer["foo"]
+
+    @pytest.mark.skipif(
+        sys.version_info > (3, 5),
+        reason="generic meta class behaviour changed from 3.5 to 3.7",
+    )
+    def test_type_annotation_pre_36(self):
+        """
+        This class does NOT inherit directly from Generic, so adding type hints to it
+        should not yield a different class.
+        """
+        assert serializers.ListSerializer[int] is not serializers.ListSerializer
 
 
 class TestListSerializerContainingNestedSerializer:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from django.test import TestCase, override_settings
 from django.urls import path
 
@@ -8,6 +9,7 @@ from rest_framework.routers import SimpleRouter
 from rest_framework.serializers import ModelSerializer
 from rest_framework.utils import json
 from rest_framework.utils.breadcrumbs import get_breadcrumbs
+from rest_framework.utils.field_mapping import ClassLookupDict
 from rest_framework.utils.formatting import lazy_format
 from rest_framework.utils.urls import remove_query_param, replace_query_param
 from rest_framework.views import APIView
@@ -267,3 +269,15 @@ class LazyFormatTests(TestCase):
         assert message.format.call_count == 1
         str(formatted)
         assert message.format.call_count == 1
+
+
+class ClassLookupDictTests(TestCase):
+    def test_type_annotation(self):
+        assert ClassLookupDict[int, int] is not ClassLookupDict
+
+    def test_need_multiple_type_params_when_hinting_class(self):
+        with pytest.raises(TypeError):
+            ClassLookupDict[None]
+
+        with pytest.raises(TypeError):
+            ClassLookupDict[None, None, None]


### PR DESCRIPTION
Specifically, have the following classes inherit from Generic:

* ClassLookupDict
* DataAndFiles
* BaseSerializer
* Field
* RelatedField

This reduces overall boilerplate-y code + feels like a more idiomatic approach.

refs #7624 