### PR TITLE
Fix: Grammatical Error in `api-guide/authentication`

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -13,7 +13,7 @@ Authentication is the mechanism of associating an incoming request with a set of
 
 REST framework provides several authentication schemes out of the box, and also allows you to implement custom schemes.
 
-Authentication is always run at the very start of the view, before the permission and throttling checks occur, and before any other code is allowed to proceed.
+Authentication always runs at the very start of the view, before the permission and throttling checks occur, and before any other code is allowed to proceed.
 
 The `request.user` property will typically be set to an instance of the `contrib.auth` package's `User` class.
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Grammatical Error

Corrected to `always runs`

![image](https://user-images.githubusercontent.com/55396651/131223269-34b4182b-a3a8-4a05-8abd-57d0a19dcc61.png)

