### PR TITLE
Update `accepted_media_type` argument in Renderer docs

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -257,7 +257,7 @@ This renderer is used for rendering HTML multipart form data.  **It is not suita
 
 # Custom renderers
 
-To implement a custom renderer, you should override `BaseRenderer`, set the `.media_type` and `.format` properties, and implement the `.render(self, data, media_type=None, renderer_context=None)` method.
+To implement a custom renderer, you should override `BaseRenderer`, set the `.media_type` and `.format` properties, and implement the `.render(self, data, accepted_media_type=None, renderer_context=None)` method.
 
 The method should return a bytestring, which will be used as the body of the HTTP response.
 
@@ -267,11 +267,11 @@ The arguments passed to the `.render()` method are:
 
 The request data, as set by the `Response()` instantiation.
 
-### `media_type=None`
+### `accepted_media_type=None`
 
 Optional.  If provided, this is the accepted media type, as determined by the content negotiation stage.
 
-Depending on the client's `Accept:` header, this may be more specific than the renderer's `media_type` attribute, and may include media type parameters.  For example `"application/json; nested=true"`.
+Depending on the client's `Accept:` header, this may be more specific than the renderer's `accepted_media_type` attribute, and may include media type parameters.  For example `"application/json; nested=true"`.
 
 ### `renderer_context=None`
 
@@ -291,7 +291,7 @@ The following is an example plaintext renderer that will return a response with 
         media_type = 'text/plain'
         format = 'txt'
 
-        def render(self, data, media_type=None, renderer_context=None):
+        def render(self, data, accepted_media_type=None, renderer_context=None):
             return smart_text(data, encoding=self.charset)
 
 ## Setting the character set
@@ -303,7 +303,7 @@ By default renderer classes are assumed to be using the `UTF-8` encoding.  To us
         format = 'txt'
         charset = 'iso-8859-1'
 
-        def render(self, data, media_type=None, renderer_context=None):
+        def render(self, data, accepted_media_type=None, renderer_context=None):
             return data.encode(self.charset)
 
 Note that if a renderer class returns a unicode string, then the response content will be coerced into a bytestring by the `Response` class, with the `charset` attribute set on the renderer used to determine the encoding.
@@ -318,7 +318,7 @@ In some cases you may also want to set the `render_style` attribute to `'binary'
         charset = None
         render_style = 'binary'
 
-        def render(self, data, media_type=None, renderer_context=None):
+        def render(self, data, accepted_media_type=None, renderer_context=None):
             return data
 
 ---

--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -271,7 +271,7 @@ The request data, as set by the `Response()` instantiation.
 
 Optional.  If provided, this is the accepted media type, as determined by the content negotiation stage.
 
-Depending on the client's `Accept:` header, this may be more specific than the renderer's `accepted_media_type` attribute, and may include media type parameters.  For example `"application/json; nested=true"`.
+Depending on the client's `Accept:` header, this may be more specific than the renderer's `media_type` attribute, and may include media type parameters.  For example `"application/json; nested=true"`.
 
 ### `renderer_context=None`
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Fixes a disconnect between the documentation of custom Renderers and the implementation in the DRF source code.

In the documentation, the `render` function is described as taking a `media_type` argument. However, in the majority of Renderers provided by DRF the argument is named `accepted_media_type`.

This PR brings the documentation more in line with how DRF internally implements Renderers.

Note: There are actually inconsistencies in DRF's own code with the argument. Most of them use `accepted_media_type`, however there are a couple that use `media_type`. I have not made any changes to those Renderers to fix this inconsistency. 

If desired, I can add another commit fixing these inconsistencies, ensuring `accepted_media_type`/`media_type` argument uniformity across the documentation and source code.
