### PR TITLE
Added target="_blank" with github repo link

### DIFF
--- a/docs_theme/nav.html
+++ b/docs_theme/nav.html
@@ -1,7 +1,7 @@
     <div class="navbar navbar-inverse navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container-fluid">
-          <a class="repo-link btn btn-primary btn-small" href="https://github.com/encode/django-rest-framework/tree/master">GitHub</a>
+          <a class="repo-link btn btn-primary btn-small" href="https://github.com/encode/django-rest-framework/tree/master" target="_blank">GitHub</a>
           <a class="repo-link btn btn-inverse btn-small {% if not page.next_page %}disabled{% endif %}" rel="next" {% if page.next_page %}href="{{ page.next_page.url|url }}"{% endif %}>
             Next <i class="icon-arrow-right icon-white"></i>
           </a>


### PR DESCRIPTION
Opening github repo in a new tab


This is kind of odd if someone click on github repo link it opens up github repo right in the same tab instead of opening in a new tab. Opening repo in a new tab might be handy. 
