### PR TITLE
both statement have dupplicate bodies

### DIFF
--- a/rest_framework/static/rest_framework/docs/js/api.js
+++ b/rest_framework/static/rest_framework/docs/js/api.js
@@ -131,13 +131,7 @@ $(function () {
         if (value !== undefined) {
           params[paramKey] = value
         }
-      } else if (dataType === 'array' && paramValue) {
-        try {
-          params[paramKey] = JSON.parse(paramValue)
-        } catch (err) {
-          // Ignore malformed JSON
-        }
-      } else if (dataType === 'object' && paramValue) {
+      } else if ((dataType === 'array' && paramValue) || (dataType === 'object' && paramValue)) {
         try {
           params[paramKey] = JSON.parse(paramValue)
         } catch (err) {


### PR DESCRIPTION
Both statement contained same bodies

..
} else if (dataType === 'array' && paramValue) {
    try {
      params[paramKey] = JSON.parse(paramValue)
    } catch (err) {
      // Ignore malformed JSON
    }
  } else if (dataType === 'object' && paramValue) {
    try {
      params[paramKey] = JSON.parse(paramValue)
    } catch (err) {
      // Ignore malformed JSON
    }
  }
..