### PR TITLE
Imported Missing Response

### DIFF
--- a/docs/api-guide/views.md
+++ b/docs/api-guide/views.md
@@ -145,6 +145,7 @@ REST framework also allows you to work with regular function based views.  It pr
 The core of this functionality is the `api_view` decorator, which takes a list of HTTP methods that your view should respond to. For example, this is how you would write a very simple view that just manually returns some data:
 
     from rest_framework.decorators import api_view
+    from rest_framework.response import Response
 
     @api_view()
     def hello_world(request):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

In current official docs version [https://www.django-rest-framework.org/api-guide/views/](https://www.django-rest-framework.org/api-guide/views/)
![Screenshot from 2021-10-07 19-40-57](https://user-images.githubusercontent.com/72073401/136401953-4f20c83a-97c8-44cb-9f6c-621c124a050e.png)
The given code spinnet will throw an error as `Response` hasn't been imported, so I imported `Response` through  
`from rest_framework.response import Response`