### PR TITLE
Update Twitter handle of project's author in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Please see the [security policy][security-policy].
 [codecov]: https://codecov.io/github/encode/django-rest-framework?branch=master
 [pypi-version]: https://img.shields.io/pypi/v/djangorestframework.svg
 [pypi]: https://pypi.org/project/djangorestframework/
-[twitter]: https://twitter.com/_tomchristie
+[twitter]: https://twitter.com/starletdreaming
 [group]: https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework
 [sandbox]: https://restframework.herokuapp.com/
 


### PR DESCRIPTION
Update Twitter of the project's author. It seems that the project author's Twitter handle has changed over the time, and [_tomchristie](https://twitter.com/_tomchristie) is now used by someone else.


A tweet of project's author in the Web Archive.

![image](https://user-images.githubusercontent.com/9450980/185102456-b4bebbc0-40ae-4aea-8c7f-5341aabf278e.png)

https://web.archive.org/web/20180828104335/https://twitter.com/_tomchristie

That same tweet in Twitter now.
https://twitter.com/starletdreaming/status/1030486286560321536