### PR TITLE
Allow overriding field mappings for choice field

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1412,12 +1412,11 @@ class ChoiceField(Field):
     html_cutoff = None
     html_cutoff_text = _('More than {count} items...')
 
-    def __init__(self, choices, **kwargs):
+    def __init__(self, choices, allow_blank=False, **kwargs):
         self.choices = choices
+        self.allow_blank = allow_blank
         self.html_cutoff = kwargs.pop('html_cutoff', self.html_cutoff)
         self.html_cutoff_text = kwargs.pop('html_cutoff_text', self.html_cutoff_text)
-
-        self.allow_blank = kwargs.pop('allow_blank', False)
 
         super().__init__(**kwargs)
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -217,6 +217,25 @@ class TestRegularFieldMappings(TestCase):
         """)
         self.assertEqual(repr(TestSerializer()), expected)
 
+    def test_override_choice_field_mapping(self):
+        class CustomChoiceField(models.CharField):
+            """
+            A custom choice model field simply for testing purposes.
+            """
+            max_length = 100
+
+        class CostomizedChoiceModel(models.Model):
+            choices_field = CustomChoiceField(choices=COLOR_CHOICES)
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = CostomizedChoiceModel
+                fields = '__all__'
+
+        self.assertTrue(isinstance(TestSerializer().fields["choices_field"], serializers.ChoiceField))
+        TestSerializer.serializer_field_mapping[CustomChoiceField] = serializers.MultipleChoiceField
+        self.assertTrue(isinstance(TestSerializer().fields["choices_field"], serializers.MultipleChoiceField))
+
     def test_nullable_boolean_field_choices(self):
         class NullableBooleanChoicesModel(models.Model):
             CHECKLIST_OPTIONS = (


### PR DESCRIPTION
## Description

Allow to modify `serializer_field_mapping` to automatically determine choice field classes rather than hard coded `ChoiceField`.

Instead of overriding `build_standard_field` via a new model serializer class:
```python3
class NewModelSerialzer(ModelSerializer)
  def build_standard_field(self, **kwargs):
      field_cls, field_kwargs = super(MyClass, self).build_standard_field(self, **kwargs)
      if issubclass(field_cls, ChoiceField):
          field_cls = WHATEVER
      return field_cls, field_kwargs
```
We could simply modify `serializer_field_mapping` directly:
```python3
serializers.ModelSerializer.serializer_field_mapping[CustomChoiceField] = serializers.MultipleChoiceField
```

refs:
#1689
#2322

