### PR TITLE
Fix GitHub Actions to run on 'master' branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-    - main
+    - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
The config I copied in #7903 was from a repo with the new name 'main', so tests have not been running on master since.
