### PR TITLE
Update 6-viewsets-and-routers.md

### DIFF
--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -112,8 +112,8 @@ Here's our re-wired `snippets/urls.py` file.
 
     # Create a router and register our viewsets with it.
     router = DefaultRouter()
-    router.register(r'snippets', views.SnippetViewSet)
-    router.register(r'users', views.UserViewSet)
+    router.register(r'snippets', views.SnippetViewSet,basename="snippets")
+    router.register(r'users', views.UserViewSet,basename="users")
 
     # The API URLs are now determined automatically by the router.
     urlpatterns = [


### PR DESCRIPTION
# Basename key missing in the tutorial
```diff
+router.register(r'snippets', views.SnippetViewSet,basename="snippets")
+router.register(r'users', views.UserViewSet,basename="users")
-router.register(r'snippets', views.SnippetViewSet)
-router.register(r'users', views.UserViewSet)
```

## Description
Modern versions are supposed to show error on setting up routers for viewset without the basename which I found missing on the tutorial page which frustrates many of new learning developers like me.  Hope the contribution will be valued

