### PR TITLE
prevent Dos attacks

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -22,22 +22,10 @@ class BaseThrottle:
 
     def get_ident(self, request):
         """
-        Identify the machine making the request by parsing HTTP_X_FORWARDED_FOR
-        if present and number of proxies is > 0. If not use all of
-        HTTP_X_FORWARDED_FOR if it is available, if not use REMOTE_ADDR.
+        Identify the machine making the request with the REMOTE_ADDR variable in the wsgi environment.
         """
-        xff = request.META.get('HTTP_X_FORWARDED_FOR')
         remote_addr = request.META.get('REMOTE_ADDR')
-        num_proxies = api_settings.NUM_PROXIES
-
-        if num_proxies is not None:
-            if num_proxies == 0 or xff is None:
-                return remote_addr
-            addrs = xff.split(',')
-            client_addr = addrs[-min(num_proxies, len(addrs))]
-            return client_addr.strip()
-
-        return ''.join(xff.split()) if xff else remote_addr
+        return remote_addr
 
     def wait(self):
         """


### PR DESCRIPTION
## Description

Throttling on django rest framework takes client ip from X-Forwarded-For header, one can control the value of X-Forwarded-For header, attacker can set its value with other user's ip then send request continuously so that service will not be available to the user who owns the ip The original.

scenario: the attacker sends a link to the victim that goes to the attacker's server. the attacker gets the victim's ip. then the attacker sends a continuous request to the target application(which uses Throttling django rest framework) by setting the X-Forwarded-For header as the target ip. target ip will be blocked by target app so service will not be available to victim
