### PR TITLE
Fix CursorPagination parameter schema type

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -961,7 +961,7 @@ class CursorPagination(BasePagination):
                 'in': 'query',
                 'description': force_str(self.cursor_query_description),
                 'schema': {
-                    'type': 'integer',
+                    'type': 'string',
                 },
             }
         ]


### PR DESCRIPTION
## Description

The CursorPagination's cursor query parameter expects a string and not
an integer.

This fixes issues where a valid cursor is rejected due to an incompatible type in the schema.

refs #7691
