### PR TITLE
Fixes that namespaced views now also appear in the extra actions

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -201,7 +201,7 @@ class ViewSetMixin:
                 namespace = self.request.resolver_match.namespace
                 if namespace:
                     url_name = '%s:%s' % (namespace, url_name)
-                
+
                 url = reverse(url_name, self.args, self.kwargs, request=self.request)
                 view = self.__class__(**action.kwargs)
                 action_urls[view.get_view_name()] = url

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -198,6 +198,10 @@ class ViewSetMixin:
         for action in actions:
             try:
                 url_name = '%s-%s' % (self.basename, action.url_name)
+                namespace = self.request.resolver_match.namespace
+                if namespace:
+                    url_name = '%s:%s' % (namespace, url_name)
+                
                 url = reverse(url_name, self.args, self.kwargs, request=self.request)
                 view = self.__class__(**action.kwargs)
                 action_urls[view.get_view_name()] = url


### PR DESCRIPTION
Before this fix, namespaced views would not appear in the extra actions. With this fix they do.

See issue https://github.com/encode/django-rest-framework/issues/8463 and discussion https://github.com/encode/django-rest-framework/discussions/7816

Closes #8463


