### PR TITLE
Add support for Django views to routers

### DIFF
--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -27,7 +27,7 @@ Here's an example of a simple URL conf, that uses `SimpleRouter`.
 There are two mandatory arguments to the `register()` method:
 
 * `prefix` - The URL prefix to use for this set of routes.
-* `viewset` - The viewset class.
+* `viewset` - The view handler: either a REST Framework `ViewSet`, REST Framework `APIView`, Django `View`, or Django view function. If you provide a class (as opposed to a Django view function), make sure to only provide the class; don't instantiate the class.
 
 Optionally, you may also specify an additional argument:
 

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -18,6 +18,7 @@ from collections import OrderedDict, namedtuple
 
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch, re_path
+from django.views.generic.base import View
 
 from rest_framework import views
 from rest_framework.response import Response
@@ -262,7 +263,13 @@ class SimpleRouter(BaseRouter):
                     'detail': route.detail,
                 })
 
-                view = viewset.as_view(mapping, **initkwargs)
+                if isinstance(viewset, ViewSet) or isinstance(viewset, View):
+                    # `viewset` is either a REST Framework `ViewSet`
+                    #   or a Django class-based view.
+                    view = viewset.as_view(mapping, **initkwargs)
+                else:
+                    # assume that `viewset` is a Django view function
+                    view = viewset
                 name = route.name.format(basename=basename)
                 ret.append(re_path(regex, view, name=name))
 

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -309,11 +309,11 @@ class APIRootView(views.APIView):
         # Return a plain {"name": "hyperlink"} response.
         ret = OrderedDict()
         namespace = request.resolver_match.namespace
+        reverse_dict = get_resolver().reverse_dict
         for key, url_name in self.api_root_dict.items():
             if namespace:
                 url_name = namespace + ':' + url_name
             try:
-                reverse_dict = get_resolver().reverse_dict
                 if reverse_dict.get(url_name):
                     # REST Framework view
                     view_name = url_name

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -151,7 +151,7 @@ class SimpleRouter(BaseRouter):
         # converting to list as iterables are good for one pass, known host needs to be checked again and again for
         # different functions.
         known_actions = list(flatten([route.mapping.values() for route in self.routes if isinstance(route, Route)]))
