### PR TITLE
Fix api_view decorator with Django 4

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -7,6 +7,7 @@ based views, as well as the `@action` decorator, which is used to annotate
 methods on viewsets that should be included by routers.
 """
 import types
+from functools import update_wrapper
 
 from django.forms.utils import pretty_name
 
@@ -22,18 +23,8 @@ def api_view(http_method_names=None):
 
     def decorator(func):
 
-        WrappedAPIView = type(
-            'WrappedAPIView',
-            (APIView,),
-            {'__doc__': func.__doc__}
-        )
-
-        # Note, the above allows us to set the docstring.
-        # It is the equivalent of:
-        #
-        #     class WrappedAPIView(APIView):
-        #         pass
-        #     WrappedAPIView.__doc__ = func.doc    <--- Not possible to do this
+        class WrappedAPIView(APIView):
+            pass
 
         # api_view applied without (method_names)
         assert not(isinstance(http_method_names, types.FunctionType)), \
@@ -51,9 +42,6 @@ def api_view(http_method_names=None):
 
         for method in http_method_names:
             setattr(WrappedAPIView, method.lower(), handler)
-
-        WrappedAPIView.__name__ = func.__name__
-        WrappedAPIView.__module__ = func.__module__
 
         WrappedAPIView.renderer_classes = getattr(func, 'renderer_classes',
                                                   APIView.renderer_classes)
@@ -73,7 +61,7 @@ def api_view(http_method_names=None):
         WrappedAPIView.schema = getattr(func, 'schema',
                                         APIView.schema)
 
-        return WrappedAPIView.as_view()
+        return update_wrapper(WrappedAPIView.as_view(), func)
 
     return decorator
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -162,6 +162,16 @@ class DecoratorTestCase(TestCase):
 
         assert isinstance(view.cls.schema, CustomSchema)
 
+    def test_wrapper_assignments(self):
+        @api_view(["GET"])
+        def test_view(request):
+            """example docstring"""
+            pass
+
+        assert test_view.__name__ == "test_view"
+        assert test_view.__doc__ == "example docstring"
+        assert test_view.__qualname__ == "DecoratorTestCase.test_wrapper_assignments.<locals>.test_view"
+
 
 class ActionDecoratorTestCase(TestCase):
 


### PR DESCRIPTION
## Description
When using Django 4, we get slightly unexpected behaviour using the `api_view` decorator:
```
@api_view(["POST"])
def some_view(request):
    pass
```
```
# Django 3.2
>>> some_view.__name__
'some_view'
>>> some_view.__qualname__
'WrappedAPIView'
```
```
# Django 4.0
>>> some_view.__name__
'view'
>>> some_view.__qualname__
'View.as_view.<locals>.view'
```
## Further Discussion
This change is caused by a change in the way that Django 4 implements `View.as_view()`. [The change and a full discussion can be viewed here](https://github.com/django/django/pull/14124), but in short: `as_view` used to use `update_wrapper` and now it doesn't.

I was definitely for the change above, and argued against using `update_wrapper` in that case, but for a decorator such as `api_view` it is definitely appropriate, and I would expect things like `__name__` and `__qualname__` to be preserved from the original function. 

When using a class-based view you have written, using `view_class` seems a reasonable approach. But in this case, the fact you have a class-based view is obscured unless you read the source code and so I think `__name__` should be copied over.
