### PR TITLE
Allow setting read_only fields from defaults

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -488,6 +488,7 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
         if errors:
             raise ValidationError(errors)
 
+        ret.update(self._read_only_defaults())
         return ret
 
     def to_representation(self, instance):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -235,7 +235,7 @@ class TestSource:
 class TestReadOnly:
     def setup(self):
         class TestSerializer(serializers.Serializer):
-            read_only = serializers.ReadOnlyField(default="789")
+            read_only = serializers.ReadOnlyField(default=789)
             writable = serializers.IntegerField()
         self.Serializer = TestSerializer
 
@@ -248,16 +248,16 @@ class TestReadOnly:
 
     def test_validate_read_only(self):
         """
-        Read-only serializers.should not be included in validation.
+        Read-only fields default value should be included in validation.
         """
         data = {'read_only': 123, 'writable': 456}
         serializer = self.Serializer(data=data)
         assert serializer.is_valid()
-        assert serializer.validated_data == {'writable': 456}
+        assert serializer.validated_data == {'read_only': 789, 'writable': 456}
 
     def test_serialize_read_only(self):
         """
-        Read-only serializers.should be serialized.
+        Read-only fields should be serialized.
         """
         instance = {'read_only': 123, 'writable': 456}
         serializer = self.Serializer(instance)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -1333,3 +1333,18 @@ class Issue6751Test(TestCase):
         serializer.save()
 
         self.assertEqual(instance.char_field, 'value changed by signal')
+
+
+class TestReadonlyDefault(TestCase):
+    def test_readonly_default(self):
+        class TestSerializer(serializers.ModelSerializer):
+            char_field = serializers.CharField(read_only=True, default='default')
+
+            class Meta:
+                model = OneFieldModel
+                fields = ('char_field',)
+
+        serializer = TestSerializer(data={})
+        serializer.is_valid()
+        instance = serializer.save()
+        assert instance.char_field == 'default'


### PR DESCRIPTION
## Description

According to the documentation, this is supposed to work, but it doesn't. Add the read_only default values after the validation runs so they actually get saved.

Fix for #7897 