### PR TITLE
Improvements to openapi schema generation

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1868,8 +1868,9 @@ class SerializerMethodField(Field):
         def get_extra_info(self, obj):
             return ...  # Calculate some data to return.
     """
-    def __init__(self, method_name=None, **kwargs):
+    def __init__(self, method_name=None, output_field=None, **kwargs):
         self.method_name = method_name
+        self.output_field = output_field
         kwargs['source'] = '*'
         kwargs['read_only'] = True
         super().__init__(**kwargs)

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -185,6 +185,9 @@ class AutoSchema(ViewInspector):
 
         return component_name
 
+    def get_paginated_component_name(self, serializer):
+        return 'Paginated' + self.get_component_name(serializer)
+
     def get_error_component_name(self, serializer):
         return self.get_component_name(serializer) + 'Error'
 
@@ -695,6 +698,9 @@ class AutoSchema(ViewInspector):
     def _get_reference(self, serializer):
         return {'$ref': '#/components/schemas/{}'.format(self.get_component_name(serializer))}
 
+    def _get_paginated_reference(self, serializer):
+        return {'$ref': '#/components/schemas/{}'.format(self.get_paginated_component_name(serializer))}
+
     def _get_error_reference(self, serializer):
         return {'$ref': '#/components/schemas/{}'.format(self.get_error_component_name(serializer))}
 
@@ -742,7 +748,9 @@ class AutoSchema(ViewInspector):
             }
             paginator = self.get_paginator()
             if paginator:
-                response_schema = paginator.get_paginated_response_schema(response_schema)
+                pagination_schema = paginator.get_paginated_response_schema(response_schema)
+                self.components[self.get_paginated_component_name(serializer)] = pagination_schema
+                response_schema = self._get_paginated_reference(serializer)
         else:
             response_schema = item_schema
         status_code = '201' if method == 'POST' else '200'

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -377,6 +377,9 @@ class AutoSchema(ViewInspector):
             data['type'] = 'object'
             return data
 
+        if isinstance(field, serializers.SerializerMethodField) and field.output_field:
+            return self.map_field(field.output_field)
+
         # Related fields.
         if isinstance(field, serializers.ManyRelatedField):
             return {

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -128,6 +128,7 @@ class AutoSchema(ViewInspector):
         self._tags = tags
         self.operation_id_base = operation_id_base
         self.component_name = component_name
+        self.components = {}
         super().__init__()
 
     request_media_types = []
@@ -195,19 +196,17 @@ class AutoSchema(ViewInspector):
         request_serializer = self.get_request_serializer(path, method)
         response_serializer = self.get_response_serializer(path, method)
 
-        components = {}
-
         if isinstance(request_serializer, serializers.Serializer):
             component_name = self.get_component_name(request_serializer)
             content = self.map_serializer(request_serializer)
-            components.setdefault(component_name, content)
+            self.components.setdefault(component_name, content)
 
         if isinstance(response_serializer, serializers.Serializer):
             component_name = self.get_component_name(response_serializer)
             content = self.map_serializer(response_serializer)
-            components.setdefault(component_name, content)
+            self.components.setdefault(component_name, content)
 
-        return components
+        return self.components
 
     def _to_camel_case(self, snake_str):
         components = snake_str.split('_')
@@ -547,7 +546,9 @@ class AutoSchema(ViewInspector):
         if required:
             result['required'] = required
 
-        return result
+        component_name = self.get_component_name(serializer=serializer)
+        self.components[component_name] = result
+        return self._get_reference(serializer)
 
     def map_field_validators(self, field, schema):
         """

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -132,6 +132,20 @@ class TestFieldMapping(TestCase):
         assert data['properties']['ro_field']['nullable'], "ro_field nullable must be true"
         assert data['properties']['ro_field']['readOnly'], "ro_field read_only must be true"
 
+    def test_serializer_method_field(self):
+        class MethodSerializer(serializers.Serializer):
+
+            method_field = serializers.SerializerMethodField(output_field=serializers.BooleanField())
+
+            def get_method_field(self, obj):
+                return True
+
+        inspector = AutoSchema()
+
+        inspector.map_serializer(MethodSerializer())
+        data = inspector.components['Method']
+        assert data['properties']['method_field']['type'] == 'boolean'
+
 
 @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')
 class TestOperationIntrospection(TestCase):

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -472,13 +472,7 @@ class TestOperationIntrospection(TestCase):
                 'content': {
                     'application/json': {
                         'schema': {
-                            'type': 'object',
-                            'item': {
-                                'type': 'array',
-                                'items': {
-                                    '$ref': '#/components/schemas/Item'
-                                },
-                            },
+                            '$ref': '#/components/schemas/PaginatedItem',
                         },
                     },
                 },
@@ -486,6 +480,15 @@ class TestOperationIntrospection(TestCase):
         }
         components = inspector.get_components(path, method)
         assert components == {
+            'PaginatedItem': {
+                'type': 'object',
+                'item': {
+                    'type': 'array',
+                    'items': {
+                        '$ref': '#/components/schemas/Item'
+                    },
+                },
+            },
             'Item': {
                 'type': 'object',
                 'properties': {

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -793,6 +793,23 @@ class TestOperationIntrospection(TestCase):
                 },
                 'required': ['text'],
                 'type': 'object'
+            },
+            'RequestError': {
+                'properties': {
+                    'non_field_errors': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string'
+                        }
+                    },
+                    'text': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string'
+                        }
+                    }
+                },
+                'type': 'object'
             }
         }
 
@@ -826,6 +843,16 @@ class TestOperationIntrospection(TestCase):
                         'application/json': {
                             'schema': {
                                 '$ref': '#/components/schemas/Response'
+                            }
+                        }
+                    },
+                    'description': ''
+                },
+                '400': {
+                    'content': {
+                        'application/json': {
+                            'schema': {
+                                '$ref': '#/components/schemas/RequestError'
                             }
                         }
                     },


### PR DESCRIPTION
This PR addresses a number of issues I've encountered when using the openapi schema generated by DRF to generate API clients in typescript, though they apply equally to any typed client generated from the schemas.

The four issues are, in order of commits:

1. More agressive usage of references, avoiding inlines
    This ensures that any serializer field is turned into a reference to the relevant schema, no matter how deeply nested.
2. Add output field to serializer method field
    I have encountered this a number of times, whether something as trivial as a boolean field, or a method field which returns structured data. Being able to express the 'output_field' ensures correct typing of the relationship.
3. Error response schemas
    Largely for convenience in parsing error responses in clients, this emits an error response based on the structure of the request.
4. Pagination responses - addresses #7299
    Bonus that I remembered - output a separate named object for paginated schemas to remove 'inline' responses. Not necessary for list-like responses as client generators are able to handle trivial list-only items.
    
I have already succesfully used these four changes locally based on the existing released code; however, the code necessary to acheive them is quite ugly as the base `AutoSchema` lacks the necessary extension points to achieve it due to there being no easy way to hoover up components.

I've not added any extensive tests, although I have updated any existing tests to reflect the new behaviour. Obviously a lot more testing and docs will be needed, but I wanted to get general approval and input on the direction to take the implementation before moving forward.

This replaces https://github.com/encode/django-rest-framework/pull/8417 which contained more substantial changes
   