### PR TITLE
Fix running runtests.py without arguments.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -45,5 +45,7 @@ if __name__ == "__main__":
             # `runtests.py TestCase [flags]`
             # `runtests.py test_function [flags]`
             pytest_args = ['tests', '-k', pytest_args[0]] + pytest_args[1:]
+    else:
+        pytest_args = []
 
     sys.exit(pytest.main(pytest_args))


### PR DESCRIPTION
Regression in aa12a5f967705f70b1dbe457bb2396d106e3570b.

```bash
$ ./runtests.py 
Traceback (most recent call last):
  File "./runtests.py", line 49, in <module>
    sys.exit(pytest.main(pytest_args))
NameError: name 'pytest_args' is not defined

```