### PR TITLE
Allow 'get_page' method for overriding

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -265,8 +265,12 @@ class PageNumberPagination(BasePagination):
         return self.page_size
 
     def get_page_number(self, request):
-        # This can be negative to mean 'pages from the end'.
-        return int(request.query_params.get(self.page_query_param, 1))
+        # This can be negative to mean 'pages from the end'.  Invalid values
+        # are ignored, and the default is page 1.
+        try:
+            return int(request.query_params.get(self.page_query_param, 1))
+        except ValueError:
+            return 1
 
     def get_next_link(self):
         if not self.page.has_next():

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -198,7 +198,7 @@ class PageNumberPagination(BasePagination):
             return None
 
         paginator = self.django_paginator_class(queryset, page_size)
-        page_number = request.query_params.get(self.page_query_param, 1)
+        page_number = self.get_page(request)
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages
 
@@ -263,6 +263,12 @@ class PageNumberPagination(BasePagination):
                 pass
 
         return self.page_size
+
+    def get_page(self, request):
+        return _positive_int(
+            request.query_params.get(self.page_query_param, 1),
+            strict=True,
+        )
 
     def get_next_link(self):
         if not self.page.has_next():

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -198,7 +198,7 @@ class PageNumberPagination(BasePagination):
             return None
 
         paginator = self.django_paginator_class(queryset, page_size)
-        page_number = self.get_page(request)
+        page_number = self.get_page_number(request)
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages
 
@@ -264,11 +264,9 @@ class PageNumberPagination(BasePagination):
 
         return self.page_size
 
-    def get_page(self, request):
-        return _positive_int(
-            request.query_params.get(self.page_query_param, 1),
-            strict=True,
-        )
+    def get_page_number(self, request):
+        # This can be negative to mean 'pages from the end'.
+        return int(request.query_params.get(self.page_query_param, 1))
 
     def get_next_link(self):
         if not self.page.has_next():


### PR DESCRIPTION
In some instances, it may be necessary for subclasses to override the way the page number is resolved.  This work implements a `get_page` method, like the `get_page_size` method, to allow this to be overridden.

This also enforces that page numbers must be greater than zero.  Without this, `page=0` and similar will return a 404.

Signed-off-by: Paul Wayper <paulway@redhat.com>