### PR TITLE
Update permissions.md to fix garden path sentences

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -24,9 +24,9 @@ A slightly less strict style of permission would be to allow full access to auth
 Permissions in REST framework are always defined as a list of permission classes.
 
 Before running the main body of the view each permission in the list is checked.
-If any permission check fails an `exceptions.PermissionDenied` or `exceptions.NotAuthenticated` exception will be raised, and the main body of the view will not run.
+If any permission check fails, an `exceptions.PermissionDenied` or `exceptions.NotAuthenticated` exception will be raised, and the main body of the view will not run.
 
-When the permissions checks fail either a "403 Forbidden" or a "401 Unauthorized" response will be returned, according to the following rules:
+When the permission checks fail, either a "403 Forbidden" or a "401 Unauthorized" response will be returned, according to the following rules:
 
 * The request was successfully authenticated, but permission was denied. *&mdash; An HTTP 403 Forbidden response will be returned.*
 * The request was not successfully authenticated, and the highest priority authentication class *does not* use `WWW-Authenticate` headers. *&mdash; An HTTP 403 Forbidden response will be returned.*


### PR DESCRIPTION
## Description

When reading this particular documentation page, I had to re-read these two sentences twice because they are like [garden-path sentences](https://en.wikipedia.org/wiki/Garden-path_sentence). The reader is lured into a parse that turns out to be a dead end or yields a clearly unintended meaning.

For example, the reader can be led down the wrong path by combining `If any permission check fails` with `an exceptions...`:

> [If any permission check fails an `exceptions.PermissionDenied` or `exceptions.NotAuthenticated` exception] [will be raised,] ??? [and the main body of the view will not run.]

Adding the comma clarifies the clauses in the sentence and will make it unambiguous from the first read-through:

> [If any permission check fails], [an `exceptions.PermissionDenied` or `exceptions.NotAuthenticated` exception will be raised], [and the main body of the view will not run.]

Same issue for the second modified sentence, with a small typo fix. 