### PR TITLE
corrected grammar to improve clarity

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -19,7 +19,7 @@ Relational fields are used to represent model relationships.  They can be applie
 
 ---
 
-**Note:** REST Framework does not attempt to automatically optimize querysets passed to serializers in terms of `select_related` and `prefetch_related` since it would be too much magic. A serializer with a field spanning an orm relation through its source attribute could require an additional database hit to fetch related object from the database. It is the programmer's responsibility to optimize queries to avoid additional database hits which could occur while using such a serializer.
+**Note:** REST Framework does not attempt to automatically optimize querysets passed to serializers in terms of `select_related` and `prefetch_related` since it would be too much magic. A serializer with a field spanning an orm relation through its source attribute could require an additional database hit to fetch related objects from the database. It is the programmer's responsibility to optimize queries to avoid additional database hits which could occur while using such a serializer.
 
 For example, the following serializer would lead to a database hit each time evaluating the tracks field if it is not prefetched:
 


### PR DESCRIPTION
## Description

While reading the docs, I noticed a confusing phrase, and realized it could confuse non-native English readers. It seemed like the phrase should be _fetch a related object_ or _fetch related objects_. After consulting my co-worker @williln, our resident language expert, I went with the 2nd option.