### PR TITLE
Support SkipField in to_representation

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -519,7 +519,10 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
             if check_for_none is None:
                 ret[field.field_name] = None
             else:
-                ret[field.field_name] = field.to_representation(attribute)
+                try:
+                    ret[field.field_name] = field.to_representation(attribute)
+                except SkipField:
+                    continue
 
         return ret
 


### PR DESCRIPTION
Allow a broader usage of the `SkipField` exception within Serializers, making it possible to skip a field from being included when `to_representation` is called on the field level. Previously this has already been supported for `Field.get_attribute`, but not `Field.to_representation`.

For an example, this change allows raising a `SkipField` exception in a function called by `SerializerMethodField` in order to omit that field conditionally.

## This code is untested

I stumbled upon the example use case (wanting to conditionally skip a SerializerMethodField from being included), and found the `SkipField` mechanism already exists, but wasn't supported for `to_representation` calls.

Rather than just opening an issue, I figured even an elementary PR is a bit better, so this was simply edited with the GitHub web editor and thus untested.