### PR TITLE
Preserve exception messages for wrapped Django exceptions

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -79,9 +79,9 @@ def exception_handler(exc, context):
     to be raised.
     """
     if isinstance(exc, Http404):
-        exc = exceptions.NotFound()
+        exc = exceptions.NotFound(*(exc.args))
     elif isinstance(exc, PermissionDenied):
-        exc = exceptions.PermissionDenied()
+        exc = exceptions.PermissionDenied(*(exc.args))
 
     if isinstance(exc, exceptions.APIException):
         headers = {}

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -521,7 +521,11 @@ class TestFilterBackendAppliedToViews(TestCase):
         response = instance_view(request, pk=1).render()
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.data == {
-            'detail': ErrorDetail(string='No BasicModel matches the given query.', code='not_found')}
+            'detail': ErrorDetail(
+                string='No BasicModel matches the given query.',
+                code='not_found'
+            )
+        }
 
     def test_get_instance_view_will_return_single_object_when_filter_does_not_exclude_it(self):
         """

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -5,13 +5,13 @@ from django.shortcuts import get_object_or_404
 from django.test import TestCase
 
 from rest_framework import generics, renderers, serializers, status
+from rest_framework.exceptions import ErrorDetail
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
 from tests.models import (
     BasicModel, ForeignKeySource, ForeignKeyTarget, RESTFrameworkModel,
     UUIDForeignKeyTarget
 )
-from rest_framework.exceptions import ErrorDetail
 
 factory = APIRequestFactory()
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -11,6 +11,7 @@ from tests.models import (
     BasicModel, ForeignKeySource, ForeignKeyTarget, RESTFrameworkModel,
     UUIDForeignKeyTarget
 )
+from rest_framework.exceptions import ErrorDetail
 
 factory = APIRequestFactory()
 
@@ -519,7 +520,8 @@ class TestFilterBackendAppliedToViews(TestCase):
         request = factory.get('/1')
         response = instance_view(request, pk=1).render()
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.data == {'detail': 'Not found.'}
+        assert response.data == {
+            'detail': ErrorDetail(string='No BasicModel matches the given query.', code='not_found')}
 
     def test_get_instance_view_will_return_single_object_when_filter_does_not_exclude_it(self):
         """


### PR DESCRIPTION
I did not review your contributing guidelines, nor did I test anything using the automated tests. I also did only the most minimal of non-automated testing. Still, I thought I'd leave this here, as it may be useful to others. See it as an "issue description with PoC of a solution" if you will.

The problem: when raising standard Django exceptions `Http404` or `PermissionDenied`, the error messages of these exceptions do not show up in the DRF's response. This is because these exceptions are recreated in the piece of code that this PR adapts.

In this PR this is solved by making sure the recreated exceptions are recreated with the same arguments as the original versions. Whether the signatures actually match up, I did not check properly.