### PR TITLE
Separating Paginated response values generator function from Response generator

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -222,12 +222,15 @@ class PageNumberPagination(BasePagination):
         return page_number
 
     def get_paginated_response(self, data):
-        return Response(OrderedDict([
+        return Response(self.get_paginated_response_values(data))
+
+    def get_paginated_response_values(self, data):
+        return OrderedDict([
             ('count', self.page.paginator.count),
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),
             ('results', data)
-        ]))
+        ])
 
     def get_paginated_response_schema(self, schema):
         return {


### PR DESCRIPTION
## Description
I don't know if there is any issues about this, but while reading the code, I figured there could be a little better implementation of get_paginated_response function.
when someone wants to pass extra data in paginated response of their view, using changes I made, they can easily override get_paginated_response_values function and add their key/val items.
right now, they have to override get_paginated_response function and generate the whole Response in their method.
Separating the function which generate the values from the function that generates the response, can save developers to generate the response themselves. they can only change the response values, without worrying about Response class or so.