### PR TITLE
Docs: Fix minor issue with permissions table

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -286,7 +286,7 @@ The following table lists the access restriction methods and the level of contro
 
 |                                    | `queryset` | `permission_classes` | `serializer_class` |
 |------------------------------------|------------|----------------------|--------------------|
-| Action: list                       | global     | no                   | object-level*      |
+| Action: list                       | global     | global               | object-level*      |
 | Action: create                     | no         | global               | object-level       |
 | Action: retrieve                   | global     | object-level         | object-level       |
 | Action: update                     | global     | object-level         | object-level       |


### PR DESCRIPTION
I might just be misunderstanding something (always a strong possibility!), but it seems to me that the table on the Permissions page is slightly inaccurate.

For `permission_classes`, wouldn't it have global-level permissions for list actions (rather than no permission control, as is currently listed)?