### PR TITLE
Stop calling `set_context`, planned for 3.13 drop

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -30,9 +30,7 @@ from django.utils.ipv6 import clean_ipv6_address
 from django.utils.translation import gettext_lazy as _
 from pytz.exceptions import InvalidTimeError
 
-from rest_framework import (
-    ISO_8601, RemovedInDRF313Warning, RemovedInDRF314Warning
-)
+from rest_framework import ISO_8601, RemovedInDRF314Warning
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.utils import html, humanize_datetime, json, representation
@@ -265,16 +263,6 @@ class CreateOnlyDefault:
         if is_update:
             raise SkipField()
         if callable(self.default):
-            if hasattr(self.default, 'set_context'):
-                warnings.warn(
-                    "Method `set_context` on defaults is deprecated and will "
-                    "no longer be called starting with 3.13. Instead set "
-                    "`requires_context = True` on the class, and accept the "
-                    "context as an additional argument.",
-                    RemovedInDRF313Warning, stacklevel=2
-                )
-                self.default.set_context(self)
-
             if getattr(self.default, 'requires_context', False):
                 return self.default(serializer_field)
             else:
@@ -504,16 +492,6 @@ class Field:
             # No default, or this is a partial update.
             raise SkipField()
         if callable(self.default):
-            if hasattr(self.default, 'set_context'):
-                warnings.warn(
-                    "Method `set_context` on defaults is deprecated and will "
-                    "no longer be called starting with 3.13. Instead set "
-                    "`requires_context = True` on the class, and accept the "
-                    "context as an additional argument.",
-                    RemovedInDRF313Warning, stacklevel=2
-                )
-                self.default.set_context(self)
-
             if getattr(self.default, 'requires_context', False):
                 return self.default(self)
             else:
@@ -578,16 +556,6 @@ class Field:
         """
         errors = []
         for validator in self.validators:
-            if hasattr(validator, 'set_context'):
-                warnings.warn(
-                    "Method `set_context` on validators is deprecated and will "
-                    "no longer be called starting with 3.13. Instead set "
-                    "`requires_context = True` on the class, and accept the "
-                    "context as an additional argument.",
-                    RemovedInDRF313Warning, stacklevel=2
-                )
-                validator.set_context(self)
-
             try:
                 if getattr(validator, 'requires_context', False):
                     validator(value, self)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -566,7 +566,7 @@ class TestCreateOnlyDefault:
 
     def test_create_only_default_callable_sets_context(self):
         """
-        CreateOnlyDefault instances with a callable default should set_context
+        CreateOnlyDefault instances with a callable default should set context
         on the callable if possible
         """
         class TestCallableDefault:


### PR DESCRIPTION
Per the deprecation warnings (which have been raised since DRF 3.11),
`set_context()` was planned not to be supported in DRF 3.13. I think we
can safely delete it, in favor of `requires_context`.

Since this represents an API change, maybe it's best slated for 3.14?
(We could alternatively start raising `RemovedInDRF314Warning`)

From the 3.11 announcement:

> Previous our approach to this was that implementations could include a
> `set_context` method, which would be called prior to validation. However
> this approach had issues with potential race conditions. We have now
> move this approach into a pending deprecation state. It will continue to
> function, but will be escalated to a deprecated state in 3.12, and
> removed entirely in 3.13.

Why keep `RemovedInDRF313Warning` around?
=========================================
It's a bit odd that version 3.13 includes an exception class describing
things which are to be deleted in 3.13, but I've opted to keep the (now
unreferenced) class around, for fear of breaking others' setup.

(For example, if projects have a `filterwarnings` setup meant to
intercept `rest_framework.RemovedInDRF313Warning`, an error will be
thrown due to an unresolvable reference).