### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -185,7 +185,7 @@ The decorator allows you to override any viewset-level configuration such as `pe
         def set_password(self, request, pk=None):
            ...
 
-The two new actions will then be available at the urls `^users/{pk}/set_password/$` and `^users/{pk}/unset_password/$`. Use the `url_path` and `url_name` parameters to change the URL segement and the reverse URL name of the action.
+The two new actions will then be available at the urls `^users/{pk}/set_password/$` and `^users/{pk}/unset_password/$`. Use the `url_path` and `url_name` parameters to change the URL segment and the reverse URL name of the action.
 
 To view all extra actions, call the `.get_extra_actions()` method.
 


### PR DESCRIPTION
## Description

Just a small fix for a typo in the documentation.