### PR TITLE
Add dynamic url, protocol and path to schema generation for pagination

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -229,7 +229,7 @@ class PageNumberPagination(BasePagination):
             ('results', data)
         ]))
 
-    def get_paginated_response_schema(self, schema):
+    def get_paginated_response_schema(self, schema, url='/accounts/', domain='api.example.org', protocol='http'):
         return {
             'type': 'object',
             'properties': {
@@ -241,15 +241,15 @@ class PageNumberPagination(BasePagination):
                     'type': 'string',
                     'nullable': True,
                     'format': 'uri',
-                    'example': 'http://api.example.org/accounts/?{page_query_param}=4'.format(
-                        page_query_param=self.page_query_param)
+                    'example': '{protocol}://{domain}{url}?{page_query_param}=4'.format(
+                        page_query_param=self.page_query_param, protocol=protocol, domain=domain, url=url)
                 },
                 'previous': {
                     'type': 'string',
                     'nullable': True,
                     'format': 'uri',
-                    'example': 'http://api.example.org/accounts/?{page_query_param}=2'.format(
-                        page_query_param=self.page_query_param)
+                    'example': '{protocol}://{domain}{url}?{page_query_param}=2'.format(
+                        page_query_param=self.page_query_param, protocol=protocol, domain=domain, url=url)
                 },
                 'results': schema,
             },
@@ -402,7 +402,7 @@ class LimitOffsetPagination(BasePagination):
             ('results', data)
         ]))
 
-    def get_paginated_response_schema(self, schema):
+    def get_paginated_response_schema(self, schema, url='/accounts/', domain='api.example.org', protocol='http'):
         return {
             'type': 'object',
             'properties': {
@@ -414,15 +414,19 @@ class LimitOffsetPagination(BasePagination):
                     'type': 'string',
                     'nullable': True,
                     'format': 'uri',
-                    'example': 'http://api.example.org/accounts/?{offset_param}=400&{limit_param}=100'.format(
-                        offset_param=self.offset_query_param, limit_param=self.limit_query_param),
+                    'example': '{protocol}://{domain}{url}?{offset_param}=400&{limit_param}=100'.format(
+                        offset_param=self.offset_query_param, limit_param=self.limit_query_param,
+                        protocol=protocol, domain=domain, url=url
+                    ),
                 },
                 'previous': {
                     'type': 'string',
                     'nullable': True,
                     'format': 'uri',
-                    'example': 'http://api.example.org/accounts/?{offset_param}=200&{limit_param}=100'.format(
-                        offset_param=self.offset_query_param, limit_param=self.limit_query_param),
+                    'example': '{protocol}://{domain}{url}?{offset_param}=200&{limit_param}=100'.format(
+                        offset_param=self.offset_query_param, limit_param=self.limit_query_param,
+                        protocol=protocol, domain=domain, url=url
+                    ),
                 },
                 'results': schema,
             },
@@ -898,7 +902,7 @@ class CursorPagination(BasePagination):
             ('results', data)
         ]))
 
-    def get_paginated_response_schema(self, schema):
+    def get_paginated_response_schema(self, schema, url='/accounts/', domain='api.example.org', protocol='http'):
         return {
             'type': 'object',
             'properties': {

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -118,7 +118,8 @@ class SchemaGenerator(BaseSchemaGenerator):
 
 class AutoSchema(ViewInspector):
 
-    def __init__(self, tags=None, operation_id_base=None, component_name=None):
+    def __init__(self, tags=None, operation_id_base=None, component_name=None, domain='api.example.org',
+                 protocol='http'):
         """
         :param operation_id_base: user-defined name in operationId. If empty, it will be deducted from the Model/Serializer/View name.
         :param component_name: user-defined component's name. If empty, it will be deducted from the Serializer's class name.
@@ -128,6 +129,8 @@ class AutoSchema(ViewInspector):
         self._tags = tags
         self.operation_id_base = operation_id_base
         self.component_name = component_name
+        self.domain = domain
+        self.protocol = protocol
         super().__init__()
 
     request_media_types = []
@@ -683,7 +686,12 @@ class AutoSchema(ViewInspector):
             }
             paginator = self.get_paginator()
             if paginator:
-                response_schema = paginator.get_paginated_response_schema(response_schema)
+                response_schema = paginator.get_paginated_response_schema(
+                    response_schema,
+                    url=path,
+                    domain=self.get_schema_domain(),
+                    protocol=self.get_schema_protocol()
+                )
         else:
             response_schema = item_schema
         status_code = '201' if method == 'POST' else '200'
@@ -712,6 +720,12 @@ class AutoSchema(ViewInspector):
             path = path[1:]
 
         return [path.split('/')[0].replace('_', '-')]
+
+    def get_schema_domain(self):
+        return self.domain
+
+    def get_schema_protocol(self):
+        return self.protocol
 
     def _get_path_parameters(self, path, method):
         warnings.warn(


### PR DESCRIPTION
- add `domain` and `protocol` to `AutoSchema` init
- add `get_schema_domain` and `get_schema_protocol` to `AutoSchema`
- adapt pagination classes to accept `domain`, `protocol` and `path` for method `get_paginated_response_schema`
- adapt `test_paginated_list_response_body_generation`
  - do not use custom `Pagination` implementation, rather use `PageNumberPagination`
  - make sure new parameters `domain`, `protocol` and `path` are tested as well

Closes #7655 

Any feedback, comments or suggestions welcome. Let me know if you guys like the approach or not. 
If there are no objections concerning the approach I'm happy to add some documentation as well.