### PR TITLE
Fixes inconsistent headers in `serializer` docs

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -605,13 +605,13 @@ For `ModelSerializer` this defaults to `PrimaryKeyRelatedField`.
 
 For `HyperlinkedModelSerializer` this defaults to `serializers.HyperlinkedRelatedField`.
 
-### `serializer_url_field`
+### `.serializer_url_field`
 
 The serializer field class that should be used for any `url` field on the serializer.
 
 Defaults to `serializers.HyperlinkedIdentityField`
 
-### `serializer_choice_field`
+### `.serializer_choice_field`
 
 The serializer field class that should be used for any choice fields on the serializer.
 


### PR DESCRIPTION
Some headers were using `.`, some - were not.
Now, all of them are the same with `.`, because it was easier to fix.

<img width="883" alt="Снимок экрана 2021-06-25 в 17 06 29" src="https://user-images.githubusercontent.com/4660275/123436814-b4076300-d5d7-11eb-9c5a-5d76298627d4.png">
