### PR TITLE
docs: fix router basename

### DIFF
--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -112,8 +112,8 @@ Here's our re-wired `snippets/urls.py` file.
 
     # Create a router and register our viewsets with it.
     router = DefaultRouter()
-    router.register(r'snippets', views.SnippetViewSet,basename="snippets")
-    router.register(r'users', views.UserViewSet,basename="users")
+    router.register(r'snippets', views.SnippetViewSet,basename="snippet")
+    router.register(r'users', views.UserViewSet,basename="user")
 
     # The API URLs are now determined automatically by the router.
     urlpatterns = [


### PR DESCRIPTION
Serializer are referencing view names `snippet-highlight` and `snippet-detail`, but router registers views with basename `snippets` which breaks the views. Same is for user views.

## Description

Error message whe following the tutorial:

```
Could not resolve URL for hyperlinked relationship using view name "user-detail". You may have failed to include the related model in your API, or incorrectly configured the `lookup_field` attribute on this field.
```