### PR TITLE
Minor refactor: Unnecessary list comprehension

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -88,7 +88,7 @@ class ViewInspector:
                                                  view.get_view_description())
 
     def _get_description_section(self, view, header, description):
-        lines = [line for line in description.splitlines()]
+        lines = list(description.splitlines())
         current_section = ''
         sections = {'': ''}
 


### PR DESCRIPTION
Unnecessary list comprehension. Refactored using list().

Both perform the same task but in
[line for line in description.splitlines()]
You manually iterate over description causing heigh time complexity.
