### PR TITLE
Added test client support for HTTP 307 and 308 redirects

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -288,7 +288,7 @@ class APIClient(APIRequestFactory, DjangoClient):
     def get(self, path, data=None, follow=False, **extra):
         response = super().get(path, data=data, **extra)
         if follow:
-            response = self._handle_redirects(response, **extra)
+            response = self._handle_redirects(response, data=data, **extra)
         return response
 
     def post(self, path, data=None, format=None, content_type=None,
@@ -296,7 +296,7 @@ class APIClient(APIRequestFactory, DjangoClient):
         response = super().post(
             path, data=data, format=format, content_type=content_type, **extra)
         if follow:
-            response = self._handle_redirects(response, **extra)
+            response = self._handle_redirects(response, data=data, format=format, content_type=content_type, **extra)
         return response
 
     def put(self, path, data=None, format=None, content_type=None,
@@ -304,7 +304,7 @@ class APIClient(APIRequestFactory, DjangoClient):
         response = super().put(
             path, data=data, format=format, content_type=content_type, **extra)
         if follow:
-            response = self._handle_redirects(response, **extra)
+            response = self._handle_redirects(response, data=data, format=format, content_type=content_type, **extra)
         return response
 
     def patch(self, path, data=None, format=None, content_type=None,
@@ -312,7 +312,7 @@ class APIClient(APIRequestFactory, DjangoClient):
         response = super().patch(
             path, data=data, format=format, content_type=content_type, **extra)
         if follow:
-            response = self._handle_redirects(response, **extra)
+            response = self._handle_redirects(response, data=data, format=format, content_type=content_type, **extra)
         return response
 
     def delete(self, path, data=None, format=None, content_type=None,
@@ -320,7 +320,7 @@ class APIClient(APIRequestFactory, DjangoClient):
         response = super().delete(
             path, data=data, format=format, content_type=content_type, **extra)
         if follow:
-            response = self._handle_redirects(response, **extra)
+            response = self._handle_redirects(response, data=data, format=format, content_type=content_type, **extra)
         return response
 
     def options(self, path, data=None, format=None, content_type=None,
@@ -328,7 +328,7 @@ class APIClient(APIRequestFactory, DjangoClient):
         response = super().options(
             path, data=data, format=format, content_type=content_type, **extra)
         if follow:
-            response = self._handle_redirects(response, **extra)
+            response = self._handle_redirects(response, data=data, format=format, content_type=content_type, **extra)
         return response
 
     def logout(self):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -146,41 +146,14 @@ class TestAPITestClient(TestCase):
         """
         Follow redirect by setting follow argument.
         """
-        response = self.client.get('/redirect-view/')
-        assert response.status_code == 302
-        response = self.client.get('/redirect-view/', follow=True)
-        assert response.redirect_chain is not None
-        assert response.status_code == 200
-
-        response = self.client.post('/redirect-view/')
-        assert response.status_code == 302
-        response = self.client.post('/redirect-view/', follow=True)
-        assert response.redirect_chain is not None
-        assert response.status_code == 200
-
-        response = self.client.put('/redirect-view/')
-        assert response.status_code == 302
-        response = self.client.put('/redirect-view/', follow=True)
-        assert response.redirect_chain is not None
-        assert response.status_code == 200
-
-        response = self.client.patch('/redirect-view/')
-        assert response.status_code == 302
-        response = self.client.patch('/redirect-view/', follow=True)
-        assert response.redirect_chain is not None
-        assert response.status_code == 200
-
-        response = self.client.delete('/redirect-view/')
-        assert response.status_code == 302
-        response = self.client.delete('/redirect-view/', follow=True)
-        assert response.redirect_chain is not None
-        assert response.status_code == 200
-
-        response = self.client.options('/redirect-view/')
-        assert response.status_code == 302
-        response = self.client.options('/redirect-view/', follow=True)
-        assert response.redirect_chain is not None
-        assert response.status_code == 200
+        for method in ('get', 'post', 'put', 'patch', 'delete', 'options'):
+            with self.subTest(method=method):
+                req_method = getattr(self.client, method)
+                response = req_method('/redirect-view/')
+                assert response.status_code == 302
+                response = req_method('/redirect-view/', follow=True)
+                assert response.redirect_chain is not None
+                assert response.status_code == 200
 
     def test_invalid_multipart_data(self):
         """


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Integrate with changes from https://github.com/django/django/commit/272f685794de0b8dead220ee57b30e65c9aa097c.

Closes #8406.
