### PR TITLE
support multi db atomic_requests

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -3,7 +3,7 @@ Provides an APIView class that is the base of all views in REST framework.
 """
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.db import connection, models, transaction
+from django.db import connections, models
 from django.http import Http404
 from django.http.response import HttpResponseBase
 from django.utils.cache import cc_delim_re, patch_vary_headers
@@ -63,9 +63,9 @@ def get_view_description(view, html=False):
 
 
 def set_rollback():
-    atomic_requests = connection.settings_dict.get('ATOMIC_REQUESTS', False)
-    if atomic_requests and connection.in_atomic_block:
-        transaction.set_rollback(True)
+    for db in connections.all():
+        if db.settings_dict['ATOMIC_REQUESTS'] and db.in_atomic_block:
+            db.set_rollback(True)
 
 
 def exception_handler(exc, context):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,10 @@ def pytest_configure(config):
             'default': {
                 'ENGINE': 'django.db.backends.sqlite3',
                 'NAME': ':memory:'
+            },
+            'secondary': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': ':memory:'
             }
         },
         SITE_ID=1,


### PR DESCRIPTION
## Description

When using https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-DATABASE-ATOMIC_REQUESTS, django wraps each invoked view with transactions to _all databases_ (https://github.com/django/django/blob/master/django/core/handlers/base.py#L323-L330). https://github.com/encode/django-rest-framework/pull/2887 resolved https://github.com/encode/django-rest-framework/issues/2034 _for the default database, only_.

In particular, https://github.com/encode/django-rest-framework/blob/master/rest_framework/views.py#L67-103 does not handle the fact that multiple transactions can be created by django. This PR adds a unit test and associated fix to ensure DRF rollsback all transactions setup by django for ATOMIC_REQUESTS rather than just the default db's transaction.

## Test Plan
Added unit tests. Fail with the old code, passes with the new code.