### PR TITLE
Update description of docs/api-guide/fields.md -> required

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -42,7 +42,7 @@ Set to false if this field is not required to be present during deserialization.
 
 Setting this to `False` also allows the object attribute or dictionary key to be omitted from output when serializing the instance. If the key is not present it will simply not be included in the output representation.
 
-Defaults to `True`.
+Defaults to `True`. If you're using [Model Serializer](https://www.django-rest-framework.org/api-guide/serializers/#modelserializer) default value will be `False` if you have specified `blank=True` or `default` or `null=True` at your field in your `Model`.
 
 ### `default`
 


### PR DESCRIPTION
fix: Documentation did not point out that the default value of `required`
`Field` parameter is `False` depending on Django's `Model.field`.

This is a continuation of https://github.com/encode/django-rest-framework/pull/7222.

The rationale of my PR is this part of the code: https://github.com/encode/django-rest-framework/blob/b1004a47334a0dd1929e6d50b8f7ff6badc959f4/rest_framework/utils/field_mapping.py#L104