### PR TITLE
Fix setuptools warning about license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE.md
+license_files = LICENSE.md
 
 [tool:pytest]
 addopts=--tb=short --strict-markers -ra


### PR DESCRIPTION
Fix this warning from setuptools:

```
/.../setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
```

It could be seen at the top of the wheel building command run on CI:

```
python3 setup.py bdist_wheel 2>&1 | head
```

(It would be best to use [`build`](https://pypi.org/project/build/) these days)