### PR TITLE
Improvements to openapi schema generation

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1868,8 +1868,9 @@ class SerializerMethodField(Field):
         def get_extra_info(self, obj):
             return ...  # Calculate some data to return.
     """
-    def __init__(self, method_name=None, **kwargs):
+    def __init__(self, method_name=None, output_field=None, **kwargs):
         self.method_name = method_name
+        self.output_field = output_field
         kwargs['source'] = '*'
         kwargs['read_only'] = True
         super().__init__(**kwargs)

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -377,6 +377,9 @@ class AutoSchema(ViewInspector):
             data['type'] = 'object'
             return data
 
+        if isinstance(field, serializers.SerializerMethodField) and field.output_field:
+            return self.map_field(field.output_field)
+
         # Related fields.
         if isinstance(field, serializers.ManyRelatedField):
             return {

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -128,6 +128,7 @@ class AutoSchema(ViewInspector):
         self._tags = tags
         self.operation_id_base = operation_id_base
         self.component_name = component_name
+        self.components = {}
         super().__init__()
 
     request_media_types = []
@@ -195,19 +196,17 @@ class AutoSchema(ViewInspector):
         request_serializer = self.get_request_serializer(path, method)
         response_serializer = self.get_response_serializer(path, method)
 
-        components = {}
-
         if isinstance(request_serializer, serializers.Serializer):
             component_name = self.get_component_name(request_serializer)
             content = self.map_serializer(request_serializer)
-            components.setdefault(component_name, content)
+            self.components.setdefault(component_name, content)
 
         if isinstance(response_serializer, serializers.Serializer):
             component_name = self.get_component_name(response_serializer)
             content = self.map_serializer(response_serializer)
-            components.setdefault(component_name, content)
+            self.components.setdefault(component_name, content)
 
-        return components
+        return self.components
 
     def _to_camel_case(self, snake_str):
         components = snake_str.split('_')
@@ -547,7 +546,9 @@ class AutoSchema(ViewInspector):
         if required:
             result['required'] = required
 
-        return result
+        component_name = self.get_component_name(serializer=serializer)
+        self.components[component_name] = result
+        return self._get_reference(serializer)
 
     def map_field_validators(self, field, schema):
         """

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -192,6 +192,9 @@ class AutoSchema(ViewInspector):
 
         return component_name
 
+    def get_paginated_component_name(self, serializer):
+        return 'Paginated' + self.get_component_name(serializer, 'GET')
+
     def get_error_component_name(self, serializer):
         return self.get_component_name(serializer, 'GET') + 'Error'
 
@@ -716,6 +719,9 @@ class AutoSchema(ViewInspector):
     def _get_reference(self, serializer, method):
         return {'$ref': '#/components/schemas/{}'.format(self.get_component_name(serializer, method))}
 
+    def _get_paginated_reference(self, serializer):
+        return {'$ref': '#/components/schemas/{}'.format(self.get_paginated_component_name(serializer))}
+
     def _get_error_reference(self, serializer):
         return {'$ref': '#/components/schemas/{}'.format(self.get_error_component_name(serializer))}
 
@@ -763,7 +769,9 @@ class AutoSchema(ViewInspector):
             }
             paginator = self.get_paginator()
             if paginator:
-                response_schema = paginator.get_paginated_response_schema(response_schema)
+                pagination_schema = paginator.get_paginated_response_schema(response_schema)
+                self.components[self.get_paginated_component_name(serializer)] = pagination_schema
+                response_schema = self._get_paginated_reference(serializer)
         else:
             response_schema = item_schema
         status_code = '201' if method == 'POST' else '200'

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -192,6 +192,9 @@ class AutoSchema(ViewInspector):
 
         return component_name
 
