### PR TITLE
Warn when extra_field_kwargs includes fields explicitly declared related to #3460)

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1062,12 +1062,26 @@ class ModelSerializer(Serializer):
         fields = OrderedDict()
 
         for field_name in field_names:
+            extra_field_kwargs = extra_kwargs.get(field_name, {})
+
             # If the field is explicitly declared on the class then use that.
             if field_name in declared_fields:
-                fields[field_name] = declared_fields[field_name]
+                assert not extra_field_kwargs, (
+                    "The field '{field_name}' was declared on serializer "
+                    "{serializer_class}, but has also been included in "
+                    "extra_fields_kwargs ({extra_field_kwargs}). "
+                    "This must be a mistake, because extra_field_kwargs are "
+                    "not applied to declared fields. For example, if you want "
+                    "the field to be read-only, you must explicitly pass "
+                    "read_only=True when declaring, instead of including the "
+                    "field in read_only_fields.".format(
+                        field_name=field_name,
+                        serializer_class=self.__class__.__name__,
+                        extra_field_kwargs=extra_field_kwargs
+                    )
+                )
                 continue
 
-            extra_field_kwargs = extra_kwargs.get(field_name, {})
             source = extra_field_kwargs.get('source', '*')
             if source == '*':
                 source = field_name

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1080,6 +1080,7 @@ class ModelSerializer(Serializer):
                         extra_field_kwargs=extra_field_kwargs
                     )
                 )
+                fields[field_name] = declared_fields[field_name]
                 continue
 
             source = extra_field_kwargs.get('source', '*')


### PR DESCRIPTION
This PR adds an invariant check via a loud assert (as suggested [here](https://github.com/encode/django-rest-framework/issues/3460#issuecomment-348447739)) to help with issue https://github.com/encode/django-rest-framework/issues/3460.

The goal is to notify people when they include fields in `extra_kwargs` (either directly or, more worryingly because of security, via `read_only_fields`). For example, I've seen this time and time again in production code:

```python3
class MySerializer(ModelSerializer):
    my_sensitive_field = ...
    ...
    class Meta:
        fields = ('my_sensitive_field', ...)
        read_only_fields = ('my_sensitive_field', )
```

I believe most people assume that `my_sensitive_field` is now readonly, without knowing that `extra_kwargs`, and, hence, `read_only_fields`, only apply to fields not explicitly declared.