### PR TITLE
Ensure that viewset actions may be identified as list views

### DIFF
--- a/rest_framework/schemas/utils.py
+++ b/rest_framework/schemas/utils.py
@@ -15,7 +15,7 @@ def is_list_view(path, method, view):
     """
     if hasattr(view, 'action'):
         # Viewsets have an explicitly defined action, which we can inspect.
-        return view.action == 'list'
+        return view.action == 'list' or view.many
 
     if method.lower() != 'get':
         return False

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -75,6 +75,9 @@ class ViewSetMixin:
         # The detail initkwarg is reserved for introspecting the viewset type.
         cls.detail = None
 
+        # The many initkwarg is reserved for introspecting the viewset return type.
+        cls.many = None
+
         # Setting a basename allows a view to reverse its action urls. This
         # value is provided by the router through the initkwargs.
         cls.basename = None


### PR DESCRIPTION
is_list_view only checks to see whether the view action is 'list'.

This means you cannot define an action with `detail=False` that will
generate a schema with a list response.

This commit allows specifying 'many=True' on an action to achieve this