### PR TITLE
Version 3.12.4

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -40,7 +40,7 @@ You can determine your currently installed version using `pip show`:
 
 Date: 26th March 2021
 
-* Revert use of `deque` instead of `list` for tracking throttling `.history`. (Due to incompatibility with DjangoRedis cache backend.) [#7849]
+* Revert use of `deque` instead of `list` for tracking throttling `.history`. (Due to incompatibility with DjangoRedis cache backend. See #7870) [#7872]
 
 ### 3.12.3
 

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -36,6 +36,12 @@ You can determine your currently installed version using `pip show`:
 
 ## 3.12.x series
 
+### 3.12.4
+
+Date: 26th March 2021
+
+* Revert use of `deque` instead of `list` for tracking throttling `.history`. (Due to incompatibility with DjangoRedis cache backend.) [#7849]
+
 ### 3.12.3
 
 Date: 25th March 2021

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -10,7 +10,7 @@ ______ _____ _____ _____    __
 import django
 
 __title__ = 'Django REST framework'
-__version__ = '3.12.3'
+__version__ = '3.12.4'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 3-Clause'
 __copyright__ = 'Copyright 2011-2019 Encode OSS Ltd'


### PR DESCRIPTION
### 3.12.4

Date: 26th March 2021

* Revert use of `deque` instead of `list` for tracking throttling `.history`. (Due to incompatibility with DjangoRedis cache backend.) [#7849]
