### PR TITLE
Handle tuples same as lists in ValidationError detail context

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -20,7 +20,7 @@ def _get_error_details(data, default_code=None):
     Descend into a nested data structure, forcing any
     lazy translation strings or strings into `ErrorDetail`.
     """
-    if isinstance(data, list):
+    if isinstance(data, (list, tuple)):
         ret = [
             _get_error_details(item, default_code) for item in data
         ]
@@ -150,7 +150,9 @@ class ValidationError(APIException):
 
         # For validation failures, we may collect many errors together,
         # so the details should always be coerced to a list if not already.
-        if not isinstance(detail, dict) and not isinstance(detail, list):
+        if isinstance(detail, tuple):
+            detail = list(detail)
+        elif not isinstance(detail, dict) and not isinstance(detail, list):
             detail = [detail]
 
         self.detail = _get_error_details(detail, code)

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from rest_framework import serializers, status
 from rest_framework.decorators import api_view
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
@@ -99,3 +100,12 @@ class TestValidationErrorWithCodes(TestCase):
         response = view(request)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == self.expected_response_data
+
+
+class TestValidationErrorConvertsTuplesToLists(TestCase):
+    def test_validation_error_details(self):
+        error = ValidationError(detail=('message1', 'message2'))
+        assert isinstance(error.detail, list)
+        assert len(error.detail) == 2
+        assert str(error.detail[0]) == 'message1'
+        assert str(error.detail[1]) == 'message2'


### PR DESCRIPTION
## Description

This PR changes the behavior of ValidationError slightly. Previously when handling details passed into the constructor, e.g. `ValidationError(detail=('message1', 'message2')) tuples got converted to strings.  This means that the resulting JSON in the response looked similar to

1)
```
"error": "('message1', 'message2')"
```
instead of

2)
```
"error": ["message1", "message2"]
```

which one might expect.

The described behavior might be unintuitive users. This is why after this PR would be merged, tuples would get the same treatment as lists in this regard, ergo result in outcome 2 instead of 1.