### PR TITLE
Ensure request method is compare to http_method_names of same case

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -497,7 +497,7 @@ class APIView(View):
             self.initial(request, *args, **kwargs)
 
             # Get the appropriate handler method
-            if request.method.lower() in self.http_method_names:
+            if request.method.lower() in map(str.lower, self.http_method_names):
                 handler = getattr(self, request.method.lower(),
                                   self.http_method_not_allowed)
             else:


### PR DESCRIPTION
## Description

Make sure both LHS and RHS are lower-cased in comparison for
membership testing.

Closes #8106 