-        extra_actions = viewset.get_extra_actions()
+        extra_actions = viewset.get_extra_actions() if isinstance(viewset, ViewSet) else []
 
         # checking action names against the known actions list
         not_allowed = [

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -27,6 +27,7 @@ from rest_framework.schemas import SchemaGenerator
 from rest_framework.schemas.views import SchemaView
 from rest_framework.settings import api_settings
 from rest_framework.urlpatterns import format_suffix_patterns
+from rest_framework.viewsets import ViewSet
 
 Route = namedtuple('Route', ['url', 'mapping', 'name', 'detail', 'initkwargs'])
 DynamicRoute = namedtuple('DynamicRoute', ['url', 'name', 'detail', 'initkwargs'])

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -20,6 +20,7 @@ from inspect import isclass
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch, re_path, path
 from django.views.generic.base import View
+from django.urls import get_resolver
 
 from rest_framework import views
 from rest_framework.response import Response
@@ -312,8 +313,18 @@ class APIRootView(views.APIView):
             if namespace:
                 url_name = namespace + ':' + url_name
             try:
+                reverse_dict = get_resolver().reverse_dict
+                if reverse_dict.get(url_name):
+                    # REST Framework view
+                    view_name = url_name
+                elif reverse_dict.get(key):
+                    # Django view
+                    view_name = key
+                else:
+                    continue
+
                 ret[key] = reverse(
-                    key,
+                    view_name,
                     args=args,
                     kwargs=kwargs,
                     request=request,

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -15,6 +15,7 @@ For example, you might have a `urls.py` that looks something like this:
 """
 import itertools
 from collections import OrderedDict, namedtuple
+from inspect import isclass
 
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch, re_path, path
@@ -150,11 +151,13 @@ class SimpleRouter(BaseRouter):
         """
         # use `issubclass` and not `isinstance` because `viewset` may be an
         #   uninstantiated class.
-        if not issubclass(viewset, ViewSetMixin):
-            if issubclass(viewset, View):
-                return [viewset.as_view(), ]
+        is_viewset = issubclass(viewset, ViewSetMixin) if isclass(viewset) else False
+        if not is_viewset:
             # `viewset` is not a REST Framework ViewSet,
             #   so we can't dynamically generate any routes
+            is_cbv = issubclass(viewset, View) if isclass(viewset) else False
+            if is_cbv:
+                return [viewset.as_view(), ]
             return [viewset, ]
 
         # converting to list as iterables are good for one pass, known host needs to be checked again and again for

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -188,7 +188,7 @@ class TestRootView(URLPatternsTestCase, TestCase):
         assert response.data == {
             "example1": "http://testserver/django-views/example1",
             "example2": "http://testserver/django-views/example2",
-            "example3": "http://testserver/django-views/example3",
+            "example3": "http://testserver/django-views/example3/",
         }
 
     def test_retrieve_namespaced_root(self):

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -184,10 +184,10 @@ class TestRootView(URLPatternsTestCase, TestCase):
     
     def test_django_views(self):
         response = self.client.get('/django-views/')
-        # assert response.data == {""}
-        print('urld', django_view_router.urls)
-        print('rd', response.data)
-        assert False
+        assert response.data == {
+            "example1": "http://testserver/django-views/example1",
+            "example2": "http://testserver/django-views/example2",
+        }
 
     def test_retrieve_namespaced_root(self):
         response = self.client.get('/namespaced/')

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -179,13 +179,15 @@ class TestRootView(URLPatternsTestCase, TestCase):
     urlpatterns = [
         path('non-namespaced/', include(namespaced_router.urls)),
         path('namespaced/', include((namespaced_router.urls, 'namespaced'), namespace='namespaced')),
-        path('/django-views/', include(django_view_router.urls)),
+        path('django-views/', include(django_view_router.urls)),
     ]
     
     def test_django_views(self):
         response = self.client.get('/django-views/')
         # assert response.data == {""}
-        assert False, response.data
+        print('urld', django_view_router.urls)
+        print('rd', response.data)
+        assert False
 
     def test_retrieve_namespaced_root(self):
         response = self.client.get('/namespaced/')

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -104,6 +104,7 @@ regex_url_path_router.register(r'', RegexUrlPathViewSet, basename='regex')
 django_view_router = DefaultRouter()
 django_view_router.register(r'example1', MockView, basename='example1')
 django_view_router.register(r'example2', mock_view, basename='example2')
+django_view_router.register(r'example3', MockViewSet, basename='example3')
 
 
 class BasicViewSet(viewsets.ViewSet):
@@ -187,6 +188,7 @@ class TestRootView(URLPatternsTestCase, TestCase):
         assert response.data == {
             "example1": "http://testserver/django-views/example1",
             "example2": "http://testserver/django-views/example2",
+            "example3": "http://testserver/django-views/example3",
         }
 
     def test_retrieve_namespaced_root(self):


### PR DESCRIPTION
## Description

This PR adds support for adding Django view function, Django class-based views, and DRF `APIView`s to DRF routers. This is very useful for combining `ViewSet`s with "custom" views while still being able to use DRF's amazing browseable root page in `DefaultRouter`s. 

usage:
```python
django_view_router = DefaultRouter()
django_view_router.register(r'django-class', ViewClass, basename='example1')
django_view_router.register(r'django-function', view_function, basename='example2')
django_view_router.register(r'drf-viewset', MyViewSet, basename='example3')
```

see https://github.com/sumanthratna/drf-browseable-views for a full demo

and in the browseable API, you should see three routes listed: `django-class`, `django-function`, and `drf-viewset`

refs/fixes #3931