### PR TITLE
Default SerializerMethodField's help_text to the docstring of the method

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1878,6 +1878,11 @@ class SerializerMethodField(Field):
         # The method name defaults to `get_{field_name}`.
         if self.method_name is None:
             self.method_name = 'get_{field_name}'.format(field_name=field_name)
+        # If help_text isn't specified, try to get the method's docstring.
+        if self.help_text is None:
+            method = getattr(parent, self.method_name, None)
+            if method is not None:
+                self.help_text = method.__doc__
 
         super().bind(field_name, parent)
 


### PR DESCRIPTION
## Description

Just a nice little default that occurred to me tonight. We're using the automatic OpenAPI generation stuff so the help text on serializer fields ends up visible in that, and I would have copied the same text into both.
