### PR TITLE
expose configurable allowing a default to be set on partial updates

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -48,7 +48,7 @@ Defaults to `True`.
 
 If set, this gives the default value that will be used for the field if no input value is supplied. If not set the default behaviour is to not populate the attribute at all.
 
-The `default` is not applied during partial update operations. In the partial update case only fields that are provided in the incoming data will have a validated value returned.
+The `default` is not applied during partial update operations, unless `set_default_if_partial` is set to True. In the typical path partial update case only fields that are provided in the incoming data will have a validated value returned.
 
 May be set to a function or other callable, in which case the value will be evaluated each time it is used. When called, it will receive no arguments. If the callable has a `requires_context = True` attribute, then the serializer field will be passed as an argument.
 
@@ -67,6 +67,12 @@ For example:
 When serializing the instance, default will be used if the object attribute or dictionary key is not present in the instance.
 
 Note that setting a `default` value implies that the field is not required. Including both the `default` and `required` keyword arguments is invalid and will raise an error.
+
+### set_default_if_partial
+
+The `default` is not applied during partial update operations, unless `set_default_if_partial` is set to True.  If set to True, the partial update will include the default value.  Otherwise, partial updates will only apply to fields provided in the incoming data.  
+
+Note: This parameter is particularly useful for HiddenInput's with default values.
 
 ### `allow_null`
 
@@ -542,7 +548,7 @@ For example, if `has_expired` was a property on the `Account` model, then the fo
 
 ## HiddenField
 
-A field class that does not take a value based on user input, but instead takes its value from a default value or callable.
+A field class that does not take a value based on user input, but instead takes its value from a default value or callable.  In the case of a partial update, the `default` value will not be applied unless `set_default_on_partial` is set to True for this field.
 
 **Signature**: `HiddenField()`
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -610,6 +610,18 @@ class TestDefaultInclusions:
         assert serializer.validated_data == {'integer': 456}
         assert serializer.errors == {}
 
+    def test_default_should_be_included_on_partial_update_when_set_default_on_partial_true(self):
+        class ExampleSerializer(serializers.Serializer):
+            char = serializers.CharField(default='abc', set_default_on_partial=True)
+            integer = serializers.IntegerField()
+            float = serializers.FloatField(required=False)
+
+        instance = MockObject(char='def', integer=123, float=4.2)
+        serializer = ExampleSerializer(instance, data={'integer': 456})
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'char': 'abc', 'integer': 456}
+        assert serializer.errors == {}
+
 
 class TestSerializerValidationWithCompiledRegexField:
     def setup(self):


### PR DESCRIPTION
## Description

In our environment, objects are frequently bound to user or parent object scopes, for which all access is achieved via django's reverse accessors.  Access to these parent objects is commonly set via usage of CurrentUserDefault (for the user) and context-driven variables set at the controller (e.g. viewset) layer and passed to the serializer via a HiddenField.  Unfortunately, for these scenarios, partial updates are painful - differing querysets must be used (e.g. user.randomobject_set.get(id=hidden_input_id) instead uses RandomObject.objects.get(id=id)).  This limits our ability to safely enforce multitenancy.  Allowing a default to always be set for partials (especially in the context of HiddenField) neatly solves this case.  

I've provided a verbosely named and highly specific parameter named `set_default_if_partial` to the Field object and ensured that the get_default behavior is changed when this is set to True, it will no longer raise a SkipField but instead set the default.  This ensures we do not apply a breaking change to this existing behavior, while allowing more easily configurable partial update behavior.

Example of this problem occurring on Stack Overflow demonstrating it is not just me running into this include:
- https://stackoverflow.com/questions/41110742/django-rest-framework-partial-update (search for "multi-attribute/field validation")

