### PR TITLE
Made relative URLs clickable as well.

### DIFF
--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -218,7 +218,7 @@ def format_value(value):
         return template.render(context)
     elif isinstance(value, str):
         if (
-            (value.startswith('http:') or value.startswith('https:')) and not
+            (value.startswith('http:') or value.startswith('https:') or value.startswith('/')) and not
             re.search(r'\s', value)
         ):
             return mark_safe('<a href="{value}">{value}</a>'.format(value=escape(value)))


### PR DESCRIPTION
## Description

As of now, relative URLs are not clickable. This creates problems for some users who can't rely on the request's host to generate absolute URLs.

Very relevant:

https://github.com/encode/django-rest-framework/discussions/8460
https://stackoverflow.com/questions/64022460/drf-how-to-render-relative-urls-as-hyperlinks-in-the-browsable-api
https://stackoverflow.com/questions/71839932/django-rest-framework-how-to-make-relative-urls-clickable

Somehow relevant:

https://stackoverflow.com/questions/70092287/changing-url-path-of-api-in-django-rest-framework
https://stackoverflow.com/questions/62421753/how-to-change-the-host-in-next-key-in-a-paginated-url-in-django-rest-framework
https://stackoverflow.com/questions/34231393/how-to-change-the-django-rest-frameworks-default-url-to-a-custom

This change fixes this problem.
