### PR TITLE
Make autogenerated read only fields to be able to be nullable

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -95,6 +95,9 @@ def get_field_kwargs(field_name, model_field):
             (hasattr(models, 'JSONField') and isinstance(model_field, models.JSONField)):
         kwargs['style'] = {'base_template': 'textarea.html'}
 
+    if model_field.null:
+        kwargs['allow_null'] = True
+
     if isinstance(model_field, models.AutoField) or not model_field.editable:
         # If this field is read-only, then return early.
         # Further keyword arguments are not valid.
@@ -103,9 +106,6 @@ def get_field_kwargs(field_name, model_field):
 
     if model_field.has_default() or model_field.blank or model_field.null:
         kwargs['required'] = False
-
-    if model_field.null:
-        kwargs['allow_null'] = True
 
     if model_field.blank and (isinstance(model_field, (models.CharField, models.TextField))):
         kwargs['allow_blank'] = True
@@ -263,6 +263,8 @@ def get_relation_kwargs(field_name, relation_info):
         if not model_field.editable:
             kwargs['read_only'] = True
             kwargs.pop('queryset', None)
+        if model_field.null:
+            kwargs['allow_null'] = True
         if kwargs.get('read_only', False):
             # If this field is read-only, then return early.
             # No further keyword arguments are valid.
@@ -270,8 +272,6 @@ def get_relation_kwargs(field_name, relation_info):
 
         if model_field.has_default() or model_field.blank or model_field.null:
             kwargs['required'] = False
-        if model_field.null:
-            kwargs['allow_null'] = True
         if model_field.validators:
             kwargs['validators'] = model_field.validators
         if getattr(model_field, 'unique', False):


### PR DESCRIPTION
## Description

Move null attr check before return for read-only fields. While as of now it doesn't break anything, it leads to incorrect API schema generation when using drf-spectacular(https://github.com/tfranzel/drf-spectacular/issues/383) or drf-yasg(https://github.com/axnsan12/drf-yasg/issues/310).