### PR TITLE
feat: pass args/kwargs to get_serializer_class

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -105,11 +105,11 @@ class GenericAPIView(views.APIView):
         Return the serializer instance that should be used for validating and
         deserializing input, and for serializing output.
         """
-        serializer_class = self.get_serializer_class()
+        serializer_class = self.get_serializer_class(*args, **kwargs)
         kwargs.setdefault('context', self.get_serializer_context())
         return serializer_class(*args, **kwargs)
 
-    def get_serializer_class(self):
+    def get_serializer_class(self, *args, **kwargs):
         """
         Return the class to use for the serializer.
         Defaults to using `self.serializer_class`.


### PR DESCRIPTION
## Description

Passing args and kwargs to `get_serializer_class` allows to determine the serializer class by the object.
so one can set different serializer for each object based on the object it self (do I admin of it?) and not (only) by the request