### PR TITLE
Add `required` fields on paginator class's schemas

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -253,6 +253,10 @@ class PageNumberPagination(BasePagination):
                 },
                 'results': schema,
             },
+            'required': [
+                'count',
+                'results',
+            ],
         }
 
     def get_page_size(self, request):
@@ -426,6 +430,10 @@ class LimitOffsetPagination(BasePagination):
                 },
                 'results': schema,
             },
+            'required': [
+                'count',
+                'results',
+            ],
         }
 
     def get_limit(self, request):
@@ -911,7 +919,10 @@ class CursorPagination(BasePagination):
                     'nullable': True,
                 },
                 'results': schema,
-            },
+            },,
+            'required': [
+                'results',
+            ],
         }
 
     def get_html_context(self):

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -919,7 +919,7 @@ class CursorPagination(BasePagination):
                     'nullable': True,
                 },
                 'results': schema,
-            },,
+            },
             'required': [
                 'results',
             ],


### PR DESCRIPTION
## Description
`required: [count, responses]` or `required: [responses]` added to schema returned by pagination classes
 to specify which fields are required on a paginated response so that client code generators can add necessary
 validations/enable null-safe implementations.

#8187 
