### PR TITLE
upgrade to latest version of pytest+pytest-django to eliminate depend…

### DIFF
--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,4 +1,4 @@
 # Pytest for running the tests.
-pytest>=5.4.1,<5.5
-pytest-django>=3.9.0,<3.10
-pytest-cov>=2.7.1
+pytest>=6.2.1,<6.3
+pytest-django>=4.1.0,<4.2
+pytest-cov>=2.10.1


### PR DESCRIPTION
## Description

PR's are failing regularly due to pytest-django 3.9's dependency on six.  This is a minimalist PR for correcting that single issue to hopefully unblock the test pipeline.  Tests pass locally, but unfortunately they passed locally before this.  

I will spend some time later (holidays) attempting to identify any other packages that may have a dependency on six and see if we can upgrade and/or replace those.