### PR TITLE
Reproduce #7706

### DIFF
--- a/tests/test_bound_fields.py
+++ b/tests/test_bound_fields.py
@@ -163,6 +163,33 @@ class TestNestedBoundField:
             rendered_packed = ''.join(rendered.split())
             assert rendered_packed == expected_packed
 
+    def test_rendering_nested_fields_with_not_mappable_value(self):
+        from rest_framework.renderers import HTMLFormRenderer
+
+        class Nested(serializers.Serializer):
+            text_field = serializers.CharField()
+
+        class ExampleSerializer(serializers.Serializer):
+            nested = Nested()
+
+        serializer = ExampleSerializer(data={'nested': 1})
+        assert not serializer.is_valid()
+        renderer = HTMLFormRenderer()
+        for field in serializer:
+            rendered = renderer.render_field(field, {})
+            expected_packed = (
+                '<fieldset>'
+                '<legend>Nested</legend>'
+                '<divclass="form-group">'
+                '<label>Textfield</label>'
+                '<inputname="nested.text_field"class="form-control"type="text"value="">'
+                '</div>'
+                '</fieldset>'
+            )
+
+            rendered_packed = ''.join(rendered.split())
+            assert rendered_packed == expected_packed
+
 
 class TestJSONBoundField:
     def test_as_form_fields(self):


### PR DESCRIPTION
Rendering a value that is not mappable for a nested serializer ends up in a crash.

## Description

refs #7706

This PR is created in order to reproduce the issue #7706. It's a minimal example to show it. When a value that is not a `Mappable` is provided to a nested serializer, the rendering of `NestedBoundField`, which takes place for Browsable API, ends up in an error, which is not caught.
