### PR TITLE
fix typo in packaging requirements

### DIFF
--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -5,4 +5,4 @@ wheel>=0.35.1,<0.36
 twine>=3.2.0,<3.3
 
 # Transifex client for managing translation resources.
-transifex-clien>=0.13.12,<0.14
+transifex-client>=0.13.12,<0.14


### PR DESCRIPTION
Hi :wave: 

first of all big thanks for developing such an awesome package! 

## Description

I was going through [Contributing guide](https://www.django-rest-framework.org/community/contributing/#testing) and for the following command:

```bash
pip install -r requirements.txt
```

I have got this error:

```
ERROR: Could not find a version that satisfies the requirement transifex-clien<0.14,>=0.13.12
ERROR: No matching distribution found for transifex-clien<0.14,>=0.13.12
```

This PR simply fixes typo in the`transifex-client` package name ;)
