### PR TITLE
Remove test dependency on django guardian

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -2,7 +2,6 @@
 coreapi==2.3.1
 coreschema==0.0.4
 django-filter>=2.4.0,<3.0
-django-guardian>=2.3.0,<2.4
 markdown==3.3;python_version>="3.6"
 markdown==3.2.2;python_version=="3.5"
 psycopg2-binary>=2.8.5,<2.9

--- a/tests/authentication/backends.py
+++ b/tests/authentication/backends.py
@@ -1,0 +1,35 @@
+from collections import defaultdict
+
+from django.contrib.auth.models import Permission
+
+
+def assign_perm(perm, group, obj=None):
+    if "." not in perm:
+        raise ValueError("perm must be in the format 'app_label.codename'")
+
+    if obj:
+        ObjectPermissionBackend.assign_perm(perm, group, obj)
+    else:
+        # Assign global permissions if there is no object
+        app_label, codename = perm.split(".", 1)
+        perm = Permission.objects.get(
+            content_type__app_label=app_label, codename=codename
+        )
+        group.permissions.add(perm)
+
+
+class ObjectPermissionBackend:
+    # Stores the set of groups that have the given permission for the given object
+    object_perms = defaultdict(lambda: defaultdict(set))
+
+    def authenticate(self, *_, **__):
+        return None
+
+    @classmethod
+    def assign_perm(cls, perm, group, obj):
+        cls.object_perms[obj][perm].add(group)
+
+    def has_perm(self, user_obj, perm, obj=None):
+        groups_with_obj_perm = self.object_perms[obj][perm]
+        users_groups = {*user_obj.groups.all()}
+        return bool(groups_with_obj_perm.intersection(users_groups))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,10 @@ def pytest_configure(config):
     from django.conf import settings
 
     settings.configure(
+        AUTHENTICATION_BACKENDS=(
+            'django.contrib.auth.backends.ModelBackend',
+            'tests.authentication.backends.ObjectPermissionBackend',
+        ),
         DEBUG_PROPAGATE_EXCEPTIONS=True,
         DATABASES={
             'default': {
@@ -69,21 +73,6 @@ def pytest_configure(config):
             'django.contrib.auth.hashers.MD5PasswordHasher',
         ),
     )
-
-    # guardian is optional
-    try:
-        import guardian  # NOQA
-    except ImportError:
-        pass
-    else:
-        settings.ANONYMOUS_USER_ID = -1
-        settings.AUTHENTICATION_BACKENDS = (
-            'django.contrib.auth.backends.ModelBackend',
-            'guardian.backends.ObjectPermissionBackend',
-        )
-        settings.INSTALLED_APPS += (
-            'guardian',
-        )
 
     if config.getoption('--no-pkgroot'):
         sys.path.pop(0)


### PR DESCRIPTION
## Description

An ObjectPermissionBackend is added which is similar to the one
in guardian.backends.ObjectPermissionBackend for test support.
The differences are that:
  - Permissions can only be assigned to groups
  - The object permissions are stored in a defaultdict
  - Permissions can only be assigned using app_label.codename

This allows DRF to be released without waiting for django-guardian
to update, refs #3427, refs #7927, refs https://github.com/django-guardian/django-guardian/issues/747.
