### PR TITLE
Add import to renderer_classes docs

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -152,6 +152,8 @@ A simple renderer that simply returns pre-rendered HTML.  Unlike other renderers
 
 An example of a view that uses `StaticHTMLRenderer`:
 
+    from rest_framework.decorators import renderer_classes
+
     @api_view(['GET'])
     @renderer_classes([StaticHTMLRenderer])
     def simple_html_view(request):


### PR DESCRIPTION
## Description

### What
Adds an import statement to the docs for `renderer_classes`
### Why 
The existing docs do not how what import is required to use `renderer_classes`, and finding the said import is not straightforward through the docs/SO/Google etc.

### Testing
None. Not necessary