### PR TITLE
Fix arguments of `path()`

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -126,7 +126,7 @@ Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
     # Additionally, we include login URLs for the browsable API.
     urlpatterns = [
         path('', include(router.urls)),
-        path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+        path('api-auth/', include('rest_framework.urls', name='rest_framework'))
     ]
 
 Because we're using viewsets instead of views, we can automatically generate the URL conf for our API, by simply registering the viewsets with a router class.


### PR DESCRIPTION
`path()` has no argument `namespace`, it has `name` argument

## Description

Raises `TypeError: _path() got an unexpected keyword argument 'namespace'`, \
argument should be changed to `name` 
