### PR TITLE
Allow 'get_page' method for overriding #7626

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -198,7 +198,7 @@ class PageNumberPagination(BasePagination):
             return None
 
         paginator = self.django_paginator_class(queryset, page_size)
-        page_number = request.query_params.get(self.page_query_param, 1)
+        page_number = self.get_page_number(request)
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages
 
@@ -216,6 +216,9 @@ class PageNumberPagination(BasePagination):
 
         self.request = request
         return list(self.page)
+
+    def get_page_number(self, request):
+        return request.query_params.get(self.page_query_param, 1)
 
     def get_paginated_response(self, data):
         return Response(OrderedDict([


### PR DESCRIPTION


## Description

refs [Allow 'get_page' method for overriding ](https://github.com/encode/django-rest-framework/pull/7626)
