### PR TITLE
 Prevent Bypass Throttle Via X-Forwarded-For Header

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -22,22 +22,10 @@ class BaseThrottle:
 
     def get_ident(self, request):
         """
-        Identify the machine making the request by parsing HTTP_X_FORWARDED_FOR
-        if present and number of proxies is > 0. If not use all of
-        HTTP_X_FORWARDED_FOR if it is available, if not use REMOTE_ADDR.
+        Identify the machine making the request by REMOTE_ADDR.
         """
-        xff = request.META.get('HTTP_X_FORWARDED_FOR')
         remote_addr = request.META.get('REMOTE_ADDR')
-        num_proxies = api_settings.NUM_PROXIES
-
-        if num_proxies is not None:
-            if num_proxies == 0 or xff is None:
-                return remote_addr
-            addrs = xff.split(',')
-            client_addr = addrs[-min(num_proxies, len(addrs))]
-            return client_addr.strip()
-
-        return ''.join(xff.split()) if xff else remote_addr
+        return remote_addr
 
     def wait(self):
         """


### PR DESCRIPTION

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

there are two ways of rest_framework to identify the client IP address, namely through the X-Forwarded-For header and the REMOTE_ADDR variable in the WSGI environment, identification via the X-Forwarded-For header is too easy to bypass, I hope this is removed, but it doesn't mean identification via The REMOTE_ADDR variable is safe, it can still be manipulated with the IP rotation method, but using the REMOTE_ADDR variable alone is better than including the X-Forwarded-For header which is very easy to bypass.
