### PR TITLE
Use .get() to find correct kwargs field and avoid KeyError

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -335,7 +335,7 @@ For example, if you need to lookup objects based on multiple fields in the URL c
             queryset = self.filter_queryset(queryset)  # Apply any filter backends
             filter = {}
             for field in self.lookup_fields:
-                if self.kwargs[field]: # Ignore empty fields.
+                if self.kwargs.get(field): # Ignore empty fields.
                     filter[field] = self.kwargs[field]
             obj = get_object_or_404(queryset, **filter)  # Lookup the object
             self.check_object_permissions(self.request, obj)


### PR DESCRIPTION
In the "Creating custom mixins" documentation, the code example recommends using
```python
if self.kwargs[field]
```
However, if the correct field is not present in kwargs, a KeyError arises.
A more secure option is tu use .get() to validate that the field is contained in the kwargs dictionary:
```python
if self.kwargs.get(field)
```

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
