### PR TITLE
fix passing list to  parse_html_list utils function

### DIFF
--- a/rest_framework/utils/html.py
+++ b/rest_framework/utils/html.py
@@ -47,6 +47,11 @@ def parse_html_list(dictionary, prefix='', default=None):
 
     :returns a list of objects, or the value specified in ``default`` if the list is empty
     """
+    if  isinstance(dictionary, (list, tuple)):
+        dictionary = str(dictionary)[1:-1]
+    dictionary = '{' + dictionary[1:-1].replace('}', '').replace('{', '') + '}'
+    dictionary = eval(dictionary)
+    
     ret = {}
     regex = re.compile(r'^%s\[([0-9]+)\](.*)$' % re.escape(prefix))
     for field, value in dictionary.items():


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Improving parse_html_list function to work in case of an input of list of dictionaries by parsing the list and converting it into one large dictionary.
 https://github.com/encode/django-rest-framework/issues/7186#issue-563281125
