### PR TITLE
Add new generic class for listing a queryset or retrieving, creating,…

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -289,3 +289,32 @@ class RetrieveUpdateDestroyAPIView(mixins.RetrieveModelMixin,
 
     def delete(self, request, *args, **kwargs):
         return self.destroy(request, *args, **kwargs)
+
+class RetrieveListCreateUpdateDestroyAPIView(mixins.RetrieveModelMixin,
+                                             mixins.ListModelMixin,
+                                             mixins.CreateModelMixin,
+                                             mixins.UpdateModelMixin,
+                                             mixins.DestroyModelMixin,
+                                             GenericAPIView):
+    """
+    Concrete view for listing a queryset or retrieving, creating, updating or deleting a model instance,
+    """
+    def get(self, request, *args, **kwargs):
+        if kwargs.get(self.lookup_field):
+            return self.retrieve(request, *args, **kwargs)
+        else:
+            return self.list(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)
+
+    def put(self, request, *args, **kwargs):
+        return self.update(request, *args, **kwargs)
+
+    def patch(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)
+
+`


### PR DESCRIPTION
… updating or deleting a model instance
## Description

This could be a new feature that we can use all the generic at once, we usually do this with separate model mixins

The important thing that I added here is: user can have the **retrieve** or **list** depends on the _lookup_field_, if the client passes him the _lookup_field_ he will get the **retrieve** else he'll get the **list**.