### PR TITLE
add write_only_fields field to model serializer

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1386,21 +1386,22 @@ class ModelSerializer(Serializer):
             if fields is not None:
                 if not isinstance(fields, (list, tuple)):
                     raise TypeError(
-                        f'The `{option}` option must be a list or tuple. '
-                        f'Got {type(fields).__name__}.'
+                        'The `%s` option must be a list or tuple. '
+                        'Got %s.' % (option, type(fields).__name__)
                     )
                 for field_name in fields:
                     kwargs = extra_kwargs.get(field_name, {})
                     kwargs[limit] = True
                     extra_kwargs[field_name] = kwargs
             else:
-                # Guard against the possible misspelling `readonly_fields` (used
-                # by the Django admin and others).
-                assert not hasattr(self.Meta, 'readonly_fields'), (
-                    'Serializer `%s.%s` has field `readonly_fields`; '
-                    'the correct spelling for the option is `read_only_fields`.' %
-                    (self.__class__.__module__, self.__class__.__name__)
-                )
+                if option == READ_ONLY_FIELDS:
+                    # Guard against the possible misspelling `readonly_fields` (used
+                    # by the Django admin and others).
+                    assert not hasattr(self.Meta, 'readonly_fields'), (
+                        'Serializer `%s.%s` has field `readonly_fields`; '
+                        'the correct spelling for the option is `read_only_fields`.' %
+                        (self.__class__.__module__, self.__class__.__name__)
+                    )
 
         return extra_kwargs
 


### PR DESCRIPTION
I think is very useful to have a `write_only_fields` field in `ModelSerializer`. I don't like to have several write only fields and write it like this:
```python
extra_kwargs = {
    'example_field_1': {'write_only': True},
    'example_field_2': {'write_only': True},
    'example_field_3': {'write_only': True},
}
```
So, i think this is more readable:
```python
write_only_fields = (
    'example_field_1',
    'example_field_2',
    'example_field_3',
)
```