### PR TITLE
Fix link to installation of httpie

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -225,4 +225,4 @@ If you want to get a more in depth understanding of how REST framework fits toge
 [image]: ../img/quickstart.png
 [tutorial]: 1-serialization.md
 [guide]: ../api-guide/requests.md
-[httpie]: https://github.com/jakubroztocil/httpie#installation
+[httpie]: https://httpie.io/docs#installation


### PR DESCRIPTION
## Description

Right now httpie moved to "httpie" organization (https://github.com/httpie/httpie) and they don't have "installation" at their GitHub. Instead of that, they have "Getting started" section with link to "Installation instructions".
