### PR TITLE
docs(tutorial: 5): improve wording (#8218)

### DIFF
--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -51,7 +51,7 @@ And then add a url pattern for the snippet highlights:
 
 ## Hyperlinking our API
 
-Dealing with relationships between entities is one of the more challenging aspects of Web API design.  There are a number of different ways that we might choose to represent a relationship:
+Dealing with relationships between entities is one of the most challenging aspects of Web API design.  There are a number of different ways that we might choose to represent a relationship:
 
 * Using primary keys.
 * Using hyperlinking between entities.


### PR DESCRIPTION
## Related Issue

- https://github.com/encode/django-rest-framework/issues/8218

## Description

On https://github.com/encode/django-rest-framework/blob/master/docs/tutorial/5-relationships-and-hyperlinked-apis.md#hyperlinking-our-api,

Change wording
- **OLD** ` the more challenging aspects of Web API design` 
- **NEW** ` the most challenging aspects of Web API design`
