### PR TITLE
Detect underlying field for OneToOne primary key

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1234,6 +1234,10 @@ class ModelSerializer(Serializer):
         if model_field.one_to_one and model_field.primary_key:
             field_class = self.serializer_related_field
             field_kwargs['queryset'] = model_field.related_model.objects
+            pk_field = field_mapping[model_field.foreign_related_fields[0]]
+            pk_field_kwargs = get_field_kwargs(field_name, model_field.foreign_related_fields[0])
+            pk_field_kwargs.pop("model_field")
+            field_kwargs["pk_field"] = pk_field(**pk_field_kwargs)
 
         if 'choices' in field_kwargs:
             # Fields with choices get coerced into `ChoiceField`

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -762,3 +762,21 @@ class Test8301Regression:
 
         assert (s.data | {}).__class__ == s.data.__class__
         assert ({} | s.data).__class__ == s.data.__class__
+
+
+class TestRelatedFieldTypes:
+
+    def test_one_to_one_field(self):
+        class MyModelA(models.Model):
+            id = models.DecimalField(max_digits=4, decimal_places=2, primary_key=True)
+
+        class MyModelB(models.Model):
+            id = models.OneToOneField(MyModelA, models.CASCADE, primary_key=True)
+
+        class MyModelBSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = MyModelB
+                fields = "__all__"
+
+        ser = MyModelBSerializer()
+        assert type(ser.fields["id"].pk_field) == fields.DecimalField


### PR DESCRIPTION
## Description

When using a OneToOneField as a primary key it does not get serialized in the same way as the "parent" model. E.g.

```python
        class MyModelA(models.Model):
            id = models.DecimalField(max_digits=4, decimal_places=2, primary_key=True)

        class MyModelB(models.Model):
            id = models.OneToOneField(MyModelA, models.CASCADE, primary_key=True)

        class MyModelASerializer(serializers.ModelSerializer):
            class Meta:
                model = MyModelA
                fields = "__all__"

        class MyModelBSerializer(serializers.ModelSerializer):
            class Meta:
                model = MyModelB
                fields = "__all__"
```

The following serializations would result
```python
MyModelASerializer().to_representation(MyModelA(id=12.34))
# {"id": "12.24"}
MyModelBSerializer().to_representation(MyModelB(id=MyModelA(id=12.34)))
# {"id": 12.24}
```

This PR sets the `pk_field` attribute of the `PrimaryKeyRelatedField` to ensure serialization is consistent with the "parent" model. This is also in line with the OpenApi schema that would be generated.

