### PR TITLE
Don't hit db to access user_id in TokenProxy

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -46,7 +46,7 @@ class TokenProxy(Token):
     """
     @property
     def pk(self):
-        return self.user.pk
+        return self.user_id
 
     class Meta:
         proxy = 'rest_framework.authtoken' in settings.INSTALLED_APPS


### PR DESCRIPTION
## Description

When using nplusone middleware from https://github.com/jmcarp/nplusone, the error occurs if one tries to access Token app in django admin. 

This happens due to recursive DB calls, as the user `id` is accessed through the `user` object rather than through `user_id` field. 

Not sure if it's a problem of DRF itself, but the following change fixes the problem as well as reduces DB hits.

![image](https://user-images.githubusercontent.com/18049710/111599877-d3753f80-87e1-11eb-9ce7-22003b8da49c.png)

https://github.com/jmcarp/nplusone/issues/38