### PR TITLE
Replace SimpleThrottle self.history default value with deque

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -121,7 +121,10 @@ class SimpleRateThrottle(BaseThrottle):
         if self.key is None:
             return True
 
-        self.history = self.cache.get(self.key, deque())
+        self.history = self.cache.get(self.key)
+        if self.history is None:
+            self.history = deque()
+
         self.now = self.timer()
 
         # Drop any requests from the history which have now passed the

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -2,6 +2,7 @@
 Provides various throttling policies.
 """
 import time
+from collections import deque
 
 from django.core.cache import cache as default_cache
 from django.core.exceptions import ImproperlyConfigured
@@ -120,7 +121,7 @@ class SimpleRateThrottle(BaseThrottle):
         if self.key is None:
             return True
 
-        self.history = self.cache.get(self.key, [])
+        self.history = self.cache.get(self.key, deque())
         self.now = self.timer()
 
         # Drop any requests from the history which have now passed the
@@ -136,7 +137,7 @@ class SimpleRateThrottle(BaseThrottle):
         Inserts the current request's timestamp along with the key
         into the cache.
         """
-        self.history.insert(0, self.now)
+        self.history.appendleft(self.now)
         self.cache.set(self.key, self.history, self.duration)
         return True
 


### PR DESCRIPTION
## Description

To decrease the time complexity from O(N) to O(1) while adding an element at the first position of the list (`self.history`), we should use `collections.deque` with `.appendleft()` for 10x performance.

Demo:
```Python
In [1]: lst = [0]*1000
In [2]: timeit -n1000 lst.insert(0, 1)
1000 loops, best of 3: 794 ns per loop

In [3]: from collections import deque
In [4]: deq = deque([0]*1000)
In [5]: timeit -n1000 deq.appendleft(1)
1000 loops, best of 3: 73 ns per loop
```