### PR TITLE
Update SECURITY policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Reporting a Vulnerability
 
-If you believe you've found something in Django REST framework which has security implications, please **do not raise the issue in a public forum**.
+Security issues are handled under the supervision of the [Django security team](https://www.djangoproject.com/foundation/teams/#security-team).
 
-Send a description of the issue via email to [rest-framework-security@googlegroups.com][security-mail].  The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
+ **Please report security issues by emailing security@djangoproject.com**.
 
-[security-mail]: mailto:rest-framework-security@googlegroups.com
+ The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.


### PR DESCRIPTION
Following on from discussion with the Django team. I believe our shared outlook is that security issues are better handled by the Django security team, than via the existing route. This change will ensure more comprehensive oversight and transparency around resolving security issues.

See also #8411