### PR TITLE
Use autocomplete widget for user selection in TokenAdmin

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -25,6 +25,7 @@ class TokenAdmin(admin.ModelAdmin):
     fields = ('user',)
     ordering = ('-created',)
     actions = None  # Actions not compatible with mapped IDs.
+    autocomplete_fields = ("user",)
 
     def get_changelist(self, request, **kwargs):
         return TokenChangeList


### PR DESCRIPTION
Use `autocomplete_fields` to keep the select user field manageable.

Refs #8533