### PR TITLE
Added django-requestlogs in third party packages

### DIFF
--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -148,6 +148,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [django-elasticsearch-dsl-drf][django-elasticsearch-dsl-drf] - Integrate Elasticsearch DSL with Django REST framework. Package provides views, serializers, filter backends, pagination and other handy add-ons.
 * [django-api-client][django-api-client] - DRF client that groups the Endpoint response, for use in CBVs and FBV as if you were working with Django's Native Models..
 * [fast-drf] - A model based library for making API development faster and easier.
+* [django-requestlogs] - Providing middleware and other helpers for audit logging for REST framework.
 
 [cite]: http://www.software-ecosystems.com/Software_Ecosystems/Ecosystems.html
 [cookiecutter]: https://github.com/jpadilla/cookiecutter-django-rest-framework
@@ -237,3 +238,4 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [graphwrap]: https://github.com/PaulGilmartin/graph_wrap
 [rest-framework-actions]: https://github.com/AlexisMunera98/rest-framework-actions
 [fast-drf]: https://github.com/iashraful/fast-drf
+[django-requestlogs]: https://github.com/Raekkeri/django-requestlogs


### PR DESCRIPTION
## Description

Added [django-requestlogs](https://github.com/Raekkeri/django-requestlogs) in third party packages. django-requestlogs hooks into the Django REST framework in the simplest way possible while logging every request without the need of remembering to enable it for each view separately.