### PR TITLE
Rfc6902

### DIFF
--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -68,29 +68,21 @@ class JSONParser(BaseParser):
             raise ParseError('JSON parse error - %s' % str(exc))
 
 
-class JSONPatchParser(BaseParser):
+class JSONPatchParser(JSONParser):
     """
     Parses PATCH RFC 6902 JSON-serialized data.
     """
 
     media_type = 'application/json-patch+json'
-    renderer_class = renderers.JSONRenderer
-    strict = api_settings.STRICT_JSON
 
     def parse(self, stream, media_type=None, parser_context=None):
         """
         Parses the incoming bytestream as JSON and returns the resulting data as json patch.
         """
-        parser_context = parser_context or {}
-        encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
+        data = super().parse(stream, media_type, parser_context)
 
         try:
-            decoded_stream = codecs.getreader(encoding)(stream)
-            parse_constant = json.strict_constant if self.strict else None
-            data = json.load(decoded_stream, parse_constant=parse_constant)
             return jsonpatch.JsonPatch(data)
-        except ValueError as exc:
-            raise ParseError('JSON parse error - %s' % str(exc))
         except jsonpatch.InvalidJsonPatch as exc:
             raise ParseError('JSON Patch (rfc 6902) invalid - %s' % str(exc))
 

--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -7,6 +7,7 @@ on the request, such as form content or json encoded data.
 import codecs
 from urllib import parse
 
+import jsonpatch
 from django.conf import settings
 from django.core.files.uploadhandler import StopFutureHandlers
 from django.http import QueryDict
@@ -65,6 +66,33 @@ class JSONParser(BaseParser):
             return json.load(decoded_stream, parse_constant=parse_constant)
         except ValueError as exc:
             raise ParseError('JSON parse error - %s' % str(exc))
+
+
+class JSONPatchParser(BaseParser):
+    """
+    Parses PATCH RFC 6902 JSON-serialized data.
+    """
+
+    media_type = 'application/json-patch+json'
+    renderer_class = renderers.JSONRenderer
+    strict = api_settings.STRICT_JSON
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        """
+        Parses the incoming bytestream as JSON and returns the resulting data as json patch.
+        """
+        parser_context = parser_context or {}
+        encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
+
+        try:
+            decoded_stream = codecs.getreader(encoding)(stream)
+            parse_constant = json.strict_constant if self.strict else None
+            data = json.load(decoded_stream, parse_constant=parse_constant)
+            return jsonpatch.JsonPatch(data)
+        except ValueError as exc:
+            raise ParseError('JSON parse error - %s' % str(exc))
+        except jsonpatch.InvalidJsonPatch as exc:
+            raise ParseError('JSON Patch (rfc 6902) invalid - %s' % str(exc))
 
 
 class FormParser(BaseParser):

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -32,6 +32,7 @@ DEFAULTS = {
     ],
     'DEFAULT_PARSER_CLASSES': [
         'rest_framework.parsers.JSONParser',
+        'rest_framework.parsers.JSONPatchParser',
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser'
     ],

--- a/rest_framework/utils/json_patch.py
+++ b/rest_framework/utils/json_patch.py
@@ -1,5 +1,4 @@
 from jsonpatch import (
-    JsonPatch,
     InvalidJsonPatch,
     JsonPatchConflict,
     JsonPatchTestFailed,
@@ -28,7 +27,7 @@ def filter_state(state, paths_parts):
     return filtered_state
 
 
-def apply_json_patch(patch: JsonPatch, current_state: dict):
+def apply_json_patch(patch, current_state):
     field = None
     try:
         # empty parts will raise JsonPointerException during apply()

--- a/rest_framework/utils/json_patch.py
+++ b/rest_framework/utils/json_patch.py
@@ -1,0 +1,53 @@
+from jsonpatch import (
+    JsonPatch,
+    InvalidJsonPatch,
+    JsonPatchConflict,
+    JsonPatchTestFailed,
+    JsonPointerException,
+)
+
+from rest_framework.exceptions import ValidationError, ParseError
+
+
+def filter_state(state, paths_parts):
+    filtered_state = {}
+    for parts in paths_parts:
+        if len(parts) > 1:
+            parts = iter(parts)
+            next_part = next(parts)
+            parts = [list(parts)]
+            filtered_state[next_part] = filter_state(state[next_part], parts)
+        elif len(parts) == 1:
+            filtered_state[parts[0]] = state[parts[0]]
+        else:
+            # empty parts will raise JsonPointerException during apply()
+            # this type of error should be checked by json_patch at the
+            # initilization not during the application.
+            continue
+
+    return filtered_state
+
+
+def apply_json_patch(patch: JsonPatch, current_state: dict):
+    field = None
+    try:
+        # empty parts will raise JsonPointerException during apply()
+        # this type of error should be checked by json_patch at the
+        # initilization not during the application.
+        paths_parts = [[part for op in patch._ops for part in op.pointer.parts if part]]
+        filtered_state = filter_state(current_state, paths_parts)
+        return patch.apply(filtered_state)
+    except KeyError:
+        raise ValidationError(
+            {'details': f'JSON Patch (rfc 6902) path does not exist - {field}'}
+        )
+    except JsonPatchConflict as exc:
+        raise ValidationError({'details': f'JSON Patch (rfc 6902) conflict - {exc}'})
+    except JsonPatchTestFailed as exc:
+        raise ValidationError({'details': f'JSON Patch (rfc 6902) test failed - {exc}'})
+    except JsonPointerException as exc:
+        raise ValidationError(
+            {'details': f"JSON Patch (rfc 6902) path's part invalid - {exc}"}
+        )
+    except InvalidJsonPatch as exc:
+        raise ParseError(f'JSON Patch (rfc 6902) invalid - {exc}')

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -789,6 +789,11 @@ class TestOperationIntrospection(TestCase):
                             '$ref': '#/components/schemas/Request'
                         }
                     },
