### PR TITLE
Respect allow_null=True on DecimalFields

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1063,6 +1063,9 @@ class DecimalField(Field):
         try:
             value = decimal.Decimal(data)
         except decimal.DecimalException:
+            if data == '' and self.allow_null:
+                return None
+
             self.fail('invalid')
 
         if value.is_nan():
@@ -1111,6 +1114,12 @@ class DecimalField(Field):
 
     def to_representation(self, value):
         coerce_to_string = getattr(self, 'coerce_to_string', api_settings.COERCE_DECIMAL_TO_STRING)
+
+        if value is None:
+            if coerce_to_string:
+                return ''
+            else:
+                return None
 
         if not isinstance(value, decimal.Decimal):
             value = decimal.Decimal(str(value).strip())

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1090,6 +1090,9 @@ class TestDecimalField(FieldValues):
         '2E+1': Decimal('20'),
     }
     invalid_inputs = (
+        (None, ["This field may not be null."]),
+        ('', ["A valid number is required."]),
+        (' ', ["A valid number is required."]),
         ('abc', ["A valid number is required."]),
         (Decimal('Nan'), ["A valid number is required."]),
         (Decimal('Snan'), ["A valid number is required."]),
@@ -1113,6 +1116,32 @@ class TestDecimalField(FieldValues):
         Decimal('0.04'): '0.0'
     }
     field = serializers.DecimalField(max_digits=3, decimal_places=1)
+
+
+class TestAllowNullDecimalField(FieldValues):
+    valid_inputs = {
+        None: None,
+        '': None,
+        ' ': None,
+    }
+    invalid_inputs = {}
+    outputs = {
+        None: '',
+    }
+    field = serializers.DecimalField(max_digits=3, decimal_places=1, allow_null=True)
+
+
+class TestAllowNullNoStringCoercionDecimalField(FieldValues):
+    valid_inputs = {
+        None: None,
+        '': None,
+        ' ': None,
+    }
+    invalid_inputs = {}
+    outputs = {
+        None: None,
+    }
+    field = serializers.DecimalField(max_digits=3, decimal_places=1, allow_null=True, coerce_to_string=False)
 
 
 class TestMinMaxDecimalField(FieldValues):


### PR DESCRIPTION
Closes #7721 

* Handle None in to_representation()
* Return None as '' in to_representation() when coerce_to_string=True
* Handle '' as None in to_internal_value(), for symmetry with
  to_representation(), and because the empty concept doesn't make sense
  for Decimal.

The main fix is the handling of None in to_representation(), but I'm not sure the handling of coerce_to_string makes sense, so I'm definitely open to discussion here.