### PR TITLE
Extend logout drop down menu

### DIFF
--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -88,7 +88,9 @@ All of the standard [Bootstrap components][bcomponents] are available.
 
 The browsable API makes use of the Bootstrap tooltips component.  Any element with the `js-tooltip` class and a `title` attribute has that title content will display a tooltip on hover events.
 
-### Login Template
+### Customizing Authentication
+
+#### Login Template
 
 To add branding and customize the look-and-feel of the login template, create a template called `login.html` and add it to your project, eg: `templates/rest_framework/login.html`.  The template should extend from `rest_framework/login_base.html`.
 
@@ -101,6 +103,39 @@ You can add your site name or branding by including the branding block:
     {% endblock %}
 
 You can also customize the style by adding the `bootstrap_theme` or `style` block similar to `api.html`.
+
+#### Login/Logout Button
+
+The Login/Logout functionality comes from userlinks block from 'base.html' and 'admin.html' templates. If you want to remove it then you can just override the block in both templates:
+
+    {% extends "rest_framework/base.html" %}
+
+    {% block userlinks %}
+    {% endblock %}
+
+If you want to extend the logout drop down menu then add the following to both project templates:
+
+    {% extends "rest_framework/base.html" %}
+    {% load rest_framework %}
+
+    {% block userlinks %}
+        {% if user.is_authenticated %}
+            <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                    {{ user }}
+                    <b class="caret"></b>
+                </a>
+                <ul class="dropdown-menu">
+                    <li><a href='#profile'>My Profile</a></li>     <! –– Customization ––>
+                    <li><a href='#messages'>My Messages</a></li>   <! –– Customization ––>
+                    <li role="separator" class="divider"></li>     <! –– Customization ––>
+                    <li>{% optional_logout request %}</li>
+                </ul>
+            </li>
+        {% else %}
+            <li>{% optional_login request %}</li>
+        {% endif %}
+    {% endblock %}
 
 ### Advanced Customization
 

--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -128,7 +128,7 @@ If you want to extend the logout drop down menu then add the following to both p
                 <ul class="dropdown-menu">
                     <li><a href='#profile'>My Profile</a></li>     <! –– Customization ––>
                     <li><a href='#messages'>My Messages</a></li>   <! –– Customization ––>
-                    <li role="separator" class="divider"></li>     <! –– Customization ––>
+                    <li role="separator" class="divider"></li>     <! –– Bootstrap v3  ––>
                     <li>{% optional_logout request %}</li>
                 </ul>
             </li>

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -120,27 +120,32 @@ def optional_docs_login(request):
 
 
 @register.simple_tag
-def optional_logout(request, user):
+def optional_logout(request, user=""):
     """
     Include a logout snippet if REST framework's logout view is in the URLconf.
     """
     try:
         logout_url = reverse('rest_framework:logout')
     except NoReverseMatch:
-        snippet = format_html('<li class="navbar-text">{user}</li>', user=escape(user))
+        snippet = format_html('<li class="navbar-text">{user}</li>', user=escape(user) or 'logged in')
         return mark_safe(snippet)
 
-    snippet = """<li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-            {user}
-            <b class="caret"></b>
-        </a>
-        <ul class="dropdown-menu">
-            <li><a href='{href}?next={next}'>Log out</a></li>
-        </ul>
-    </li>"""
-    snippet = format_html(snippet, user=escape(user), href=logout_url, next=escape(request.path))
+    if user:
+        snippet = """<li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                {user}
+                <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                <li><a href='{href}?next={next}'>Log out</a></li>
+            </ul>
+        </li>"""
+#        snippet = format_html(snippet, user=escape(user), href=logout_url, next=escape(request.path))
+    else:
+        snippet = "<a href='{href}?next={next}'>Log out</a>"
+#        snippet = format_html(snippet, href=logout_url, next=escape(request.path))
 
+    snippet = format_html(snippet, user=escape(user), href=logout_url, next=escape(request.path))
     return mark_safe(snippet)
 
 

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -140,10 +140,8 @@ def optional_logout(request, user=""):
                 <li><a href='{href}?next={next}'>Log out</a></li>
             </ul>
         </li>"""
-#        snippet = format_html(snippet, user=escape(user), href=logout_url, next=escape(request.path))
     else:
         snippet = "<a href='{href}?next={next}'>Log out</a>"
-#        snippet = format_html(snippet, href=logout_url, next=escape(request.path))
 
     snippet = format_html(snippet, user=escape(user), href=logout_url, next=escape(request.path))
     return mark_safe(snippet)


### PR DESCRIPTION
I wanted to add some extra options to the Browseable API logout drop down menu, but I couldn't find a clean way. Googling revealed others trying to achieve the same, but no good solutions.

I extended _optional_logout_ to be called also without the _user_ parameter. In that case _optional_logout_ just returns the logout link, which can be added to a custom menu. If there is a _user_ parameter, then it works as it used to so my change won't break anything.

In the case _optional_logout_ is called outside of _rest_framework:logout_ it will just return string 'logged in'.

I also wrote some documentation with examples.

_optional_logout_ is not included in any tests, but I ran them anyways. All passed as one would expect.
