### PR TITLE
Fix tests with mock timezone

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1485,7 +1485,7 @@ class TestNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     }
     outputs = {}
 
-    class MockTimezone:
+    class MockTimezone(pytz.BaseTzInfo):
         @staticmethod
         def localize(value, is_dst):
             raise pytz.InvalidTimeError()


### PR DESCRIPTION
## Description

Django no longer checks for `hasattr(timezone, 'localize')` and instead does an inheritance check:

https://github.com/django/django/blob/da542ccab6d61e1467199b52f77f64a2d72f5faf/django/utils/timezone.py#L259-L261