### PR TITLE
Allow customization in AutoSchema for determining if a serializer is valid

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -375,6 +375,16 @@ operationIds.
 In order to work around this, you can override `get_operation_id_base()` to
 provide a different base for name part of the ID.
 
+#### `is_valid_serializer()`
+
+Returns true if a serializer instance will produce a valid component schema 
+for describing request and response bodies. The default behavior is to return
+'True' for any Serializer instance.
+
+If you have a custom subclass of BaseSerializer which is capable of producing
+a component schema, you can use that component schema by overrideing this method
+(along with `map_serializer()`).
+
 ### `AutoSchema.__init__()` kwargs
 
 `AutoSchema` provides a number of `__init__()` kwargs that can be used for

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -194,7 +194,7 @@ class AutoSchema(ViewInspector):
 
         serializer = self.get_serializer(path, method)
 
-        if not isinstance(serializer, serializers.Serializer):
+        if not self.is_valid_serializer(serializer):
             return {}
 
         component_name = self.get_component_name(serializer)
@@ -626,7 +626,7 @@ class AutoSchema(ViewInspector):
 
         serializer = self.get_serializer(path, method)
 
-        if not isinstance(serializer, serializers.Serializer):
+        if not self.is_valid_serializer(serializer):
             item_schema = {}
         else:
             item_schema = self._get_reference(serializer)
@@ -650,7 +650,7 @@ class AutoSchema(ViewInspector):
 
         serializer = self.get_serializer(path, method)
 
-        if not isinstance(serializer, serializers.Serializer):
+        if not self.is_valid_serializer(serializer):
             item_schema = {}
         else:
             item_schema = self._get_reference(serializer)
@@ -691,6 +691,10 @@ class AutoSchema(ViewInspector):
             path = path[1:]
 
         return [path.split('/')[0].replace('_', '-')]
+
+    def is_valid_serializer(self, serializer):
+        # return True if the serializer produces a valid component schema
+        return isinstance(serializer, serializers.Serializer)
 
     def _get_path_parameters(self, path, method):
         warnings.warn(


### PR DESCRIPTION
I have a subclass of serializers.BaseSerializer which produces a valid component schema, but for that component schema to actually be used in API docs I have to override every method in AutoSchema which checks `isinstance(serializer, Serializer)` -- get_components(), get_request_body(), and get_responses()

Centralizing that logic removes the need to override these methods