### PR TITLE
Include serialized model data when validating

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -216,8 +216,11 @@ class BaseSerializer(Field):
         )
 
         if not hasattr(self, '_validated_data'):
+            validation_data = self.to_representation(self.instance) if self.instance else {}
+            validation_data.update(self.initial_data)
+
             try:
-                self._validated_data = self.run_validation(self.initial_data)
+                self._validated_data = self.run_validation(validation_data)
             except ValidationError as exc:
                 self._validated_data = {}
                 self._errors = exc.detail

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -124,6 +124,9 @@ DEFAULTS = {
         'retrieve': 'read',
         'destroy': 'delete'
     },
+    
+    # Validation
+    'VALIDATE_ENTIRE_INSTANCE': False,
 }
 
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -1333,3 +1333,27 @@ class Issue6751Test(TestCase):
         serializer.save()
 
         self.assertEqual(instance.char_field, 'value changed by signal')
+
+
+class Issue7489Model(models.Model):
+    field1 = models.CharField(max_length=1)
+    field2 = models.CharField(max_length=1)
+    field3 = models.CharField(max_length=1)
+
+    class Meta:
+        unique_together = ('field1', 'field2')
+
+
+class Issue7489Serializer(serializers.ModelSerializer):
+    class Meta:
+        model = Issue7489Model
+        fields = '__all__'
+
+
+class Issue7489Test(TestCase):
+    def test_model_serializer_substitutes_default_on_unique_together_validation(self):
+        Issue7489Model.objects.create(field1='A', field2='A')
+        b = Issue7489Model.objects.create(field1='B', field2='B')
+        # Attempt to validate the serializer for updating `field3` on instance `b`
+        serializer = Issue7489Serializer(instance=b, data={'field3': 'X'})
+        self.assertTrue(serializer.is_valid(), serializer.errors)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -1348,6 +1348,7 @@ class Issue7489Serializer(serializers.ModelSerializer):
     class Meta:
         model = Issue7489Model
         fields = '__all__'
+        validate_entire_instance = True
 
 
 class Issue7489Test(TestCase):


### PR DESCRIPTION
## Description

Potential fix for: https://github.com/encode/django-rest-framework/issues/7489

When an instance is passed to a ModelSerializer, we might need fields 
that aren't specified in initial_data to run a validator. Specifically 
for UniqueTogether

### More details

There's potentially a backwards-incompatible change, that should at the very least be documented.

Previously there could be a dirty value in the database, and so long as you didn't try to touch it, it wouldn't cause re-validation.

For instance, suppose you have a validator on some_bad_field that prohibits "bad_value", and another unrelated field 'foo'.

```python
# OK
instance = MyModel.objects.create(some_bad_field='bad_value')

# Old way didn't complain
serializer = MyModelSerializer(instance=instance, data={'foo': 'bar'})

# New way will re-validate ALL the fields, including some_bad_field, and fail
serializer = MyModelSerializer(instance=instance, data={'foo': 'bar'})
```

Whether that's desirable behavior or not should probably be discussed.

