### PR TITLE
Fix authentication message in Spanish

### DIFF
--- a/rest_framework/locale/es/LC_MESSAGES/django.po
+++ b/rest_framework/locale/es/LC_MESSAGES/django.po
@@ -119,7 +119,7 @@ msgstr "Credenciales de autenticación incorrectas."
 
 #: exceptions.py:173
 msgid "Authentication credentials were not provided."
-msgstr "Las credenciales de autenticación no se proveyeron."
+msgstr "Las credenciales de autenticación no fueron suministradas."
 
 #: exceptions.py:179
 msgid "You do not have permission to perform this action."


### PR DESCRIPTION
The translation of this message in Spanish is not correct.


## Description

It fixes the translation to use the right words.
