### PR TITLE
Make ReturnDict support dict union operators on Python 3.9 and later

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -1,3 +1,4 @@
+import sys
 from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
 
@@ -27,6 +28,22 @@ class ReturnDict(OrderedDict):
         # Pickling these objects will drop the .serializer backlink,
         # but preserve the raw data.
         return (dict, (dict(self),))
+
+    if sys.version_info >= (3, 9):
+        # These are basically copied from OrderedDict, with `serializer` added.
+        def __or__(self, other):
+            if not isinstance(other, dict):
+                return NotImplemented
+            new = self.__class__(self, serializer=self.serializer)
+            new.update(other)
+            return new
+
+        def __ror__(self, other):
+            if not isinstance(other, dict):
+                return NotImplemented
+            new = self.__class__(other, serializer=self.serializer)
+            new.update(self)
+            return new
 
 
 class ReturnList(list):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -740,3 +740,25 @@ class TestDeclaredFieldInheritance:
             'f4': serializers.CharField,
             'f5': serializers.CharField,
         }
+
+
+class Test8301Regression:
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="dictionary union operator requires Python 3.9 or higher",
+    )
+    def test_ReturnDict_merging(self):
+        # Serializer.data returns ReturnDict, this is essentially a test for that.
+
+        class TestSerializer(serializers.Serializer):
+            char = serializers.CharField()
+
+        s = TestSerializer(data={'char': 'x'})
+        assert s.is_valid()
+        assert s.data | {} == {'char': 'x'}
+        assert s.data | {'other': 'y'} == {'char': 'x', 'other': 'y'}
+        assert {} | s.data == {'char': 'x'}
+        assert {'other': 'y'} | s.data == {'char': 'x', 'other': 'y'}
+
+        assert (s.data | {}).__class__ == s.data.__class__
+        assert ({} | s.data).__class__ == s.data.__class__


### PR DESCRIPTION
Fixes issue #8301

# Notes


For tests, as there were no other direct tests of `ReturnDict`, I thought it best to consider this as an implementation detail of `Serializer`, and just added it to the serializer tests.

As the union operator was added in PEP 584 for Python 3.9, I think it makes most sense to only add this support for Python 3.9 upwards.

One decision made here is that the union operator, both for left hand and right hand versions, produces a `ReturnDict`, instead of just an `OrderedDict` or a `dict`. My rationale is as follows:

If you do:

```python
d = serializer_instance.data
d |= other_data
```

then `d` ends up as an instance of `ReturnDict`. If you refactored this to:

```python
d = serializer_instance.data | other_data
```

you would probably expect it to stay the same type. Also, usually the additional behaviour of `ReturnDict` (access to serializer instance) is not going to get in the way if you don't need it, but it will be an issue if you did need it and it wasn't there.

A counter argument would be that the dictionary `|` operator could be considered an upgrade for this idiom:

```python
d = {**serializer_instance.data, **other_data}
```

The above code produces a `dict`, not `ReturnDict`. I find this argument less convincing.


