### PR TITLE
Update documentation on dependency installation

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -80,7 +80,7 @@ To run the tests, clone the repository, and then:
     # Setup the virtual environment
     python3 -m venv env
     source env/bin/activate
-    pip install django
+    pip install -e .
     pip install -r requirements.txt
 
     # Run the tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # The base set of requirements for REST framework is actually
-# just Django, but for the purposes of development and testing
-# there are a number of packages that are useful to install.
+# just Django and pytz, but for the purposes of development
+# and testing there are a number of packages that are useful
+# to install.
 
 # Laying these out as separate requirements files, allows us to
 # only included the relevant sets when running tox, and ensures


### PR DESCRIPTION
We depend on `pytz`, but until late last year we got it implicitly through
depending on `Django`. Since their release 4.0, however, they no longer
depend on `pytz`; commit `250479dc3` added the dependency directly to our
metadata in `setup.py`, but the documentation about dependencies (most
importantly, the instructions for new contributors) was left untouched.

This commit updates the new contributor instructions to suggest an
"editable installation" of the project at the step that previously had
users manually install Django. In this mode, pip fetches and installs
the project dependencies automatically (so in the unlikely event we grow
another dependency, that doc doesn't need to be changed again) and makes
the project available to the virtualenv's python as a normal package,
but doesn't require reinstallation for mundane edits.