### PR TITLE
docs: outline the difference between JSON and form parsers. Fix #7633

### DIFF
--- a/docs/api-guide/parsers.md
+++ b/docs/api-guide/parsers.md
@@ -73,7 +73,7 @@ Or, if you're using the `@api_view` decorator with function based views.
 
 ## JSONParser
 
-Parses `JSON` request content.
+Parses `JSON` request content. `request.data` will be populated with a dictionary of data.
 
 **.media_type**: `application/json`
 

--- a/docs/api-guide/requests.md
+++ b/docs/api-guide/requests.md
@@ -23,7 +23,7 @@ REST framework's Request objects provide flexible request parsing that allows yo
 
 * It includes all parsed content, including *file and non-file* inputs.
 * It supports parsing the content of HTTP methods other than `POST`, meaning that you can access the content of `PUT` and `PATCH` requests.
-* It supports REST framework's flexible request parsing, rather than just supporting form data.  For example you can handle incoming JSON data in the same way that you handle incoming form data.
+* It supports REST framework's flexible request parsing, rather than just supporting form data.  For example you can handle incoming [JSON data] similarly to how you handle incoming [form data].
 
 For more details see the [parsers documentation].
 
@@ -136,5 +136,7 @@ Note that due to implementation reasons the `Request` class does not inherit fro
 
 [cite]: https://groups.google.com/d/topic/django-developers/dxI4qVzrBY4/discussion
 [parsers documentation]: parsers.md
+[JSON data]: parsers.md#jsonparser
+[form data]: parsers.md#formparser
 [authentication documentation]: authentication.md
 [browser enhancements documentation]: ../topics/browser-enhancements.md


### PR DESCRIPTION
## Description

This documents the return type of `JSONParser`, modifies the `request.data` wording in the Parsers page and links to JSON and form parsers.

refs #7633 