### PR TITLE
fix 404 when page query parameter is empty string

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -216,7 +216,7 @@ class PageNumberPagination(BasePagination):
         return list(self.page)
 
     def get_page_number(self, request, paginator):
-        page_number = request.query_params.get(self.page_query_param, 1)
+        page_number = request.query_params.get(self.page_query_param) or 1
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages
         return page_number

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -216,7 +216,7 @@ class PageNumberPagination(BasePagination):
         return list(self.page)
 
     def get_page_number(self, request, paginator):
-        page_number = request.query_params.get(self.page_query_param) or 1
+        page_number = request.query_params.get(self.page_query_param) or  1
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages
         return page_number

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -216,7 +216,7 @@ class PageNumberPagination(BasePagination):
         return list(self.page)
 
     def get_page_number(self, request, paginator):
-        page_number = request.query_params.get(self.page_query_param) or  1
+        page_number = request.query_params.get(self.page_query_param) or 1
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages
         return page_number

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -180,8 +180,9 @@ class TestPageNumberPagination:
     def get_html_context(self):
         return self.pagination.get_html_context()
 
-    def test_no_page_number(self):
-        request = Request(factory.get('/'))
+    @pytest.mark.parametrize('url', ['/', '/?page='])
+    def test_no_page_number(self, url):
+        request = Request(factory.get(url))
         queryset = self.paginate_queryset(request)
         content = self.get_paginated_content(queryset)
         context = self.get_html_context()


### PR DESCRIPTION
## Description

It will return 404 if page query parameter is empty string, like `/?page=`.
Some of api testing tools will assign query parameter with empty string (like `Apifox`, as I know), this PR handles this case.