+    def get_error_component_name(self, serializer):
+        return self.get_component_name(serializer, 'GET') + 'Error'
+
     def get_components(self, path, method):
         """
         Return components with their properties from the serializer.
@@ -207,6 +210,11 @@ class AutoSchema(ViewInspector):
             component_name = self.get_component_name(request_serializer, method)
             content = self.map_serializer(request_serializer, method)
             self.components.setdefault(component_name, content)
+
+            if method.lower() in ('put', 'post', 'patch'):
+                error_component_name = self.get_error_component_name(request_serializer)
+                error_content = self.map_error_serializer(request_serializer)
+                self.components.setdefault(error_component_name, error_content)
 
         if isinstance(response_serializer, serializers.Serializer):
             component_name = self.get_component_name(response_serializer, 'GET')
@@ -516,6 +524,23 @@ class AutoSchema(ViewInspector):
         }
         return {'type': FIELD_CLASS_SCHEMA_TYPE.get(field.__class__, 'string')}
 
+    def map_error_field(self, field):
+        if isinstance(field, serializers.ListSerializer):
+            return {
+                'type': 'array',
+                'items': self.map_error_serializer(field.child)
+            }
+        if isinstance(field, serializers.Serializer):
+            return self.map_error_serializer(field)
+        if isinstance(field, serializers.SerializerMethodField) and isinstance(field.output_field, serializers.Serializer):
+            return self.map_error_serializer(field.output_field)
+        return {
+            'type': 'array',
+            'items': {
+                'type': 'string'
+            },
+        }
+
     def _map_min_max(self, field, content):
         if field.max_value:
             content['maximum'] = field.max_value
@@ -573,6 +598,33 @@ class AutoSchema(ViewInspector):
         component_name = self.get_component_name(serializer=serializer, method=method)
         self.components[component_name] = result
         return self._get_reference(serializer, method)
+
+    def map_error_serializer(self, serializer):
+        properties = {
+            api_settings.NON_FIELD_ERRORS_KEY: {
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                }
+            }
+        }
+
+        for field in serializer.fields.values():
+            if isinstance(field, serializers.HiddenField):
+                continue
+            if field.read_only:
+                continue
+
+            properties[field.field_name] = self.map_error_field(field)
+
+        result = {
+            'type': 'object',
+            'properties': properties
+        }
+
+        component_name = self.get_error_component_name(serializer=serializer)
+        self.components[component_name] = result
+        return self._get_error_reference(serializer)
 
     def map_field_validators(self, field, schema):
         """
@@ -664,6 +716,9 @@ class AutoSchema(ViewInspector):
     def _get_reference(self, serializer, method):
         return {'$ref': '#/components/schemas/{}'.format(self.get_component_name(serializer, method))}
 
+    def _get_error_reference(self, serializer):
+        return {'$ref': '#/components/schemas/{}'.format(self.get_error_component_name(serializer))}
+
     def get_request_body(self, path, method):
         if method not in ('PUT', 'PATCH', 'POST'):
             return {}
@@ -712,7 +767,7 @@ class AutoSchema(ViewInspector):
         else:
             response_schema = item_schema
         status_code = '201' if method == 'POST' else '200'
-        return {
+        responses = {
             status_code: {
                 'content': {
                     ct: {'schema': response_schema}
@@ -724,6 +779,20 @@ class AutoSchema(ViewInspector):
                 'description': ""
             }
         }
+
+        if method in ('POST', 'PUT', 'PATCH'):
+            error_schema = self._get_error_reference(self.get_request_serializer(path, method))
+            responses['400'] = {
+                'content': {
+                    ct: {'schema': error_schema}
+                    for ct in self.response_media_types
+                },
+                # description is a mandatory property,
+                # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject
+                # TODO: put something meaningful into it
+                'description': ""
+            }
+        return responses
 
     def get_tags(self, path, method):
         # If user have specified tags, use them.

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -132,6 +132,20 @@ class TestFieldMapping(TestCase):
         assert data['properties']['ro_field']['nullable'], "ro_field nullable must be true"
         assert data['properties']['ro_field']['readOnly'], "ro_field read_only must be true"
 
+    def test_serializer_method_field(self):
+        class MethodSerializer(serializers.Serializer):
+
+            method_field = serializers.SerializerMethodField(output_field=serializers.BooleanField())
+
+            def get_method_field(self, obj):
+                return True
+
+        inspector = AutoSchema()
+
+        inspector.map_serializer(MethodSerializer())
+        data = inspector.components['Method']
+        assert data['properties']['method_field']['type'] == 'boolean'
+
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')
 class TestOperationIntrospection(TestCase):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -795,6 +795,23 @@ class TestOperationIntrospection(TestCase):
                 },
                 'required': ['text'],
                 'type': 'object'
+            },
+            'RequestError': {
+                'properties': {
+                    'non_field_errors': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string'
+                        }
+                    },
+                    'text': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string'
+                        }
+                    }
+                },
+                'type': 'object'
             }
         }
 
