### PR TITLE
Have options example in documenting-your-api.md to return a Response

### DIFF
--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -202,7 +202,7 @@ You can modify the response behavior to `OPTIONS` requests by overriding the `op
         meta = self.metadata_class()
         data = meta.determine_metadata(request, self)
         data.pop('description')
-        return data
+        return Response(data=data, status=status.HTTP_200_OK)
 
 See [the Metadata docs][metadata-docs] for more details.
 


### PR DESCRIPTION
## Description
Have options example in documenting-your-api.md to return a Response
    
It was returning data which is not correct. Closes #7638.
