### PR TITLE
Minor decluttering of generics.py and authtoken/models.py

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -1,4 +1,3 @@
-import binascii
 import os
 
 from django.conf import settings
@@ -34,7 +33,7 @@ class Token(models.Model):
 
     @classmethod
     def generate_key(cls):
-        return binascii.hexlify(os.urandom(20)).decode()
+        return (os.urandom(20)).hex()
 
     def __str__(self):
         return self.key

--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -48,6 +48,5 @@ class TokenProxy(Token):
         return self.user_id
 
     class Meta:
-        proxy = 'rest_framework.authtoken' in settings.INSTALLED_APPS
-        abstract = not proxy
+        proxy = not Token._meta.abstract
         verbose_name = "token"

--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -49,5 +49,5 @@ class TokenProxy(Token):
 
     class Meta:
         proxy = 'rest_framework.authtoken' in settings.INSTALLED_APPS
-        abstract = 'rest_framework.authtoken' not in settings.INSTALLED_APPS
+        abstract = not proxy
         verbose_name = "token"

--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -41,7 +41,7 @@ class Token(models.Model):
 
 class TokenProxy(Token):
     """
-    Proxy mapping pk to user pk for use in admin.
+    Proxy mapping pk to user_id for use in admin.
     """
     @property
     def pk(self):

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -242,50 +242,22 @@ class ListCreateAPIView(mixins.ListModelMixin,
         return self.create(request, *args, **kwargs)
 
 
-class RetrieveUpdateAPIView(mixins.RetrieveModelMixin,
-                            mixins.UpdateModelMixin,
-                            GenericAPIView):
+class RetrieveUpdateAPIView(RetrieveAPIView, UpdateAPIView):
     """
     Concrete view for retrieving, updating a model instance.
     """
-    def get(self, request, *args, **kwargs):
-        return self.retrieve(request, *args, **kwargs)
-
-    def put(self, request, *args, **kwargs):
-        return self.update(request, *args, **kwargs)
-
-    def patch(self, request, *args, **kwargs):
-        return self.partial_update(request, *args, **kwargs)
+    pass
 
 
-class RetrieveDestroyAPIView(mixins.RetrieveModelMixin,
-                             mixins.DestroyModelMixin,
-                             GenericAPIView):
+class RetrieveDestroyAPIView(RetrieveAPIView, DestroyAPIView):
     """
     Concrete view for retrieving or deleting a model instance.
     """
-    def get(self, request, *args, **kwargs):
-        return self.retrieve(request, *args, **kwargs)
-
-    def delete(self, request, *args, **kwargs):
-        return self.destroy(request, *args, **kwargs)
+    pass
 
 
-class RetrieveUpdateDestroyAPIView(mixins.RetrieveModelMixin,
-                                   mixins.UpdateModelMixin,
-                                   mixins.DestroyModelMixin,
-                                   GenericAPIView):
+class RetrieveUpdateDestroyAPIView(RetrieveAPIView, UpdateAPIView, DestroyAPIView):
     """
     Concrete view for retrieving, updating or deleting a model instance.
     """
-    def get(self, request, *args, **kwargs):
-        return self.retrieve(request, *args, **kwargs)
-
-    def put(self, request, *args, **kwargs):
-        return self.update(request, *args, **kwargs)
-
-    def patch(self, request, *args, **kwargs):
-        return self.partial_update(request, *args, **kwargs)
-
-    def delete(self, request, *args, **kwargs):
-        return self.destroy(request, *args, **kwargs)
+    pass


### PR DESCRIPTION
## Description

### generics.py
- Make use of RetrieveAPIView, UpdateAPIView, DestroyAPIView in subclasses

### authtoken/models.py
- Remove reliance on binascii for converting binary to hex
- Simplify proxy vs abstract booleans in TokenProxy
- Fix docstring for recent commit
- Make use of Token Meta attributes in TokenProxy


