### PR TITLE
DurationField output format

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -380,12 +380,12 @@ The `validated_data` for these fields will contain a `datetime.timedelta` instan
 
 **Signature:** `DurationField(format=api_settings.DURATION_FORMAT, max_value=None, min_value=None)`
 
-* `format` - A string representing the output format.  If not specified, this defaults to the same value as the `DURATION_FORMAT` settings key, which will be `'standard'` unless set. Setting to a format string indicates that `to_representation` return values should be coerced to string output. Format strings are described below. Setting this value to `None` indicates that Python `timedelta` objects should be returned by `to_representation`. In this case the date encoding will be determined by the renderer.
+* `format` - A string representing the output format.  If not specified, this defaults to the same value as the `DURATION_FORMAT` settings key, which will be `'django'` unless set. Formats are described below. Setting this value to `None` indicates that Python `timedelta` objects should be returned by `to_representation`. In this case the date encoding will be determined by the renderer.
 * `max_value` Validate that the duration provided is no greater than this value.
 * `min_value` Validate that the duration provided is no less than this value.
 
-#### `DurationField` format strings
-Format strings may either be the special string `'iso-8601'`, which indicates that [ISO 8601][iso8601] style intervals should be used (eg `'P4DT1H15M20S'`), or the special string `'standard'`, which indicates that Django interval format `'[DD] [HH:[MM:]]ss[.uuuuuu]'` should be used (eg: `'4 1:15:20'`).
+#### `DurationField` formats
+Format may either be the special string `'iso-8601'`, which indicates that [ISO 8601][iso8601] style intervals should be used (eg `'P4DT1H15M20S'`), or `'django'` which indicates that Django interval format `'[DD] [HH:[MM:]]ss[.uuuuuu]'` should be used (eg: `'4 1:15:20'`).
 
 ---
 

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -377,12 +377,15 @@ A Duration representation.
 Corresponds to `django.db.models.fields.DurationField`
 
 The `validated_data` for these fields will contain a `datetime.timedelta` instance.
-The representation is a string following this format `'[DD] [HH:[MM:]]ss[.uuuuuu]'`.
 
-**Signature:** `DurationField(max_value=None, min_value=None)`
+**Signature:** `DurationField(format=api_settings.DURATION_FORMAT, max_value=None, min_value=None)`
 
+* `format` - A string representing the output format.  If not specified, this defaults to the same value as the `DURATION_FORMAT` settings key, which will be `'standard'` unless set. Setting to a format string indicates that `to_representation` return values should be coerced to string output. Format strings are described below. Setting this value to `None` indicates that Python `timedelta` objects should be returned by `to_representation`. In this case the date encoding will be determined by the renderer.
 * `max_value` Validate that the duration provided is no greater than this value.
 * `min_value` Validate that the duration provided is no less than this value.
+
+#### `DurationField` format strings
+Format strings may either be the special string `'iso-8601'`, which indicates that [ISO 8601][iso8601] style intervals should be used (eg `'P4DT1H15M20S'`), or the special string `'standard'`, which indicates that Django interval format `'[DD] [HH:[MM:]]ss[.uuuuuu]'` should be used (eg: `'4 1:15:20'`).
 
 ---
 

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -314,6 +314,15 @@ May be a list including the string `'iso-8601'` or Python [strftime format][strf
 
 Default: `['iso-8601']`
 
+
+#### DURATION_FORMAT
+
+A format string that should be used by default for rendering the output of `DurationField` serializer fields.  If `None`, then `DurationField` serializer fields will return Python `timedelta` objects, and the duration encoding will be determined by the renderer.
+
+May be any of `None`, `'iso-8601'` or `'standard'` (the format accepted by `django.utils.dateparse.parse_duration`).
+
+Default: `'standard'`
+
 ---
 
 ## Encodings

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -317,7 +317,7 @@ Default: `['iso-8601']`
 
 #### DURATION_FORMAT
 
-Indicates the default format thath should be used for rendering the output of `DurationField` serializer fields.  If `None`, then `DurationField` serializer fields will return Python `timedelta` objects, and the duration encoding will be determined by the renderer.
+Indicates the default format that should be used for rendering the output of `DurationField` serializer fields.  If `None`, then `DurationField` serializer fields will return Python `timedelta` objects, and the duration encoding will be determined by the renderer.
 
 May be any of `None`, `'iso-8601'` or `'django'` (the format accepted by `django.utils.dateparse.parse_duration`).
 

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -317,11 +317,11 @@ Default: `['iso-8601']`
 
 #### DURATION_FORMAT
 
-A format string that should be used by default for rendering the output of `DurationField` serializer fields.  If `None`, then `DurationField` serializer fields will return Python `timedelta` objects, and the duration encoding will be determined by the renderer.
+Indicates the default format thath should be used for rendering the output of `DurationField` serializer fields.  If `None`, then `DurationField` serializer fields will return Python `timedelta` objects, and the duration encoding will be determined by the renderer.
 
-May be any of `None`, `'iso-8601'` or `'standard'` (the format accepted by `django.utils.dateparse.parse_duration`).
+May be any of `None`, `'iso-8601'` or `'django'` (the format accepted by `django.utils.dateparse.parse_duration`).
 
-Default: `'standard'`
+Default: `'django'`
 
 ---
 

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -21,6 +21,7 @@ HTTP_HEADER_ENCODING = 'iso-8859-1'
 
 # Default datetime input and output formats
 ISO_8601 = 'iso-8601'
+STD_DURATION = 'standard'
 
 
 class RemovedInDRF317Warning(PendingDeprecationWarning):

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -21,7 +21,7 @@ HTTP_HEADER_ENCODING = 'iso-8859-1'
 
 # Default datetime input and output formats
 ISO_8601 = 'iso-8601'
-STD_DURATION = 'standard'
+DJANGO_DURATION_FORMAT = 'django'
 
 
 class RemovedInDRF317Warning(PendingDeprecationWarning):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -24,7 +24,7 @@ from django.utils import timezone
 from django.utils.dateparse import (
     parse_date, parse_datetime, parse_duration, parse_time
 )
-from django.utils.duration import duration_string
+from django.utils.duration import duration_iso_string, duration_string
 from django.utils.encoding import is_protected_type, smart_str
 from django.utils.formats import localize_input, sanitize_separators
 from django.utils.ipv6 import clean_ipv6_address
@@ -1351,9 +1351,11 @@ class DurationField(Field):
         'overflow': _('The number of days must be between {min_days} and {max_days}.'),
     }
 
