### PR TITLE
Fix error in throttling when request.user is None

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -171,7 +171,7 @@ class AnonRateThrottle(SimpleRateThrottle):
     scope = 'anon'
 
     def get_cache_key(self, request, view):
-        if request.user.is_authenticated:
+        if request.user and request.user.is_authenticated:
             return None  # Only throttle unauthenticated requests.
 
         return self.cache_format % {
@@ -191,7 +191,7 @@ class UserRateThrottle(SimpleRateThrottle):
     scope = 'user'
 
     def get_cache_key(self, request, view):
-        if request.user.is_authenticated:
+        if request.user and request.user.is_authenticated:
             ident = request.user.pk
         else:
             ident = self.get_ident(request)
@@ -239,7 +239,7 @@ class ScopedRateThrottle(SimpleRateThrottle):
         Otherwise generate the unique cache key by concatenating the user id
         with the '.throttle_scope` property of the view.
         """
-        if request.user.is_authenticated:
+        if request.user and request.user.is_authenticated:
             ident = request.user.pk
         else:
             ident = self.get_ident(request)


### PR DESCRIPTION
While trying to remove the Django authentication module, I've ran into an error when using the configuration below.
Specifically, an `AttributeError` is raised because DRF does not expect the user to be `None`.

```python
# settings.py
REST_FRAMEWORK = {
    ...
    "DEFAULT_THROTTLE_CLASSES": (
        "rest_framework.throttling.AnonRateThrottle",
    ),
    "DEFAULT_THROTTLE_RATES": {"anon": "10000/day"},
    'DEFAULT_AUTHENTICATION_CLASSES': [],
    'DEFAULT_PERMISSION_CLASSES': [],
    'UNAUTHENTICATED_USER': None,
}
```

This PR fixes the issue by checking if `request.user` is set before proceeding with further authentication checks.
The test suite and pre-commit hooks are passing. If needed, I'll be happy to write a test-case for this.

As this is my first contribution to DRF please let me know in case I am missing any contribution guidelines. I'd like for the process to be as seamless as possible.

Thank you for your time and consideration.
