### PR TITLE
Update authtoken admin to make "user" a raw_id_field

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -22,6 +22,7 @@ class TokenChangeList(ChangeList):
 
 class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
+    raw_id_fields = ('user',)
     fields = ('user',)
     ordering = ('-created',)
     actions = None  # Actions not compatible with mapped IDs.


### PR DESCRIPTION
This PR Adds the "user" field of Token to the list of `raw_id_fields` in
the TokenAdmin class.

If you have a large number of users this page will attempt to load your
entire User model dataset into a select box, which will likely time out
/ crash the admin site.

(I appreciate that this does _not_ reference an open issue, so am opening
it speculatively, but it's so trivial I thought I'd chance it.)
