### PR TITLE
fix: requiring Django 3.X version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,14 +82,13 @@ setup(
     author_email='tom@tomchristie.com',  # SEE NOTE BELOW (*)
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=["django>=2.2"],
+    install_requires=["django>=3.0"],
     python_requires=">=3.5",
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',


### PR DESCRIPTION
## Description

Django 2.2 support has been dropped in #7337, the setup should reflect this change in order to ensure correct dependencies resolution. Currently it's broken and will affect all 3.12.0 to 3.12.4 versions at least.

Moreover the support drop has not been put in the changelog, or at least I haven't seen it in the 3.12 page (PR id cannot be found).