@@ -828,6 +845,16 @@ class TestOperationIntrospection(TestCase):
                         'application/json': {
                             'schema': {
                                 '$ref': '#/components/schemas/Response'
+                            }
+                        }
+                    },
+                    'description': ''
+                },
+                '400': {
+                    'content': {
+                        'application/json': {
+                            'schema': {
+                                '$ref': '#/components/schemas/RequestError'
                             }
                         }
                     },

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -474,13 +474,7 @@ class TestOperationIntrospection(TestCase):
                 'content': {
                     'application/json': {
                         'schema': {
-                            'type': 'object',
-                            'item': {
-                                'type': 'array',
-                                'items': {
-                                    '$ref': '#/components/schemas/Item'
-                                },
-                            },
+                            '$ref': '#/components/schemas/PaginatedItem',
                         },
                     },
                 },
@@ -488,6 +482,15 @@ class TestOperationIntrospection(TestCase):
         }
         components = inspector.get_components(path, method)
         assert components == {
+            'PaginatedItem': {
+                'type': 'object',
+                'item': {
+                    'type': 'array',
+                    'items': {
+                        '$ref': '#/components/schemas/Item'
+                    },
+                },
+            },
             'Item': {
                 'type': 'object',
                 'properties': {


### PR DESCRIPTION
This PR addresses a number of issues I've encountered when using the openapi schema generated by DRF to generate API clients in typescript, though they apply equally to any typed client generated from the schemas.

I don't consider this PR to be the way this should be achieved, as it breaks a number of APIs; it does however hopefully communicate the intent and intended effect of the changes.

The ~four~ five issues are, in order of commits:

1. More agressive usage of references, avoiding inlines
    This ensures that any serializer field is turned into a reference to the relevant schema, no matter how deeply nested. This both fixes the associated issue with list serialisers, as well as reducing duplication.
2. Add output field to serializer method field
    I have encountered this a number of times, whether something as trivial as a boolean field, or a method field which returns structured data. Being able to express the 'output_field' ensures correct typing of the relationship.
3. Separate shcemas per method (addresses #8103)
   This was particularly annoying with `PATCH` requests, but became even more apparnent when strict null checks were enabled on typescript. While the existing generated schemas are flexible, it's a case of 'one-size-fits-nobody'. This change emits a different serialiser for `PUT`, `POST` and `PATCH` requests, ensuring that for example read only fields don't appear in the definition of write operations, and vice versa.
4. Error response schemas
    Largely for convenience in parsing error responses in clients, this emits an error response based on the structure of the request.
5. Pagination responses - addresses #7299
    Bonus that I remembered - output a separate named object for paginated schemas to remove 'inline' responses. Not necessary for list-like responses as client generators are able to handle trivial list-only items.
    
I have already succesfully used these four changes locally based on the existing released code; however, the code necessary to acheive them is quite ugly as the base `AutoSchema` lacks the necessary extension points to achieve it: a. the method being 'dropped' quite early in the processing, and b. no easy way to hoover up components

I've not added any extensive tests, although I have updated any existing tests to reflect the new behaviour. Obviously a lot more testing and docs will be needed, but I wanted to get general approval and input on the direction to take the implementation before moving forward.


   