### PR TITLE
Fix extra actions button not showing with namespaces refs #7500

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -198,6 +198,9 @@ class ViewSetMixin:
         for action in actions:
             try:
                 url_name = '%s-%s' % (self.basename, action.url_name)
+                namespace = self.request.resolver_match.namespace
+                if namespace:
+                    url_name = '%s:%s' % (namespace, url_name) 
                 url = reverse(url_name, self.args, self.kwargs, request=self.request)
                 view = self.__class__(**action.kwargs)
                 action_urls[view.get_view_name()] = url


### PR DESCRIPTION
See https://github.com/encode/django-rest-framework/issues/7500
I'm already using this in production for a long time, but of course a test case would be even better.