### PR TITLE
pick deque instead of list

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -2,6 +2,7 @@
 Provides various throttling policies.
 """
 import time
+from collections import deque
 
 from django.core.cache import cache as default_cache
 from django.core.exceptions import ImproperlyConfigured
@@ -120,7 +121,7 @@ class SimpleRateThrottle(BaseThrottle):
         if self.key is None:
             return True
 
-        self.history = self.cache.get(self.key, [])
+        self.history = self.cache.get(self.key, deque())
         self.now = self.timer()
 
         # Drop any requests from the history which have now passed the


### PR DESCRIPTION
## Description

Currently, a list object, `self.history`, is used for storing request history.
`self.history.insert(0, self.now)` in function `throttle_success` and `self.history.pop()` in function `allow_request`, are used to insert and remove request history, respectively.

If deque is picked, we would have fast insertion and removal at both ends.

Please see the information below for more details about [deque](https://docs.python.org/3/library/collections.html#collections.deque).

> Though [list](https://docs.python.org/3/library/stdtypes.html#list) objects support similar operations, they are optimized for fast fixed-length operations and incur O(n) memory movement costs for `pop(0)` and `insert(0, v)` operations which change both the size and position of the underlying data representation.

Would it be possible to review and approve this change?