### PR TITLE
Minor refactor: Unnecessary use of list() function

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -88,7 +88,7 @@ class ViewInspector:
                                                  view.get_view_description())
 
     def _get_description_section(self, view, header, description):
-        lines = list(description.splitlines())
+        lines = description.splitlines()
         current_section = ''
         sections = {'': ''}
 


### PR DESCRIPTION
as **joncle** mentioned in [this message](https://github.com/encode/django-rest-framework/pull/8670#issuecomment-1258174101) that **.splitlines()** already returns a list type so no need to call **list()**  function here.
