### PR TITLE
Update documentation to include Django 3.2 as supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 # Requirements
 
 * Python (3.5, 3.6, 3.7, 3.8, 3.9)
-* Django (2.2, 3.0, 3.1)
+* Django (2.2, 3.0, 3.1, 3.2)
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ continued development by **[signing up for a paid plan][funding]**.
 REST framework requires the following:
 
 * Python (3.5, 3.6, 3.7, 3.8, 3.9)
-* Django (2.2, 3.0, 3.1)
+* Django (2.2, 3.0, 3.1, 3.2)
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.


### PR DESCRIPTION
## Description

The project works and has been tested under Django version 3.2, but the documentation did not reflect this, yet. I added version 3.2 to the supported versions both in the `README.md` and the `docs/index.md` files.

This pull request closes `refs #7993` (#7993) and `refs #7944` (#7944).
