### PR TITLE
Add django-rest-authemail to Third Party Packages

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -432,6 +432,10 @@ There are currently two forks of this project.
 
 [drfpasswordless][drfpasswordless] adds (Medium, Square Cash inspired) passwordless support to Django REST Framework's own TokenAuthentication scheme. Users log in and sign up with a token sent to a contact point like an email address or a mobile number.
 
+## django-rest-authemail
+
+[django-rest-authemail][django-rest-authemail] provides a RESTful API interface for user signup and authentication. Email addresses are used for authentication, rather than usernames.  API endpoints are available for signup, signup email verification, login, logout, password reset, password reset verification, email change, email change verification, password change, and user detail.  A fully-functional example project and detailed instructions are included.
+
 [cite]: https://jacobian.org/writing/rest-worst-practices/
 [http401]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
 [http403]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
@@ -466,3 +470,4 @@ There are currently two forks of this project.
 [django-rest-framework-social-oauth2]: https://github.com/PhilipGarnero/django-rest-framework-social-oauth2
 [django-rest-knox]: https://github.com/James1345/django-rest-knox
 [drfpasswordless]: https://github.com/aaronn/django-rest-framework-passwordless
+[django-rest-authemail]: https://github.com/celiao/django-rest-authemail

--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -190,6 +190,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [django-rest-auth][django-rest-auth] - Provides a set of REST API endpoints for registration, authentication (including social media authentication), password reset, retrieve and update user details, etc.
 * [drf-oidc-auth][drf-oidc-auth] - Implements OpenID Connect token authentication for DRF.
 * [drfpasswordless][drfpasswordless] - Adds (Medium, Square Cash inspired) passwordless logins and signups via email and mobile numbers.
+* [django-rest-authemail][django-rest-authemail] - Provides a RESTful API for user signup and authentication using email addresses.
 
 ### Permissions
 
@@ -362,3 +363,4 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [django-elasticsearch-dsl-drf]: https://github.com/barseghyanartur/django-elasticsearch-dsl-drf
 [django-api-client]: https://github.com/rhenter/django-api-client
 [drf-psq]: https://github.com/drf-psq/drf-psq
+[django-rest-authemail]: https://github.com/celiao/django-rest-authemail


### PR DESCRIPTION
## Description

This pull request adds [django-rest-authemail](https://github.com/celiao/django-rest-authemail) to Third Party Packages, under Authentication.

[django-rest-authemail](https://github.com/celiao/django-rest-authemail) supports and is tested with Python 3.6/3.7/3.8, Django 2.2.8/2.2.13/3.0/3.1, and Django REST Framework 3.11.0.

[django-rest-authemail](https://github.com/celiao/django-rest-authemail) can be found on PyPi [here](https://pypi.org/project/django-rest-authemail/).

[django-rest-authemail](https://github.com/celiao/django-rest-authemail) can be found on the [Django REST Framework grid](https://djangopackages.org/grids/g/django-rest-framework/) on Django Packages [here](https://djangopackages.org/packages/p/django-rest-authemail/).
