### PR TITLE
Fix #7706

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 
 from django.utils.encoding import force_str
 
@@ -101,7 +101,7 @@ class NestedBoundField(BoundField):
     """
 
     def __init__(self, field, value, errors, prefix=''):
-        if value is None or value == '':
+        if value is None or value == '' or not isinstance(value, Mapping):
             value = {}
         super().__init__(field, value, errors, prefix)
 

--- a/tests/test_bound_fields.py
+++ b/tests/test_bound_fields.py
@@ -163,6 +163,33 @@ class TestNestedBoundField:
             rendered_packed = ''.join(rendered.split())
             assert rendered_packed == expected_packed
 
+    def test_rendering_nested_fields_with_not_mappable_value(self):
+        from rest_framework.renderers import HTMLFormRenderer
+
+        class Nested(serializers.Serializer):
+            text_field = serializers.CharField()
+
+        class ExampleSerializer(serializers.Serializer):
+            nested = Nested()
+
+        serializer = ExampleSerializer(data={'nested': 1})
+        assert not serializer.is_valid()
+        renderer = HTMLFormRenderer()
+        for field in serializer:
+            rendered = renderer.render_field(field, {})
+            expected_packed = (
+                '<fieldset>'
+                '<legend>Nested</legend>'
+                '<divclass="form-group">'
+                '<label>Textfield</label>'
+                '<inputname="nested.text_field"class="form-control"type="text"value="">'
+                '</div>'
+                '</fieldset>'
+            )
+
+            rendered_packed = ''.join(rendered.split())
+            assert rendered_packed == expected_packed
+
 
 class TestJSONBoundField:
     def test_as_form_fields(self):


### PR DESCRIPTION
Handle non-dict values for NestedSerializer during BrowsableAPI rendering.

## Description

This PR is created in order to fix issue #7706. When a value that is not a Mappable is provided to a nested serializer, the rendering of NestedBoundField, which takes place for Browsable API, ends up in an error, which is not caught. Here, the suggested solution is to an empty `dict` if it is not an instance of any `Mappable` such as `dict`. Since the data is not valid and the validation error is not a field-specific error, I did not try to find a solution to show it in the `HTML form` in browsable API. Instead, I decided not to show that error in the `HTML form` and to convert the data to an empty `dict` since it cannot be properly shown on the `HTML form`.

fix #7706
refs #7706