### PR TITLE
Update supported versions for 3.14 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ There is a live example API for testing purposes, [available here][sandbox].
 
 # Requirements
 
-* Python (3.6, 3.7, 3.8, 3.9, 3.10)
-* Django (2.2, 3.0, 3.1, 3.2, 4.0, 4.1)
+* Python 3.6+
+* Django 4.1, 4.0, 3.2, 3.1, 3.0
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/docs/community/3.14-announcement.md
+++ b/docs/community/3.14-announcement.md
@@ -26,7 +26,7 @@ The latest release now fully supports Django 4.1.
 Our requirements are now:
 
 * Python 3.6+
-* Django 4.1, 4.0, 3.2, 3.1, 2.2 (LTS)
+* Django 4.1, 4.0, 3.2, 3.1, 3.0
 
 ## `raise_exceptions` argument for `is_valid` is now keyword-only.
 

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -219,8 +219,8 @@ class SessionAuthTests(TestCase):
         Ensure POSTing form over session authentication with CSRF token succeeds.
         Regression test for #6088
         """
-        # Remove this shim when dropping support for Django 2.2.
-        if django.VERSION < (3, 0):
+        # Remove this shim when dropping support for Django 3.0.
+        if django.VERSION < (3, 1):
             from django.middleware.csrf import _get_new_csrf_token
         else:
             from django.middleware.csrf import (

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py36,py37,py38,py39}-django22,
+       {py36,py37,py38,py39}-django30,
        {py36,py37,py38,py39}-django31,
        {py36,py37,py38,py39,py310}-django32,
        {py38,py39,py310}-{django40,django41,djangomain},
@@ -8,7 +8,7 @@ envlist =
 
 [travis:env]
 DJANGO =
-    2.2: django22
+    3.0: django30
     3.1: django31
     3.2: django32
     4.0: django40
@@ -22,7 +22,7 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django22: Django>=2.2,<3.0
+        django30: Django>=3.0,<3.1
         django31: Django>=3.1,<3.2
         django32: Django>=3.2,<4.0
         django40: Django>=4.0,<4.1


### PR DESCRIPTION
Update supported versions in line with this proposal...

https://github.com/encode/django-rest-framework/pull/8518#issuecomment-1247915701

---

* We release new versions of REST framework twice a year. Same [as for Django](https://www.djangoproject.com/download/#supported-versions).
* We aim each new release to arrive shortly after each Django release.
* We always support the latest 5 Django releases.
* We support whichever Python versions are required by Django.

Why "support the latest 5 Django releases"? Well, because I'd like it to always be a simple fixed number, and (unless I'm messing this up?) that's the lowest number we could pick that ensures we never drop a Django version that's still covered by their "extended support" policy.

![release-roadmap 4cf783b31fbe](https://user-images.githubusercontent.com/647359/190382056-85cd7bbe-7c85-428e-877c-711c59480a09.png)

The implication for our upcoming [3.14 release](https://github.com/encode/django-rest-framework/pull/8599) is that we ought to support...

* Django 3.0, 3.1, 3.2, 4.0, 4.1.
* Python 3.6+. (See the Meta section of https://pypi.org/project/Django/3.0/)
