### PR TITLE
Clear Sphinx warnings from serializers.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -136,12 +136,12 @@ class BaseSerializer(Field):
 
         Note that we're over-cautious in passing most arguments to both parent
         and child classes in order to try to cover the general case. If you're
-        overriding this method you'll probably want something much simpler, eg:
+        overriding this method you'll probably want something much simpler, eg::
 
-        @classmethod
-        def many_init(cls, *args, **kwargs):
-            kwargs['child'] = cls()
-            return CustomListSerializer(*args, **kwargs)
+            @classmethod
+            def many_init(cls, *args, **kwargs):
+                kwargs['child'] = cls()
+                return CustomListSerializer(*args, **kwargs)
         """
         allow_empty = kwargs.pop('allow_empty', None)
         max_length = kwargs.pop('max_length', None)
@@ -928,13 +928,13 @@ class ModelSerializer(Serializer):
         """
         We have a bit of extra checking around this in order to provide
         descriptive messages when something goes wrong, but this method is
-        essentially just:
+        essentially just::
 
             return ExampleModel.objects.create(**validated_data)
 
         If there are many to many fields present on the instance then they
         cannot be set until the model is instantiated, in which case the
-        implementation is like so:
+        implementation is like so::
 
             example_relationship = validated_data.pop('example_relationship')
             instance = ExampleModel.objects.create(**validated_data)


### PR DESCRIPTION
Cleared Sphinx warnings from:

- ModelSerializer.create
- BaseSerializer.many_init

## Description

Clear Sphinx warnings from serializers by adding the double-colon syntax preceding an indented block to identify an inline code sample.


Sphinx is interpreting the `**` in examples like `def many_init(cls, *args, **kwargs):`  as having un-balanced start/end strings. In this case `**` is the strong-emphasis start string. Similarly, Sphinx sees the `*` in `*args` as having unbalanced emphasis strings as `*` is the emphasis markup.

For example, the following code would generate the following warnings:

serializers.py:

```
from rest_framework import serializers
from flights.models import Flight

class FlightSerializer(serializers.ModelSerializer):
    """Serializer for Flight records.
    """
    class Meta:
        model = Flight
        fields = ['date', 'aircraft_id', 'pilot_comments']
```

Warnings:

```
/home/derek/src/aviation/backend/flights/serializers.py:docstring of rest_framework.serializers.ModelSerializer.create:5: WARNING: Inline strong start-string without end-string.
/home/derek/src/aviation/backend/flights/serializers.py:docstring of rest_framework.serializers.ModelSerializer.create:11: WARNING: Inline strong start-string without end-string.
/home/derek/src/aviation/backend/flights/serializers.py:docstring of rest_framework.serializers.BaseSerializer.many_init:12: WARNING: Unexpected indentation.
/home/derek/src/aviation/backend/flights/serializers.py:docstring of rest_framework.serializers.BaseSerializer.many_init:10: WARNING: Inline emphasis start-string without end-string.
/home/derek/src/aviation/backend/flights/serializers.py:docstring of rest_framework.serializers.BaseSerializer.many_init:10: WARNING: Inline strong start-string without end-string.
/home/derek/src/aviation/backend/flights/serializers.py:docstring of rest_framework.serializers.BaseSerializer.many_init:12: WARNING: Inline emphasis start-string without end-string.
/home/derek/src/aviation/backend/flights/serializers.py:docstring of rest_framework.serializers.BaseSerializer.many_init:12: WARNING: Inline strong start-string without end-string.
```

