### PR TITLE
Simplify MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,3 @@
-include README.md
-include LICENSE.md
-recursive-include tests/* *
-recursive-include rest_framework/static *.js *.css *.png *.ico *.eot *.svg *.ttf *.woff *.woff2
-recursive-include rest_framework/templates *.html schema.js
-recursive-include rest_framework/locale *.mo
-global-exclude __pycache__
+graft rest_framework
+include README.md LICENSE.md
 global-exclude *.py[co]


### PR DESCRIPTION
MANIFEST.in:
Use 'graft' to include all resources relevant for the application and
all tests more generically.
Specifically include README.md and LICENSE.md.

Follow-up to #7141 which only included tests partially.

Please make sure that this works as you expect it to work (e.g. by running `python setup sdist`).