### PR TITLE
Raise PEP 3134 chained exceptions

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -79,9 +79,9 @@ class BasicAuthentication(BaseAuthentication):
             except UnicodeDecodeError:
                 auth_decoded = base64.b64decode(auth[1]).decode('latin-1')
             auth_parts = auth_decoded.partition(':')
-        except (TypeError, UnicodeDecodeError, binascii.Error):
+        except (TypeError, UnicodeDecodeError, binascii.Error) as exc:
             msg = _('Invalid basic header. Credentials not correctly base64 encoded.')
-            raise exceptions.AuthenticationFailed(msg)
+            raise exceptions.AuthenticationFailed(msg) from exc
 
         userid, password = auth_parts[0], auth_parts[2]
         return self.authenticate_credentials(userid, password, request)
@@ -189,9 +189,9 @@ class TokenAuthentication(BaseAuthentication):
 
         try:
             token = auth[1].decode()
-        except UnicodeError:
+        except UnicodeError as exc:
             msg = _('Invalid token header. Token string should not contain invalid characters.')
-            raise exceptions.AuthenticationFailed(msg)
+            raise exceptions.AuthenticationFailed(msg) from exc
 
         return self.authenticate_credentials(token)
 

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -17,8 +17,8 @@ def get_object_or_404(queryset, *filter_args, **filter_kwargs):
     """
     try:
         return _get_object_or_404(queryset, *filter_args, **filter_kwargs)
-    except (TypeError, ValueError, ValidationError):
-        raise Http404
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise Http404 from exc
 
 
 class GenericAPIView(views.APIView):

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -206,7 +206,7 @@ class PageNumberPagination(BasePagination):
             msg = self.invalid_page_message.format(
                 page_number=page_number, message=str(exc)
             )
-            raise NotFound(msg)
+            raise NotFound(msg) from exc
 
         if paginator.num_pages > 1 and self.template is not None:
             # The browsable API should display pagination controls.
@@ -862,8 +862,8 @@ class CursorPagination(BasePagination):
             reverse = bool(int(reverse))
 
             position = tokens.get('p', [None])[0]
-        except (TypeError, ValueError):
-            raise NotFound(self.invalid_cursor_message)
+        except (TypeError, ValueError) as exc:
+            raise NotFound(self.invalid_cursor_message) from exc
 
         return Cursor(offset=offset, reverse=reverse, position=position)
 

--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -64,7 +64,7 @@ class JSONParser(BaseParser):
             parse_constant = json.strict_constant if self.strict else None
             return json.load(decoded_stream, parse_constant=parse_constant)
         except ValueError as exc:
-            raise ParseError('JSON parse error - %s' % str(exc))
+            raise ParseError('JSON parse error - %s' % str(exc)) from exc
 
 
 class FormParser(BaseParser):
@@ -109,7 +109,7 @@ class MultiPartParser(BaseParser):
             data, files = parser.parse()
             return DataAndFiles(data, files)
         except MultiPartParserError as exc:
-            raise ParseError('Multipart form parse error - %s' % str(exc))
+            raise ParseError('Multipart form parse error - %s' % str(exc)) from exc
 
 
 class FileUploadParser(BaseParser):

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -1,4 +1,3 @@
-import sys
 from collections import OrderedDict
 from urllib import parse
 
@@ -316,12 +315,10 @@ class HyperlinkedRelatedField(RelatedField):
 
         try:
             return queryset.get(**lookup_kwargs)
-        except ValueError:
-            exc = ObjectValueError(str(sys.exc_info()[1]))
-            raise exc.with_traceback(sys.exc_info()[2])
-        except TypeError:
-            exc = ObjectTypeError(str(sys.exc_info()[1]))
-            raise exc.with_traceback(sys.exc_info()[2])
+        except ValueError as exc:
+            raise ObjectValueError(str(exc)) from exc
+        except TypeError as exc:
+            raise ObjectTypeError(str(exc)) from exc
 
     def get_url(self, obj, view_name, request, format):
         """
@@ -399,7 +396,7 @@ class HyperlinkedRelatedField(RelatedField):
         # Return the hyperlink, or error if incorrectly configured.
         try:
             url = self.get_url(value, self.view_name, request, format)
-        except NoReverseMatch:
+        except NoReverseMatch as exc:
             msg = (
                 'Could not resolve URL for hyperlinked relationship using '
                 'view name "%s". You may have failed to include the related '
@@ -413,7 +410,7 @@ class HyperlinkedRelatedField(RelatedField):
                     "was %s, which may be why it didn't match any "
                     "entries in your URL conf." % value_string
                 )
-            raise ImproperlyConfigured(msg % self.view_name)
+            raise ImproperlyConfigured(msg % self.view_name) from exc
 
         if url is None:
             return None

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -9,7 +9,6 @@ The wrapped request then offers a richer API, in particular :
     - form overloading of HTTP method, content type and content
 """
 import io
-import sys
 from contextlib import contextmanager
 
 from django.conf import settings
@@ -72,10 +71,8 @@ def wrap_attributeerrors():
     """
     try:
         yield
-    except AttributeError:
-        info = sys.exc_info()
-        exc = WrappedAttributeError(str(info[1]))
-        raise exc.with_traceback(info[2])
+    except AttributeError as exc:
+        raise WrappedAttributeError(str(exc)) from exc
 
 
 class Empty:

--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -89,13 +89,13 @@ def insert_into(target, keys, value):
 
     try:
         target.links.append((keys[-1], value))
-    except TypeError:
+    except TypeError as exc:
         msg = INSERT_INTO_COLLISION_FMT.format(
             value_url=value.url,
             target_url=target.url,
             keys=keys
         )
-        raise ValueError(msg)
+        raise ValueError(msg) from exc
 
 
 class SchemaGenerator(BaseSchemaGenerator):

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -177,7 +177,7 @@ def import_from_string(val, setting_name):
         return import_string(val)
     except ImportError as e:
         msg = "Could not import '%s' for API setting '%s'. %s: %s." % (val, setting_name, e.__class__.__name__, e)
-        raise ImportError(msg)
+        raise ImportError(msg) from e
 
 
 class APISettings:

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -90,9 +90,9 @@ class SimpleRateThrottle(BaseThrottle):
 
         try:
             return self.THROTTLE_RATES[self.scope]
-        except KeyError:
+        except KeyError as exc:
             msg = "No default throttle rate set for '%s' scope" % self.scope
-            raise ImproperlyConfigured(msg)
+            raise ImproperlyConfigured(msg) from exc
 
     def parse_rate(self, rate):
         """


### PR DESCRIPTION
## Description

Use PEP 3134 (https://peps.python.org/pep-3134/) exception chaining to provide enhanced reporting and extra context when errors are encountered.

This was primarily so I could debug issues while developing my own nested serializers that were failing validation.  I wanted to see the specifics of how the validation had failed, chaining the exceptions raised along with adding the following to my `settings.py` proved to be very helpful:
```python
def raise_api_exception(exc, context):
    raise exc

REST_FRAMEWORK = {
    "EXCEPTION_HANDLER": f"{__name__}.raise_api_exception",
}
```