### PR TITLE
Fix #7575

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -439,7 +439,13 @@ class LimitOffsetPagination(BasePagination):
             except (KeyError, ValueError):
                 pass
 
-        return self.default_limit
+        return self.get_lower_of_max_or_default_limit()
+
+    def get_lower_of_max_or_default_limit(self):
+        try:
+            return min(self.max_limit, self.default_limit)
+        except TypeError:
+            return self.default_limit
 
     def get_offset(self, request):
         try:


### PR DESCRIPTION
refs: #7575 

Take max_limit into account when no limit parameter is present in the request with LimitOffsetPagination class.
If max_limit is less than default limit then max_limit will be returned.
