### PR TITLE
Add optional functionality to ChoiceField & MultipleChoiceField

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -404,6 +404,7 @@ Used by `ModelSerializer` to automatically generate fields if the corresponding 
 - `allow_blank` - If set to `True` then the empty string should be considered a valid value. If set to `False` then the empty string is considered invalid and will raise a validation error. Defaults to `False`.
 - `html_cutoff` - If set this will be the maximum number of choices that will be displayed by a HTML select drop down. Can be used to ensure that automatically generated ChoiceFields with very large possible selections do not prevent a template from rendering. Defaults to `None`.
 - `html_cutoff_text` - If set this will display a textual indicator if the maximum number of items have been cutoff in an HTML select drop down. Defaults to `"More than {count} items…"`
+- `strict_choices` - If set to `True` then `to_representation()` checks if output is one of choices. Defaults to `False`.
 
 Both the `allow_blank` and `allow_null` are valid options on `ChoiceField`, although it is highly recommended that you only use one and not both. `allow_blank` should be preferred for textual choices, and `allow_null` should be preferred for numeric or other non-textual choices.
 
@@ -417,6 +418,7 @@ A field that can accept a set of zero, one or many values, chosen from a limited
 - `allow_blank` - If set to `True` then the empty string should be considered a valid value. If set to `False` then the empty string is considered invalid and will raise a validation error. Defaults to `False`.
 - `html_cutoff` - If set this will be the maximum number of choices that will be displayed by a HTML select drop down. Can be used to ensure that automatically generated ChoiceFields with very large possible selections do not prevent a template from rendering. Defaults to `None`.
 - `html_cutoff_text` - If set this will display a textual indicator if the maximum number of items have been cutoff in an HTML select drop down. Defaults to `"More than {count} items…"`
+- `strict_choices` - If set to `True` then `to_representation()` checks if output is a set from choices. Defaults to `False`.
 
 As with `ChoiceField`, both the `allow_blank` and `allow_null` options are valid, although it is highly recommended that you only use one and not both. `allow_blank` should be preferred for textual choices, and `allow_null` should be preferred for numeric or other non-textual choices.
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1693,6 +1693,23 @@ class TestChoiceField(FieldValues):
             field.run_validation(2)
         assert exc_info.value.detail == ['"2" is not a valid choice.']
 
+    def test_strict_choices(self):
+        """
+        If `strict_choices` then to_representation() should return one of given choices.
+        """
+        field = serializers.ChoiceField(
+            strict_choices=True,
+            choices=[
+                ('poor', 'Poor quality'),
+                ('medium', 'Medium quality'),
+                ('good', 'Good quality'),
+            ]
+        )
+        assert field.to_representation('poor') == 'poor'
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            field.to_representation('amazing')
+        assert exc_info.value.detail == ['"amazing" is not a valid choice.']
+
 
 class TestChoiceFieldWithType(FieldValues):
     """
@@ -1829,6 +1846,24 @@ class TestMultipleChoiceField(FieldValues):
         assert field.get_value(QueryDict({})) == []
         field.partial = True
         assert field.get_value(QueryDict({})) == rest_framework.fields.empty
+
+    def test_multiple_strict_choices(self):
+        """
+        If `strict_choices` then to_representation() should return a set from given choices.
+        """
+        field = serializers.MultipleChoiceField(
+            strict_choices=True,
+            choices=[
+                ('aircon', 'AirCon'),
+                ('manual', 'Manual drive'),
+                ('diesel', 'Diesel'),
+            ]
+        )
+
+        assert field.to_representation(['aircon', 'manual']) == {'aircon', 'manual'}
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            field.to_representation(['aircon', 'incorrect'])
+        assert exc_info.value.detail == ['"incorrect" is not a valid choice.']
 
 
 class TestEmptyMultipleChoiceField(FieldValues):


### PR DESCRIPTION
Add optional functionality to ChoiceField & MultipleChoiceField when `to_represention()` is called to check if the output of serializer is a valid value(or set) among given choices.
Hopefully developers will be strongly confident that the response is limited to certain choices, so they can skip the redundant validation tests for choices.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
