### PR TITLE
Change `MIDDLEWARE_CLASSES` to `MIDDLEWARE`

### DIFF
--- a/docs/topics/internationalization.md
+++ b/docs/topics/internationalization.md
@@ -17,9 +17,9 @@ You can change the default language by using the standard Django `LANGUAGE_CODE`
 
     LANGUAGE_CODE = "es-es"
 
-You can turn on per-request language requests by adding `LocalMiddleware` to your `MIDDLEWARE_CLASSES` setting:
+You can turn on per-request language requests by adding `LocalMiddleware` to your `MIDDLEWARE` setting:
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         ...
         'django.middleware.locale.LocaleMiddleware'
     ]
@@ -90,7 +90,7 @@ If you're only translating custom error messages that exist inside your project 
 
 ## How the language is determined
 
-If you want to allow per-request language preferences you'll need to include `django.middleware.locale.LocaleMiddleware` in your `MIDDLEWARE_CLASSES` setting.
+If you want to allow per-request language preferences you'll need to include `django.middleware.locale.LocaleMiddleware` in your `MIDDLEWARE` setting.
 
 You can find more information on how the language preference is determined in the [Django documentation][django-language-preference]. For reference, the method is:
 


### PR DESCRIPTION
The `MIDDLEWARE_CLASSES` setting got changed to `MIDDLEWARE` in [Django 1.10](https://docs.djangoproject.com/en/1.10/topics/http/middleware/).