### PR TITLE
Update setup.py to drop Django 2.2 and update release notes

### DIFF
--- a/docs/community/3.14-announcement.md
+++ b/docs/community/3.14-announcement.md
@@ -21,7 +21,7 @@
 
 ## Django 4.1 support
 
-The latest release now fully supports Django 4.1.
+The latest release now fully supports Django 4.1, and drops support for Django 2.2.
 
 Our requirements are now:
 

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -40,8 +40,10 @@ You can determine your currently installed version using `pip show`:
 
 Date: 22nd September 2022
 
+* Django 2.2 is no longer supported. [[#8662](https://github.com/encode/django-rest-framework/pull/8662)]
+* Django 4.1 compatibility. [[#8591](https://github.com/encode/django-rest-framework/pull/8591)]
+* Add `--api-version` CLI option to `generateschema` management command. [[#8663](https://github.com/encode/django-rest-framework/pull/8663)]
 * Enforce `is_valid(raise_exception=False)` as a keyword-only argument. [[#7952](https://github.com/encode/django-rest-framework/pull/7952)]
-* Django 4.1 compatability. [[#8591](https://github.com/encode/django-rest-framework/pull/8591)]
 * Stop calling `set_context` on Validators. [[#8589](https://github.com/encode/django-rest-framework/pull/8589)]
 * Return `NotImplemented` from `ErrorDetails.__ne__`. [[#8538](https://github.com/encode/django-rest-framework/pull/8538)]
 * Don't evaluate `DateTimeField.default_timezone` when a custom timezone is set. [[#8531](https://github.com/encode/django-rest-framework/pull/8531)]

--- a/setup.py
+++ b/setup.py
@@ -82,14 +82,13 @@ setup(
     author_email='tom@tomchristie.com',  # SEE NOTE BELOW (*)
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=["django>=2.2", "pytz"],
+    install_requires=["django>=3.0", "pytz"],
     python_requires=">=3.6",
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',


### PR DESCRIPTION
As prompted by https://github.com/encode/django-rest-framework/pull/8599#issuecomment-1254371840
