### PR TITLE
Django 4.0 compatibility

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -325,7 +325,7 @@ Corresponds to `django.db.models.fields.DateTimeField`.
 
 * `format` - A string representing the output format. If not specified, this defaults to the same value as the `DATETIME_FORMAT` settings key, which will be `'iso-8601'` unless set. Setting to a format string indicates that `to_representation` return values should be coerced to string output. Format strings are described below. Setting this value to `None` indicates that Python `datetime` objects should be returned by `to_representation`. In this case the datetime encoding will be determined by the renderer.
 * `input_formats` - A list of strings representing the input formats which may be used to parse the date.  If not specified, the `DATETIME_INPUT_FORMATS` setting will be used, which defaults to `['iso-8601']`.
-* `default_timezone` - A `pytz.timezone` representing the timezone. If not specified and the `USE_TZ` setting is enabled, this defaults to the [current timezone][django-current-timezone]. If `USE_TZ` is disabled, then datetime objects will be naive.
+* `default_timezone` - A `tzinfo` subclass (`zoneinfo` or `pytz`) prepresenting the timezone. If not specified and the `USE_TZ` setting is enabled, this defaults to the [current timezone][django-current-timezone]. If `USE_TZ` is disabled, then datetime objects will be naive.
 
 #### `DateTimeField` format strings.
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author_email='tom@tomchristie.com',  # SEE NOTE BELOW (*)
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=["django>=2.2"],
+    install_requires=["django>=2.2", "pytz"],
     python_requires=">=3.5",
     zip_safe=False,
     classifiers=[

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -1,5 +1,6 @@
 import base64
 
+import django
 import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -218,7 +219,16 @@ class SessionAuthTests(TestCase):
         Ensure POSTing form over session authentication with CSRF token succeeds.
         Regression test for #6088
         """
-        from django.middleware.csrf import _get_new_csrf_token
+        # Remove this shim when dropping support for Django 2.2.
+        if django.VERSION < (3, 0):
+            from django.middleware.csrf import _get_new_csrf_token
+        else:
+            from django.middleware.csrf import (
+                _get_new_csrf_string, _mask_cipher_secret
+            )
+
+            def _get_new_csrf_token():
+                return _mask_cipher_secret(_get_new_csrf_string())
 
         self.csrf_client.login(username=self.username, password=self.password)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     from django.conf import settings
 
+    # USE_L10N is deprecated, and will be removed in Django 5.0.
+    use_l10n = {"USE_L10N": True} if django.VERSION < (4, 0) else {}
     settings.configure(
         DEBUG_PROPAGATE_EXCEPTIONS=True,
         DATABASES={
@@ -33,7 +35,6 @@ def pytest_configure(config):
         SITE_ID=1,
         SECRET_KEY='not very secret in tests',
         USE_I18N=True,
-        USE_L10N=True,
         STATIC_URL='/static/',
         ROOT_URLCONF='tests.urls',
         TEMPLATES=[
@@ -68,6 +69,7 @@ def pytest_configure(config):
         PASSWORD_HASHERS=(
             'django.contrib.auth.hashers.MD5PasswordHasher',
         ),
+        **use_l10n,
     )
 
     # guardian is optional

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1464,15 +1464,24 @@ class TestDefaultTZDateTimeField(TestCase):
         cls.field = serializers.DateTimeField()
         cls.kolkata = pytz.timezone('Asia/Kolkata')
 
+    def assertUTC(self, tzinfo):
+        """
+        Check UTC for datetime.timezone, ZoneInfo, and pytz tzinfo instances.
+        """
+        assert (
+            tzinfo is utc or
+            (getattr(tzinfo, "key", None) or getattr(tzinfo, "zone", None)) == "UTC"
+        )
+
     def test_default_timezone(self):
-        assert self.field.default_timezone() == utc
+        self.assertUTC(self.field.default_timezone())
 
     def test_current_timezone(self):
-        assert self.field.default_timezone() == utc
+        self.assertUTC(self.field.default_timezone())
         activate(self.kolkata)
         assert self.field.default_timezone() == self.kolkata
         deactivate()
-        assert self.field.default_timezone() == utc
+        self.assertUTC(self.field.default_timezone())
 
 
 @pytest.mark.skipif(pytz is None, reason='pytz not installed')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1220,12 +1220,12 @@ class TestNoStringCoercionDecimalField(FieldValues):
 
 
 class TestLocalizedDecimalField(TestCase):
-    @override_settings(USE_L10N=True, LANGUAGE_CODE='pl')
+    @override_settings(LANGUAGE_CODE='pl')
     def test_to_internal_value(self):
         field = serializers.DecimalField(max_digits=2, decimal_places=1, localize=True)
         assert field.to_internal_value('1,1') == Decimal('1.1')
 
-    @override_settings(USE_L10N=True, LANGUAGE_CODE='pl')
+    @override_settings(LANGUAGE_CODE='pl')
     def test_to_representation(self):
         field = serializers.DecimalField(max_digits=2, decimal_places=1, localize=True)
         assert field.to_representation(Decimal('1.1')) == '1,1'

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
        {py35,py36,py37}-django22,
        {py36,py37,py38,py39}-django31,
        {py36,py37,py38,py39}-django32,
-       {py38,py39}-djangomain,
+       {py38,py39}-{django40,djangomain},
        base,dist,docs,
 
 [travis:env]
@@ -11,6 +11,7 @@ DJANGO =
     2.2: django22
     3.1: django31
     3.2: django32
+    4.0: django40
     main: djangomain
 
 [testenv]
@@ -23,6 +24,7 @@ deps =
         django22: Django>=2.2,<3.0
         django31: Django>=3.1,<3.2
         django32: Django>=3.2,<4.0
+        django40: Django>=4.0a1,<5.0
         djangomain: https://github.com/django/django/archive/main.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
Adds compatibility for Django 4.0. 

[From Django 4.0 `zoneinfo` is the default time zone implementation](https://docs.djangoproject.com/en/dev/releases/4.0/#zoneinfo-default-timezone-implementation). This PR makes the minimum changes to work with that, plus other necessary adjustments.  

DRF now requires `pytz` in `install_requires`. There's a small amount of work to be done in `fields.py` and `test_fields.py` to remove the `pytz` dependency. (Django will remove support for `pytz` in Django 5.0.) 