### PR TITLE
Improve performance for noncallable attributes

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -63,6 +63,9 @@ def is_simple_callable(obj):
     """
     True if the object is a callable that takes no arguments.
     """
+    if not callable(obj):
+        return False
+
     # Bail early since we cannot inspect built-in function signatures.
     if inspect.isbuiltin(obj):
         raise BuiltinSignatureError(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -73,6 +73,10 @@ class TestIsSimpleCallable:
         assert is_simple_callable(valid_vargs_kwargs)
         assert not is_simple_callable(invalid)
 
+    @pytest.mark.parametrize('obj', (True, None, "str", b'bytes', 123, 1.23))
+    def test_not_callable(self, obj):
+        assert not is_simple_callable(obj)
+
     def test_4602_regression(self):
         from django.db import models
 


### PR DESCRIPTION
## Description

The issue that this MR trying to fix, was described in the other MR that was not finished https://github.com/encode/django-rest-framework/pull/8318 
 I faced the same problem, python spend most of the time in larges serializers with a lot of nested objects in `is_simple_callable`. 
Based on your comments in mentioned MR, this MR contains only a 2 lines of code to fix this issue. 
Here an example of code ( this issue effect almost all fields types):
```python
from timeit import timeit
from rest_framework import serializers


class Comment:
    def __init__(self, email, number=0):
        self.email = email
        self.number = number


class CommentSerializer(serializers.Serializer):
    email = serializers.CharField()
    number = serializers.IntegerField()


comments = [Comment(email='leila@example.com') for _ in range(100)]


def serialize():
    serializer = CommentSerializer(comments, many=True)
    return serializer.data


print(timeit('serialize()', number=1000, setup="from __main__ import serialize"))
```

This MR gives only 1-2% boost for 1 field object serialization, but about 50% boost for large and branched objects with a lot of fields