### PR TITLE
update SerializerMethodField example in docs

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -583,6 +583,7 @@ The serializer method referred to by the `method_name` argument should accept a 
 
         class Meta:
             model = User
+			fields = '__all__'
 
         def get_days_since_joined(self, obj):
             return (now() - obj.date_joined).days

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -583,7 +583,7 @@ The serializer method referred to by the `method_name` argument should accept a 
 
         class Meta:
             model = User
-			fields = '__all__'
+            fields = '__all__'
 
         def get_days_since_joined(self, obj):
             return (now() - obj.date_joined).days


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

This PR will update the code in the example below ([as seen in the docs](https://www.django-rest-framework.org/api-guide/fields/#serializermethodfield)), which will throw the following error if run:

> AssertionError: ("Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = '__all__' to the AlbumSerializer serializer.",)

```
from django.contrib.auth.models import User
from django.utils.timezone import now
from rest_framework import serializers

class UserSerializer(serializers.ModelSerializer):
    days_since_joined = serializers.SerializerMethodField()

    class Meta:
        model = User

    def get_days_since_joined(self, obj):
        return (now() - obj.date_joined).days 
```
This PR adds the required `fields = '__all__'` to the example and may help folks following along for the first time.