### PR TITLE
Properly escape code block in docstring

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -905,13 +905,13 @@ class ModelSerializer(Serializer):
         """
         We have a bit of extra checking around this in order to provide
         descriptive messages when something goes wrong, but this method is
-        essentially just:
+        essentially just::
 
             return ExampleModel.objects.create(**validated_data)
 
         If there are many to many fields present on the instance then they
         cannot be set until the model is instantiated, in which case the
-        implementation is like so:
+        implementation is like so::
 
             example_relationship = validated_data.pop('example_relationship')
             instance = ExampleModel.objects.create(**validated_data)


### PR DESCRIPTION
Fix a problem where the code block in the ModelSerializer create()
docstring was improperly escaped which causes sphinx to raise a warning
about the un-terminated strong text.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
