### PR TITLE
Solve the typo issue with character [AR Locale]

### DIFF
--- a/rest_framework/locale/ar/LC_MESSAGES/django.po
+++ b/rest_framework/locale/ar/LC_MESSAGES/django.po
@@ -8,6 +8,7 @@
 # Bashar Al-Abdulhadi, 2016-2017
 # Eyad Toma <d.eyad.t@gmail.com>, 2015,2017
 # zak zak <zakaria.bendifallah@gmail.com>, 2020
+# Elayan Hamamrah <elayan.hr@gmail.com>, 2021
 msgid ""
 msgstr ""
 "Project-Id-Version: Django REST framework\n"

--- a/rest_framework/locale/ar/LC_MESSAGES/django.po
+++ b/rest_framework/locale/ar/LC_MESSAGES/django.po
@@ -179,12 +179,12 @@ msgstr "لا يمكن لهذا الحقل ان يكون فارغاً."
 #: fields.py:768 fields.py:1881
 #, python-brace-format
 msgid "Ensure this field has no more than {max_length} characters."
-msgstr "تأكد ان الحقل لا يزيد عن {max_length} محرف."
+msgstr "تأكد ان الحقل لا يزيد عن {max_length} حرف."
 
 #: fields.py:769
 #, python-brace-format
 msgid "Ensure this field has at least {min_length} characters."
-msgstr "تأكد ان الحقل {min_length} محرف على الاقل."
+msgstr "تأكد ان الحقل {min_length} حرف على الاقل."
 
 #: fields.py:816
 msgid "Enter a valid email address."
@@ -340,7 +340,7 @@ msgstr "الملف الذي تم إرساله فارغ."
 #, python-brace-format
 msgid ""
 "Ensure this filename has at most {max_length} characters (it has {length})."
-msgstr "تأكد ان اسم الملف لا يحوي أكثر من {max_length} محرف (الإسم المرسل يحوي {length} محرف)."
+msgstr "تأكد ان اسم الملف لا يحوي أكثر من {max_length} حرف (الإسم المرسل يحوي {length} حرف)."
 
 #: fields.py:1566
 msgid ""


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

The issue was with typo locale in the Arabic language, As 'character' translation is 'حرف' and not 'محرف'
