### PR TITLE
Fix pytest warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,7 @@
 license_file = LICENSE.md
 
 [tool:pytest]
-addopts=--tb=short --strict -ra
-testspath = tests
+addopts=--tb=short --strict-markers -ra
 
 [flake8]
 ignore = E501,W504


### PR DESCRIPTION
* Use `--strict-markers` instead of `--strict`, as per this warning:

  ```
  /.../_pytest/config/__init__.py:1183: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
  ```

* Remove config option 'testspath' - pytest is logging a warning about this being unknown:

  ```
  /.../_pytest/config/__init__.py:1233: PytestConfigWarning: Unknown config option: testspath
  ```

  I can't find any reference to it in the pytest docs or changelog.
