### PR TITLE
More helpful errors in logs / terminal

### DIFF
--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -17,9 +17,16 @@ class Response(SimpleTemplateResponse):
     arbitrary media types.
     """
 
-    def __init__(self, data=None, status=None,
-                 template_name=None, headers=None,
-                 exception=False, content_type=None):
+    def __init__(
+        self,
+        data=None,
+        status=None,
+        template_name=None,
+        headers=None,
+        exception=False,
+        content_type=None,
+        reason=None,
+    ):
         """
         Alters the init arguments slightly.
         For example, drop 'template_name', and instead use 'data'.
@@ -41,6 +48,8 @@ class Response(SimpleTemplateResponse):
         self.template_name = template_name
         self.exception = exception
         self.content_type = content_type
+        if reason:
+            self.reason_phrase = "{} ({})".format(self.status_text, reason)
 
         if headers:
             for name, value in headers.items():

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.http.response import HttpResponseBase
 from django.utils.cache import cc_delim_re, patch_vary_headers
 from django.utils.encoding import smart_str
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
@@ -92,11 +93,15 @@ def exception_handler(exc, context):
 
         if isinstance(exc.detail, (list, dict)):
             data = exc.detail
+            reason = _('See response body for full details')
         else:
-            data = {'detail': exc.detail}
+            data = {"detail": exc.detail}
+            reason = str(exc.detail)
+        if isinstance(exc.detail, list) and len(exc.detail) == 1:
+            reason = exc.detail[0]
 
         set_rollback()
-        return Response(data, status=exc.status_code, headers=headers)
+        return Response(data, status=exc.status_code, headers=headers, reason=reason)
 
     return None
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -32,6 +32,7 @@ class MockTextMediaRenderer(BaseRenderer):
 
 DUMMYSTATUS = status.HTTP_200_OK
 DUMMYCONTENT = 'dummycontent'
+DUMMYREASON = 'dummyreason'
 
 
 def RENDERER_A_SERIALIZER(x):
@@ -76,6 +77,12 @@ class MockViewSettingContentType(APIView):
 
     def get(self, request, **kwargs):
         return Response(DUMMYCONTENT, status=DUMMYSTATUS, content_type='setbyview')
+
+
+class MockViewSettingReason(APIView):
+
+    def get(self, request, **kwargs):
+        return Response(DUMMYCONTENT, status=DUMMYSTATUS, reason=DUMMYREASON)
 
 
 class JSONView(APIView):
@@ -125,7 +132,8 @@ urlpatterns = [
     path('html1', HTMLView1.as_view()),
     path('html_new_model', HTMLNewModelView.as_view()),
     path('html_new_model_viewset', include(new_model_viewset_router.urls)),
-    path('restframework', include('rest_framework.urls', namespace='rest_framework'))
+    path('restframework', include('rest_framework.urls', namespace='rest_framework')),
+    path('with_reason', MockViewSettingReason.as_view())
 ]
 
 
@@ -283,3 +291,14 @@ class Issue807Tests(TestCase):
         self.assertEqual(resp['Content-Type'], 'text/html; charset=utf-8')
         # self.assertContains(resp, 'Text comes here')
         # self.assertContains(resp, 'Text description.')
+
+
+@override_settings(ROOT_URLCONF='tests.test_response')
+class ReasonPhraseTests(TestCase):
+    def test_reason_is_set(self):
+        resp = self.client.get('/with_reason')
+        self.assertEqual("OK ({})".format(DUMMYREASON), resp.reason_phrase)
+
+    def test_reason_phrase_with_no_reason(self):
+        resp = self.client.get('/')
+        self.assertEqual("OK", resp.reason_phrase)


### PR DESCRIPTION
## More helpful errors in logs / terminal

Currently the default `error_handler` returns a `Response` with error details in the response body. Django logs `status_code` and the url. For `ValidationError`s and `ParserError`s or any other 400 error this is just `"Bad Request"`, which isn't particularly helpful. There are many other errors where a little extra info beyond the `status_code` is incredibly helpful.

Django's `HttpResponseBase` has a `reason_phrase` property that can be used to provide more detail. 
 - In cases where the exception has a `detail` that is either a string, or a an array of length 1 this detail can be added
 - In more complicated cases a message such as "See response body for full details" can be appended, to point people in the right direction.

Closes #7645 