### PR TITLE
Allow custom serializer class for request and response

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -33,6 +33,8 @@ class GenericAPIView(views.APIView):
     # for all subsequent requests.
     queryset = None
     serializer_class = None
+    request_serializer_class = None
+    response_serializer_class = None
 
     # If you want to use object lookups other than pk, set 'lookup_field'.
     # For more complex lookup requirements override `get_object()`.
@@ -109,6 +111,23 @@ class GenericAPIView(views.APIView):
         kwargs.setdefault('context', self.get_serializer_context())
         return serializer_class(*args, **kwargs)
 
+    def get_request_serializer(self, *args, **kwargs):
+        """
+        Return the serializer instance that should be used for validating and
+        deserializing input.
+        """
+        serializer_class = self.get_request_serializer_class()
+        kwargs.setdefault('context', self.get_serializer_context())
+        return serializer_class(*args, **kwargs)
+
+    def get_response_serializer(self, *args, **kwargs):
+        """
+        Return the serializer instance that should be used for serializing output.
+        """
+        serializer_class = self.get_response_serializer_class()
+        kwargs.setdefault('context', self.get_serializer_context())
+        return serializer_class(*args, **kwargs)
+
     def get_serializer_class(self):
         """
         Return the class to use for the serializer.
@@ -126,6 +145,18 @@ class GenericAPIView(views.APIView):
         )
 
         return self.serializer_class
+
+    def get_request_serializer_class(self):
+        """
+        Return the class to use as input serializer.
+        """
+        return self.request_serializer_class or self.get_serializer_class()
+
+    def get_response_serializer_class(self):
+        """
+        Returns the class to use as output serializer.
+        """
+        return self.response_serializer_class or self.get_serializer_class()
 
     def get_serializer_context(self):
         """

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -627,14 +627,40 @@ class AutoSchema(ViewInspector):
         Override this method if your view uses a different serializer for
         handling request body.
         """
-        return self.get_serializer(path, method)
+        view = self.view
+
+        if not hasattr(view, "get_request_serializer"):
+            return self.get_serializer(path, method)
+
+        try:
+            return view.get_request_serializer()
+        except exceptions.APIException:
+            warnings.warn(
+                "{}.get_request_serializer() raised an exception during "
+                "schema generation. Serializer fields will not be "
+                "generated for {} {}.".format(view.__class__.__name__, method, path)
+            )
+            return None
 
     def get_response_serializer(self, path, method):
         """
         Override this method if your view uses a different serializer for
         populating response data.
         """
-        return self.get_serializer(path, method)
+        view = self.view
+
+        if not hasattr(view, "get_response_serializer"):
+            return self.get_serializer(path, method)
+
+        try:
+            return view.get_response_serializer()
+        except exceptions.APIException:
+            warnings.warn(
+                "{}.get_response_serializer() raised an exception during "
+                "schema generation. Serializer fields will not be "
+                "generated for {} {}.".format(view.__class__.__name__, method, path)
+            )
+            return None
 
     def _get_reference(self, serializer):
         return {'$ref': '#/components/schemas/{}'.format(self.get_component_name(serializer))}

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -692,3 +692,45 @@ class TestSerializer(TestCase):
         serializer = response.serializer
 
         assert serializer.context is context
+
+    def test_get_request_serializer_class(self):
+        class View(generics.GenericAPIView):
+            request_serializer_class = BasicSerializer
+
+        view = View()
+        assert view.get_request_serializer_class() == BasicSerializer
+
+    def test_get_response_serializer_class(self):
+        class TestResponseSerializerView(generics.GenericAPIView):
+            response_serializer_class = BasicSerializer
+
+        view = TestResponseSerializerView()
+        assert view.get_response_serializer_class() == BasicSerializer
+
+    def test_get_request_serializer(self):
+        class View(generics.ListAPIView):
+            request_serializer_class = BasicSerializer
+
+            def list(self, request):
+                response = Response()
+                response.serializer = self.get_request_serializer()
+                return response
+
+        view = View.as_view()
+        request = factory.get('/')
+        response = view(request)
+        assert isinstance(response.serializer, BasicSerializer)
+
+    def test_get_response_serializer(self):
+        class View(generics.ListAPIView):
+            response_serializer_class = BasicSerializer
+
+            def list(self, request):
+                response = Response()
+                response.serializer = self.get_response_serializer()
+                return response
+
+        view = View.as_view()
+        request = factory.get('/')
+        response = view(request)
+        assert isinstance(response.serializer, BasicSerializer)


### PR DESCRIPTION
Following this [commit](https://github.com/encode/django-rest-framework/commit/8812394ed83d7cce0ed5b2c5fcf093269d364b9b), this PR add the possibility to specify classes that will be used when generating the input/output specs in the OpenAPI documentation.