### PR TITLE
Update perms_map in DjangoModelPermissions and DjangoObjectPermissions

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -175,7 +175,7 @@ class DjangoModelPermissions(BasePermission):
     # Override this if you need to also provide 'view' permissions,
     # or if you want to provide custom permission codes.
     perms_map = {
-        'GET': [],
+        'GET': ['%(app_label)s.view_%(model_name)s'],
         'OPTIONS': [],
         'HEAD': [],
         'POST': ['%(app_label)s.add_%(model_name)s'],
@@ -252,7 +252,7 @@ class DjangoObjectPermissions(DjangoModelPermissions):
     provide a `.queryset` attribute.
     """
     perms_map = {
-        'GET': [],
+        'GET': ['%(app_label)s.view_%(model_name)s'],
         'OPTIONS': [],
         'HEAD': [],
         'POST': ['%(app_label)s.add_%(model_name)s'],


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

Django permissions allows for 'view_modelname'. When users have view_modelname permission, these permission classes don't recognize it and reject access to the user.

My specific case was assigning customers to a group with the group having specific permissions allowed from the model permissions. Made this edit in an extension of DjangoModelPermissions to make it work. Thought it would be useful to have inherently. Not sure if this solves an existing error of any sort.