-    def __init__(self, **kwargs):
+    def __init__(self, format=empty, **kwargs):
         self.max_value = kwargs.pop('max_value', None)
         self.min_value = kwargs.pop('min_value', None)
+        if format is not empty:
+            self.format = format
         super().__init__(**kwargs)
         if self.max_value is not None:
             message = lazy_format(self.error_messages['max_value'], max_value=self.max_value)
@@ -1376,6 +1378,13 @@ class DurationField(Field):
         self.fail('invalid', format='[DD] [HH:[MM:]]ss[.uuuuuu]')
 
     def to_representation(self, value):
+        output_format = getattr(self, 'format', api_settings.DURATION_FORMAT)
+
+        if output_format is None or isinstance(value, str):
+            return value
+
+        if output_format.lower() == ISO_8601:
+            return duration_iso_string(value)
         return duration_string(value)
 
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1357,10 +1357,15 @@ class DurationField(Field):
         if format is not empty:
             if format is None or (isinstance(format, str) and format.lower() in (ISO_8601, DJANGO_DURATION_FORMAT)):
                 self.format = format
-            else:
+            elif isinstance(format, str):
                 raise ValueError(
                     f"Unknown duration format provided, got '{format}'"
                     " while expecting 'django', 'iso-8601' or `None`."
+                )
+            else:
+                raise TypeError(
+                    "duration format must be either str or `None`,"
+                    f" not {type(format).__name__}"
                 )
         super().__init__(**kwargs)
         if self.max_value is not None:
@@ -1396,9 +1401,13 @@ class DurationField(Field):
             if output_format.lower() == DJANGO_DURATION_FORMAT:
                 return duration_string(value)
 
