### PR TITLE
Minor fix to SerializerMethodField docstring

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1832,7 +1832,7 @@ class SerializerMethodField(Field):
 
     For example:
 
-    class ExampleSerializer(self):
+    class ExampleSerializer(Serializer):
         extra_info = SerializerMethodField()
 
         def get_extra_info(self, obj):


### PR DESCRIPTION
## Description

Very minor fix to `SerializerMethodField` docstring. It now follows the same pattern as the example in the docstring of `ReadOnlyField `