### PR TITLE
Fix code block in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ Install using `pip`...
     pip install djangorestframework
 
 Add `'rest_framework'` to your `INSTALLED_APPS` setting.
-
-    INSTALLED_APPS = [
-        ...
-        'rest_framework',
-    ]
+```python
+INSTALLED_APPS = [
+    ...
+    'rest_framework',
+]
+```
 
 # Example
 


### PR DESCRIPTION
Hi there,

The code block below show imply `Python` as it lives in `settings.py`

```
INSTALLED_APPS = [
    ...
    'rest_framework',
]
```

This pull request essentially fixes that.

Sorry if i didn't discuss it on a discussion thread. As its a very minor issue. I think it can be resolved without any discussion.