### PR TITLE
SearchFilter with unaccent

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -226,6 +226,7 @@ The search behavior may be restricted by prepending various characters to the `s
 * '=' Exact matches.
 * '@' Full-text search.  (Currently only supported Django's [PostgreSQL backend](https://docs.djangoproject.com/en/dev/ref/contrib/postgres/search/).)
 * '$' Regex search.
+* '&' Accent-insensitive search.  (Currently only supported Django's [PostgreSQL backend](https://docs.djangoproject.com/en/dev/ref/contrib/postgres/lookups/#unaccent).)
 
 For example:
 

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -45,6 +45,7 @@ class SearchFilter(BaseFilterBackend):
         '=': 'iexact',
         '@': 'search',
         '$': 'iregex',
+        '&': 'unaccent',
     }
     search_title = _('Search')
     search_description = _('A search term.')


### PR DESCRIPTION
## Description

Implements #7727 

New restriction for SearchFilter: `&` Accent-insensitive search.

As this is only supported by Django's [PostgreSQL backend](https://docs.djangoproject.com/en/dev/ref/contrib/postgres/lookups/#unaccent).), no test was added (same case as the Full-text search restriction).

This uses the  `__unaccent` lookup, allowing for accent-insensitive searches.