### PR TITLE
Correct variable name in docs/api-guide/format-suffixes.md

### DIFF
--- a/docs/api-guide/format-suffixes.md
+++ b/docs/api-guide/format-suffixes.md
@@ -62,7 +62,7 @@ Also note that `format_suffix_patterns` does not support descending into `includ
 
 If using the `i18n_patterns` function provided by Django, as well as `format_suffix_patterns` you should make sure that the `i18n_patterns` function is applied as the final, or outermost function. For example:
 
-    url patterns = [
+    urlpatterns = [
         …
     ]
 


### PR DESCRIPTION
urlpatterns name variable name in space remove.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
