### PR TITLE
fix comments by using correct css comment syntax

### DIFF
--- a/rest_framework/static/rest_framework/docs/css/base.css
+++ b/rest_framework/static/rest_framework/docs/css/base.css
@@ -7,15 +7,15 @@ h1 {
 }
 
 pre.highlight code * {
-  white-space: nowrap;    // this sets all children inside to nowrap
+  white-space: nowrap;    /* this sets all children inside to nowrap */
 }
 
 pre.highlight {
-  overflow-x: auto;       // this sets the scrolling in x
+  overflow-x: auto;       /* this sets the scrolling in x */
 }
 
 pre.highlight code {
-  white-space: pre;       // forces <code> to respect <pre> formatting
+  white-space: pre;       /* forces <code> to respect <pre> formatting */
 }
 
 .main-container {


### PR DESCRIPTION
these intended comments were causing errors in sonarqube scans due to using wrong css comment syntax

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
