### PR TITLE
Enforce `is_valid(raise_exception=False)` as a keyword-only argument.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -209,7 +209,7 @@ class BaseSerializer(Field):
 
         return self.instance
 
-    def is_valid(self, raise_exception=False):
+    def is_valid(self, *, raise_exception=False):
         assert hasattr(self, 'initial_data'), (
             'Cannot call `.is_valid()` as no `data=` keyword argument was '
             'passed when instantiating the serializer instance.'

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -712,7 +712,7 @@ class ListSerializer(BaseSerializer):
 
         return self.instance
 
-    def is_valid(self, raise_exception=False):
+    def is_valid(self, *, raise_exception=False):
         # This implementation is the same as the default,
         # except that we use lists, rather than dicts, as the empty case.
         assert hasattr(self, 'initial_data'), (


### PR DESCRIPTION
At the moment `is_valid` calls are possible without keyword-only arguments, so code
`serializer.is_valid(True)` is possible and will be quite misleading, especially for new developers. This pull requests makes "raise_exception" name mandatory if serializer is called with argument.
