### PR TITLE
Fix ./runtests.py failing without any args

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -45,5 +45,7 @@ if __name__ == "__main__":
             # `runtests.py TestCase [flags]`
             # `runtests.py test_function [flags]`
             pytest_args = ['tests', '-k', pytest_args[0]] + pytest_args[1:]
+    else:
+        pytest_args = []
 
     sys.exit(pytest.main(pytest_args))


### PR DESCRIPTION
## Description

Previously, running this script without args would result in an error:

    $ ./runtests.py
    Traceback (most recent call last):
      File "./runtests.py", line 49, in <module>
        sys.exit(pytest.main(pytest_args))
    NameError: name 'pytest_args' is not defined

