### PR TITLE
Use PrimaryKeyRelatedField pkfield in openapi

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -385,6 +385,8 @@ class AutoSchema(ViewInspector):
                 'items': self.map_field(field.child_relation)
             }
         if isinstance(field, serializers.PrimaryKeyRelatedField):
+            if getattr(field, "pk_field", False):
+                return self.map_field(field=field.pk_field)
             model = getattr(field.queryset, 'model', None)
             if model is not None:
                 model_field = model._meta.pk

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -18,6 +18,7 @@ from rest_framework.renderers import (
 from rest_framework.request import Request
 from rest_framework.schemas.openapi import AutoSchema, SchemaGenerator
 
+from ..models import BasicModel
 from . import views
 
 
@@ -128,6 +129,22 @@ class TestFieldMapping(TestCase):
         assert data['properties']['rw_field']['nullable'], "rw_field nullable must be true"
         assert data['properties']['ro_field']['nullable'], "ro_field nullable must be true"
         assert data['properties']['ro_field']['readOnly'], "ro_field read_only must be true"
+
+    def test_primary_key_related_field(self):
+        class PrimaryKeyRelatedFieldSerializer(serializers.Serializer):
+            basic = serializers.PrimaryKeyRelatedField(queryset=BasicModel.objects.all())
+            uuid = serializers.PrimaryKeyRelatedField(queryset=BasicModel.objects.all(),
+                                                      pk_field=serializers.UUIDField())
+            char = serializers.PrimaryKeyRelatedField(queryset=BasicModel.objects.all(),
+                                                      pk_field=serializers.CharField())
+
+        serializer = PrimaryKeyRelatedFieldSerializer()
+        inspector = AutoSchema()
+
+        data = inspector.map_serializer(serializer=serializer)
+        assert data['properties']['basic']['type'] == "integer"
+        assert data['properties']['uuid']['format'] == "uuid"
+        assert data['properties']['char']['type'] == "string"
 
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description
As per the unit test, changed to use `pk_field` argument when creating schema of `PrimaryKeyRelatedField`.

This fix isn't the perfect solution, but I couldn't come up with another best idea.

I'm sorry that my English isn't very good.

Ex,
```
class SampleSerializer(Serializer):
    user_id = serializers.PrimaryKeyRelatedField(queryset=User.objects.all())
    user_id_with_pk_field = serializers.PrimaryKeyRelatedField(queryset=User.objects.all(), pk_field=serializers.UUIDField())

# in docs
Sample:
  type: object
  properties:
    user_id:
      type: integer (or string)
    user_id_with_pk_field:
      type: string
      format: uuid
```