### PR TITLE
Fixed missing "fields" meta argument in docs

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -524,6 +524,7 @@ You can add extra fields to a `ModelSerializer` or override the default fields b
 
         class Meta:
             model = Account
+            fields = ['get_absolute_url', 'groups']
 
 Extra fields can correspond to any property or callable on the model.
 

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -524,7 +524,7 @@ You can add extra fields to a `ModelSerializer` or override the default fields b
 
         class Meta:
             model = Account
-            fields = ['get_absolute_url', 'groups']
+            fields = ['url', 'groups']
 
 Extra fields can correspond to any property or callable on the model.
 


### PR DESCRIPTION
In "Specifying fields explicitly" https://github.com/encode/django-rest-framework/blob/master/docs/api-guide/serializers.md#specifying-fields-explicitly paragraph from the docs, the code example provided was missing the `fields` meta argument, which is mandatory from `3.3.0`. 
The assertion error was: `Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = '__all__' to the CalendarTaskSerializer serializer.`
