### PR TITLE
Propagate 'default' from model_field to serializer field

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -101,6 +101,9 @@ def get_field_kwargs(field_name, model_field):
         kwargs['read_only'] = True
         return kwargs
 
+    if model_field.has_default():
+        kwargs['default'] = model_field.default
+
     if model_field.has_default() or model_field.blank or model_field.null:
         kwargs['required'] = False
 


### PR DESCRIPTION
## Description

This is an attempt to fix https://github.com/encode/django-rest-framework/issues/7469

It's actually really simple. `ModelSerializer.build_standard_field` looks for the `default` key in the dictionary returned by `get_field_kwargs`, but `get_field_kwargs` never returns a dictionary with that key. 

### Edit

I was personally motivated to fix this because I wanted the `default` value to appear when you do an `OPTIONS` query. That's incredibly tedious without this fix. More info here: https://github.com/encode/django-rest-framework/discussions/8003