### PR TITLE
Better handle conflicting keys in set_values

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -125,9 +125,14 @@ def set_value(dictionary, keys, value):
     for key in keys[:-1]:
         if key not in dictionary:
             dictionary[key] = {}
+        elif type(dictionary[key]) is not dict:
+            dictionary[key] = {'': dictionary[key]}
         dictionary = dictionary[key]
 
-    dictionary[keys[-1]] = value
+    if keys[-1] in dictionary and type(dictionary[keys[-1]]) is dict:
+        dictionary[keys[-1]][''] = value
+    else:
+        dictionary[keys[-1]] = value
 
 
 def to_choices_dict(choices):


### PR DESCRIPTION
This commit adds logic to set_values to move values on keys to be added upon to a blank key inside the value's previous key. This would allow constructions like:

```python
fk_object = HyperlinkedRelatedField(source='fk')
fk_name = CharField('fk.field')
```

This is important for my use-case to allow linking to an existing object, or creating/modifying it from a related field's serializer.

Tests are also added specifically for set_values with the examples given in the function description as well as for this change.