### PR TITLE
Prevent head method mapping to coerce action name

### DIFF
--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -198,7 +198,11 @@ class SchemaGenerator(BaseSchemaGenerator):
 
         if is_custom_action(action):
             # Custom action, eg "/users/{pk}/activate/", "/users/active/"
-            if len(view.action_map) > 1:
+            mapped_methods = {
+                # Don't count head mapping, e.g. not part of the schema
+                method for method in view.action_map if method != 'head'
+            }
+            if len(mapped_methods) > 1:
                 action = self.default_mapping[method.lower()]
                 if action in self.coerce_method_names:
                     action = self.coerce_method_names[action]


### PR DESCRIPTION
This PR resolves an untested backwards incompatible schema change that sneaked in along with the `3.12` release.

In the nested view of `ViewSetMixin`, the `head` method is auto mapped [here](https://github.com/encode/django-rest-framework/blob/1ec0f86b585cd87e4b413aeaad1ecc947bacfef2/rest_framework/viewsets.py#L107) to the `get` action, leading to the view's action mapping to contain more than 1 mapping under normal `read` conditions.

The length of the action map is later used to determine the action names and depth for the links in the schema document, generated by `SchemaGenerator`.

The `head` method should not be accounted for when generating the depth and details of the links, since it's not part of the schema anyways.

Furthermore this also propagates and changes the operation ids for the affected actions.