-        raise ValueError(
-            f"Unknown duration format provided, got '{output_format}'"
-            " while expecting 'django', 'iso-8601' or `None`."
+            raise ValueError(
+                f"Unknown duration format provided, got '{output_format}'"
+                " while expecting 'django', 'iso-8601' or `None`."
+            )
+        raise TypeError(
+            "duration format must be either str or `None`,"
+            f" not {type(output_format).__name__}"
         )
 
 

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -24,7 +24,7 @@ from django.conf import settings
 from django.core.signals import setting_changed
 from django.utils.module_loading import import_string
 
-from rest_framework import ISO_8601
+from rest_framework import ISO_8601, STD_DURATION
 
 DEFAULTS = {
     # Base API policies
@@ -108,6 +108,8 @@ DEFAULTS = {
 
     'TIME_FORMAT': ISO_8601,
     'TIME_INPUT_FORMATS': [ISO_8601],
+
+    'DURATION_FORMAT': STD_DURATION,
 
     # Encoding
     'UNICODE_JSON': True,

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -24,7 +24,7 @@ from django.conf import settings
 from django.core.signals import setting_changed
 from django.utils.module_loading import import_string
 
-from rest_framework import ISO_8601, STD_DURATION
+from rest_framework import DJANGO_DURATION_FORMAT, ISO_8601
 
 DEFAULTS = {
     # Base API policies
@@ -109,7 +109,7 @@ DEFAULTS = {
     'TIME_FORMAT': ISO_8601,
     'TIME_INPUT_FORMATS': [ISO_8601],
 
-    'DURATION_FORMAT': STD_DURATION,
+    'DURATION_FORMAT': DJANGO_DURATION_FORMAT,
 
     # Encoding
     'UNICODE_JSON': True,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1775,7 +1775,7 @@ class TestDurationField(FieldValues):
 
 class TestNoOutputFormatDurationField(FieldValues):
     """
-    Values for `TimeField` with a no output format.
+    Values for `DurationField` with a no output format.
     """
     valid_inputs = {}
     invalid_inputs = {}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1779,23 +1779,28 @@ class TestDurationField(FieldValues):
             "Unknown duration format provided, got 'unknown'"
             " while expecting 'django', 'iso-8601' or `None`."
         )
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(TypeError) as exc_info:
             serializers.DurationField(format=123)
         assert str(exc_info.value) == (
-            "Unknown duration format provided, got '123'"
-            " while expecting 'django', 'iso-8601' or `None`."
+            "duration format must be either str or `None`, not int"
         )
 
-    @override_settings(REST_FRAMEWORK={'DURATION_FORMAT': 'unknown'})
     def test_invalid_format_in_config(self):
         field = serializers.DurationField()
 
-        with pytest.raises(ValueError) as exc_info:
-            field.to_representation(datetime.timedelta(days=1))
+        with override_settings(REST_FRAMEWORK={'DURATION_FORMAT': 'unknown'}):
+            with pytest.raises(ValueError) as exc_info:
+                field.to_representation(datetime.timedelta(days=1))
 
         assert str(exc_info.value) == (
             "Unknown duration format provided, got 'unknown'"
             " while expecting 'django', 'iso-8601' or `None`."
+        )
+        with override_settings(REST_FRAMEWORK={'DURATION_FORMAT': 123}):
+            with pytest.raises(TypeError) as exc_info:
+                field.to_representation(datetime.timedelta(days=1))
+        assert str(exc_info.value) == (
+            "duration format must be either str or `None`, not int"
         )
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1773,8 +1773,31 @@ class TestDurationField(FieldValues):
     field = serializers.DurationField()
 
 
-# Choice types...
+class TestNoOutputFormatDurationField(FieldValues):
+    """
+    Values for `TimeField` with a no output format.
+    """
+    valid_inputs = {}
+    invalid_inputs = {}
+    outputs = {
+        datetime.timedelta(1): datetime.timedelta(1)
+    }
+    field = serializers.DurationField(format=None)
 
+
+class TestISOOutputFormatDurationField(FieldValues):
+    """
+    Values for `TimeField` with a custom output format.
+    """
+    valid_inputs = {}
+    invalid_inputs = {}
+    outputs = {
+        datetime.timedelta(days=3, hours=8, minutes=32, seconds=1, microseconds=123): 'P3DT08H32M01.000123S'
+    }
+    field = serializers.DurationField(format='iso-8601')
+
+
+# Choice types...
 class TestChoiceField(FieldValues):
     """
     Valid and invalid values for `ChoiceField`.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1787,7 +1787,7 @@ class TestNoOutputFormatDurationField(FieldValues):
 
 class TestISOOutputFormatDurationField(FieldValues):
     """
-    Values for `TimeField` with a custom output format.
+    Values for `DurationField` with a custom output format.
     """
     valid_inputs = {}
     invalid_inputs = {}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1772,6 +1772,32 @@ class TestDurationField(FieldValues):
     }
     field = serializers.DurationField()
 
+    def test_invalid_format(self):
+        with pytest.raises(ValueError) as exc_info:
+            serializers.DurationField(format='unknown')
+        assert str(exc_info.value) == (
+            "Unknown duration format provided, got 'unknown'"
+            " while expecting 'django', 'iso-8601' or `None`."
+        )
+        with pytest.raises(ValueError) as exc_info:
+            serializers.DurationField(format=123)
+        assert str(exc_info.value) == (
+            "Unknown duration format provided, got '123'"
+            " while expecting 'django', 'iso-8601' or `None`."
+        )
+
+    @override_settings(REST_FRAMEWORK={'DURATION_FORMAT': 'unknown'})
+    def test_invalid_format_in_config(self):
+        field = serializers.DurationField()
+
+        with pytest.raises(ValueError) as exc_info:
+            field.to_representation(datetime.timedelta(days=1))
+
+        assert str(exc_info.value) == (
+            "Unknown duration format provided, got 'unknown'"
+            " while expecting 'django', 'iso-8601' or `None`."
+        )
+
 
 class TestNoOutputFormatDurationField(FieldValues):
     """
@@ -1789,7 +1815,13 @@ class TestISOOutputFormatDurationField(FieldValues):
     """
     Values for `DurationField` with a custom output format.
     """
-    valid_inputs = {}
+    valid_inputs = {
+        '13': datetime.timedelta(seconds=13),
+        'P3DT08H32M01.000123S': datetime.timedelta(days=3, hours=8, minutes=32, seconds=1, microseconds=123),
+        'PT8H1M': datetime.timedelta(hours=8, minutes=1),
+        '-P999999999D': datetime.timedelta(days=-999999999),
+        'P999999999D': datetime.timedelta(days=999999999)
+    }
     invalid_inputs = {}
     outputs = {
         datetime.timedelta(days=3, hours=8, minutes=32, seconds=1, microseconds=123): 'P3DT08H32M01.000123S'


### PR DESCRIPTION
## Description
As explained in #8527 this PR will provide the ability to choose the output format for `DurationFields`.

Since Python builtim `timedelta` object does not have any format function we are going to allow only formats which are already defined in Django codebase in the package `django.utils.duration`:

- `duration_string`
- `duration_iso_string`
