### PR TITLE
Docs: Removed pluralisation from basenames

### DIFF
--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -112,8 +112,8 @@ Here's our re-wired `snippets/urls.py` file.
 
     # Create a router and register our viewsets with it.
     router = DefaultRouter()
-    router.register(r'snippets', views.SnippetViewSet,basename="snippets")
-    router.register(r'users', views.UserViewSet,basename="users")
+    router.register(r'snippets', views.SnippetViewSet,basename="snippet")
+    router.register(r'users', views.UserViewSet,basename="user")
 
     # The API URLs are now determined automatically by the router.
     urlpatterns = [


### PR DESCRIPTION
Correction on an example that errors. HyperlinkIdentityFields in serializers reference 'snippet-highlight' and 'snippet-detail', router basenames updated to match.