+                    'application/json-patch+json': {
+                        'schema': {
+                            '$ref': '#/components/schemas/Request'
+                        }
+                    },
                     'application/x-www-form-urlencoded': {
                         'schema': {
                             '$ref': '#/components/schemas/Request'

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -39,6 +39,7 @@ class TestMetadata:
             ],
             'parses': [
                 'application/json',
+                'application/json-patch+json',
                 'application/x-www-form-urlencoded',
                 'multipart/form-data'
             ]
@@ -103,6 +104,7 @@ class TestMetadata:
             ],
             'parses': [
                 'application/json',
+                'application/json-patch+json',
                 'application/x-www-form-urlencoded',
                 'multipart/form-data'
             ],
@@ -366,6 +368,7 @@ class TestModelSerializerMetadata(TestCase):
             ],
             'parses': [
                 'application/json',
+                'application/json-patch+json',
                 'application/x-www-form-urlencoded',
                 'multipart/form-data'
             ],


### PR DESCRIPTION
Hello, I made a bit of work around to implement the rfc 6902 (`application/json-patch+json`).

I have not implemented any tests. I just produced curl tests while producing the code :

```bash
h_token=`cat cookies | sed -En 's/.*csrftoken\s+(\S*)$/X-CSRFToken: \1/p'`

curl -s -b cookies -c cookies -d "@patch.json" -X PATCH http://localhost:8000/api/whatever -H "$h_token" -H "Content-Type: application/json-patch+json"
```
And I tested few data (odd items are `patch.json`, even ones are the return result ; "works" means the returned object) :
```json
[
    [{"op": "add", "path": "/taags", "value": ["temporary_work_agency"]}],
    {
        "details": "JSON Patch (rfc 6902) path does not exist - taags"
    }

    [{"op": "add", "path": "/tags", "value": ["temporary_work_agency"]}],
    "works",

    [{"op": "test", "path": "/tags", "value": ["temporary_work_agency"]}],
    "works",

    [{"op": "test", "path": "/tags", "value": []}],
    {
        "details": "JSON Patch (rfc 6902) test failed - ['temporary_work_agency'] (<class 'list'>) is not equal to tested value [] (<class 'list'>)"
    },

    [{"op": "replace", "path": "/company/name/", "value": "plop"}],
    {
        "details": "JSON Patch (rfc 6902) path's part invalid - '' is not a valid sequence index"
    },

    [{"op": "replace", "path": "/company/name", "value": "plop"}],
    "works",

    [{"op": "replace", "path": "/", "value": "plop"}],
    {
        "details": "JSON Patch (rfc 6902) conflict - can't replace a non-existent object ''"
    },

    [{"op": "replace", "path": "/tags"}],
    {
        "detail": "JSON Patch (rfc 6902) invalid - The operation does not contain a 'value' member"
    },

    [{"path": "/tags", "value": ["temporary_work_agency"]}],
    {
        "detail": "JSON Patch (rfc 6902) invalid - Operation does not contain 'op' member"
    },

    [{"op": "replace", "value": ["temporary_work_agency"]}],
    {
        "detail": "JSON Patch (rfc 6902) invalid - Operation must have a 'path' member"
    },

    [{"op": "replace", "path": "/tags", "value": ["temporary_work_agency"], "plop": "truc"}],
    "works"
]
```

I'm not so good to create clean tests on an existing project, so I might need help at least to start.