### PR TITLE
Update serializers.md

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -457,7 +457,7 @@ To do so, open the Django shell, using `python manage.py shell`, then import the
 
     >>> from myapp.serializers import AccountSerializer
     >>> serializer = AccountSerializer()
-    >>> print(repr(serializer))
+    >>> print(repr(serializer()))
     AccountSerializer():
         id = IntegerField(label='ID', read_only=True)
         name = CharField(allow_blank=True, max_length=100, required=False)


### PR DESCRIPTION
Serializer in line 260 needs brackets or response will be: <class 'api.serializers.WaveSerializer'> instead of the representation

## Description
In the current version, the brackets are missing and this is the result in the terminal:
    >>> print(repr(serializer))
    <class 'api.serializers.WaveSerializer'>
For a proper display of the representation, brackets have to be included:
    >>> print(repr(serializer()))