### PR TITLE
Remove old deprecation classes for 3.14 release

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -29,13 +29,5 @@ if django.VERSION < (3, 2):
     default_app_config = 'rest_framework.apps.RestFrameworkConfig'
 
 
-class RemovedInDRF313Warning(DeprecationWarning):
-    pass
-
-
-class RemovedInDRF314Warning(PendingDeprecationWarning):
-    pass
-
-
 class RemovedInDRF315Warning(PendingDeprecationWarning):
     pass


### PR DESCRIPTION
When DRF 3.14 is released, these exception classes will be meaningless, so we can delete them (this has always been done).

A previous PR removed the last incidence of `RemovedInDRF313Warning`, but didn't outright delete the class for fear of shipping a breaking
change: https://github.com/encode/django-rest-framework/pull/8589