### PR TITLE
ValueFromContext

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -183,6 +183,16 @@ A default class that can be used to represent the current user. In order to use 
         default=serializers.CurrentUserDefault()
     )
 
+#### ValueFromContext
+
+CurrentUserDefault is an example of extracting a value from context and setting a hidden field to this value.  This pattern resurfaces in a number of contexts related to hidden fields, and you may wish to insert something other than user, such as a parent object who's ID was extracted from the URL as part of view processing.  Simply pass in the value to extract from the context:
+
+    parent = serializers.HiddenField(
+        default=serializers.ValueFromContext("parent_object")
+    )
+
+In the event that there is nested data inside the context that you need to extract, you can override ValueFromContext's call method.
+
 #### CreateOnlyDefault
 
 A default class that can be used to *only set a default argument during create operations*. During updates the field is omitted.

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -283,14 +283,25 @@ class CreateOnlyDefault:
         return '%s(%s)' % (self.__class__.__name__, repr(self.default))
 
 
-class CurrentUserDefault:
+class ValueFromContext:
     requires_context = True
 
+    def __init__(self, context_name):
+        self.context_name = context_name
+
     def __call__(self, serializer_field):
-        return serializer_field.context['request'].user
+        return serializer_field.context[self.context_name]
 
     def __repr__(self):
-        return '%s()' % self.__class__.__name__
+        return "%s()" % self.__class__.__name__
+
+
+class CurrentUserDefault(ValueFromContext):
+    def __init__(self, *args, **kwargs):
+        super().__init__(context_name="request")
+
+    def __call__(self, serializer_field):
+        return super().__call__(serializer_field).user
 
 
 class SkipField(Exception):


### PR DESCRIPTION
## Description

In our environment, we deal with a number of nested objects (e.g. many to one relations such as income documentation uploads associated with an employment record) where we extract the parent object id from the url at the ViewSet (and GQL mutation resolver) level.  We then set the context, and allow the serializer to simply extract from there.  We've found this pattern more explicit respects contract boundaries and allows for more efficient querying of data.  The CurrentUserDefault implementation is a single example of this.  By exposing a more general 'ValueFromContext" helper, we can allow developers to build serializers more simply and better respect the boundary between controller and view logic.

Note: This PR also introduces tests for CurrentUserDefault.  I could not find any of these before.


