### PR TITLE
add explicit timer method definition

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -60,7 +60,6 @@ class SimpleRateThrottle(BaseThrottle):
     Previous request information used for throttling is stored in the cache.
     """
     cache = default_cache
-    timer = staticmethod(time.time)
     cache_format = 'throttle_%(scope)s_%(ident)s'
     scope = None
     THROTTLE_RATES = api_settings.DEFAULT_THROTTLE_RATES
@@ -130,6 +129,10 @@ class SimpleRateThrottle(BaseThrottle):
         if len(self.history) >= self.num_requests:
             return self.throttle_failure()
         return self.throttle_success()
+
+    def timer(self):
+        """Time in seconds since the epoch."""
+        return time.time()
 
     def throttle_success(self):
         """

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -60,7 +60,7 @@ class SimpleRateThrottle(BaseThrottle):
     Previous request information used for throttling is stored in the cache.
     """
     cache = default_cache
-    timer = time.time
+    timer = staticmethod(time.time)
     cache_format = 'throttle_%(scope)s_%(ident)s'
     scope = None
     THROTTLE_RATES = api_settings.DEFAULT_THROTTLE_RATES


### PR DESCRIPTION
Hi :wave:

## Description

Recently when I was writing tests for a view using 
[`SimpleRateThrottle`](https://github.com/encode/django-rest-framework/blob/a0083f7f9867113a37a5096a06ee69344781075a/rest_framework/throttling.py#L50) and when using [`freezegun`](https://github.com/spulec/freezegun/) to mock/freeze `time` I have encountered an error like [this](https://github.com/spulec/freezegun/issues/382?fbclid=IwAR3UKEZ-JZjOOmvFyWCTJ0MByV8dyF7FhXaHwyZmrbiiuRWT2-jsj9pIjyo#issuecomment-812167551).
Generally `time.time` is a `bultin_function_or_method` object, so it works when called as a method, however, I am not sure it's a proper way to use it. According to [`typeshed`](https://github.com/python/typeshed/blob/8bd3e16eef2737562be5351ea38f7d34d73acad5/stdlib/time.pyi#L92) its type is:

```python
def time() -> float: ...
```

so why not treat it like a regular function?

This PR simply defines `timer` as a static method, so `time.time` is always called like a regular function.