### PR TITLE
Added support for queryset in DjangoModelPermissions for functional-based views

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -69,6 +69,7 @@ def api_view(http_method_names=None):
 
         WrappedAPIView.permission_classes = getattr(func, 'permission_classes',
                                                     APIView.permission_classes)
+        WrappedAPIView.queryset = getattr(func, 'queryset', APIView.permission_classes)
 
         WrappedAPIView.schema = getattr(func, 'schema',
                                         APIView.schema)
@@ -106,9 +107,11 @@ def throttle_classes(throttle_classes):
     return decorator
 
 
-def permission_classes(permission_classes):
+def permission_classes(permission_classes, queryset=None):
     def decorator(func):
         func.permission_classes = permission_classes
+        if queryset is not None:
+            func.queryset = queryset
         return func
     return decorator
 


### PR DESCRIPTION
## Description

Proposed solution to fixing the #7662 Issue 

Pass the queryset as the second parmater in permission_classess decorator

```

@api_view(['GET'])
@permission_classes((CustomDjangoModelPermissions,), queryset=MyModel.objects.all())
def test(request):
    if request.method == 'GET':
```
      