### PR TITLE
Fix Spanish translation mistake.

### DIFF
--- a/rest_framework/locale/es/LC_MESSAGES/django.po
+++ b/rest_framework/locale/es/LC_MESSAGES/django.po
@@ -336,7 +336,7 @@ msgstr "No se pudo determinar un nombre de archivo."
 
 #: fields.py:1517
 msgid "The submitted file is empty."
-msgstr "El archivo enviado está vació."
+msgstr "El archivo enviado está vacío."
 
 #: fields.py:1518
 #, python-brace-format


### PR DESCRIPTION
Evidences:

- https://translate.google.es/?sl=en&tl=es&text=The%20submitted%20file%20is%20empty.&op=translate

- https://github.com/django/django/blob/main/django/conf/locale/es/LC_MESSAGES/django.po#L740