### PR TITLE
Fix QueryDict type error in test

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1859,9 +1859,9 @@ class TestMultipleChoiceField(FieldValues):
     def test_against_partial_and_full_updates(self):
         field = serializers.MultipleChoiceField(choices=(('a', 'a'), ('b', 'b')))
         field.partial = False
-        assert field.get_value(QueryDict({})) == []
+        assert field.get_value(QueryDict('')) == []
         field.partial = True
-        assert field.get_value(QueryDict({})) == rest_framework.fields.empty
+        assert field.get_value(QueryDict('')) == rest_framework.fields.empty
 
 
 class TestEmptyMultipleChoiceField(FieldValues):


### PR DESCRIPTION
`QueryDict` takes a `str` argument. But this makes no difference in practice. Discovered while working on djangorestframework-stubs.
