### PR TITLE
Use correct class to indicate present deprecation

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -37,5 +37,5 @@ class RemovedInDRF314Warning(PendingDeprecationWarning):
     pass
 
 
-class RemovedInDRF315Warning(PendingDeprecationWarning):
+class RemovedInDRF315Warning(DeprecationWarning):
     pass


### PR DESCRIPTION
`PendingDeprecationWarning` means "we plan to deprecate, but haven't yet." A feature that's to be deleted in the next release is not planned to be deprecated; it **is** deprecated.

> Base class for warnings about features which are obsolete and expected
> to be deprecated in the future, but are not deprecated at the moment.
>
> This class is _**rarely used**_ as emitting a warning about a possible
> upcoming deprecation is unusual, and _**DeprecationWarning is preferred**_ for
> already active deprecations.

(emphasis mine)

https://docs.python.org/3/library/exceptions.html#PendingDeprecationWarning