### PR TITLE
Avoid executing querysets when getting the string representation of Serializers with related fields

### DIFF
--- a/rest_framework/utils/representation.py
+++ b/rest_framework/utils/representation.py
@@ -23,9 +23,16 @@ def manager_repr(value):
     return repr(value)
 
 
+def queryset_repr(queryset):
+    return "{}".format(queryset.query)
+
+
 def smart_repr(value):
     if isinstance(value, models.Manager):
         return manager_repr(value)
+
+    if isinstance(value, models.QuerySet):
+        value = queryset_repr(value)
 
     if isinstance(value, Promise) and value._delegate_text:
         value = force_str(value)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -23,7 +23,7 @@ from django.db.models.signals import m2m_changed
 from django.dispatch import receiver
 from django.test import TestCase
 
-from rest_framework import serializers, fields
+from rest_framework import serializers
 from rest_framework.compat import postgres_fields
 
 from .models import NestedForeignKeySource

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -23,7 +23,7 @@ from django.db.models.signals import m2m_changed
 from django.dispatch import receiver
 from django.test import TestCase
 
-from rest_framework import serializers
+from rest_framework import serializers, fields
 from rest_framework.compat import postgres_fields
 
 from .models import NestedForeignKeySource
@@ -558,6 +558,18 @@ class TestRelationalFieldMappings(TestCase):
                 through = PrimaryKeyRelatedField(many=True, read_only=True)
         """)
         self.assertEqual(repr(TestSerializer()), expected)
+
+    def test_manual_pk_relation_will_customize_queryset_repr_to_avoid_execute_it(self):
+        queryset = ForeignKeyTargetModel.objects.all()
+
+        class TestSerializer(serializers.Serializer):
+            field = serializers.PrimaryKeyRelatedField(queryset=queryset)
+
+        expected = dedent("""
+            TestSerializer():
+                field = PrimaryKeyRelatedField(queryset='{}')
+        """)
+        self.assertEqual(repr(TestSerializer()), expected.format(queryset.query))
 
     def test_nested_relations(self):
         class TestSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This way, if the serializer is inadvertently converted to a string, the queryset won't be executed. Take the snippet below as an example:

```python
class SampleSerializer(serializers.Serializer):
    user = serializers.PrimaryKeyRelatedField(
        queryset=User.objects.filter(is_active=True)
    )

def sample_view(request):
    serializer = SampleSerializer(data=request.data)
    data = serializer.is_valid(raise_exception=True)
    do_something_with(data)
    return response.Response(data, status=status.HTTP_200_OK)
```

Django has a default string representation for a queryset: if you try to print it, it will actually query 21 items from the database and print them. It could be potentially harmful if the queryset you are using is not optimized to be listed sequentially and has millions of records.

The discussion #7782 has more details. I didn't convert the discussion to a ticket yet though.