### PR TITLE
make `enforce_csrf` a class method

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -132,7 +132,8 @@ class SessionAuthentication(BaseAuthentication):
         # CSRF passed with authenticated user
         return (user, None)
 
-    def enforce_csrf(self, request):
+    @classmethod
+    def enforce_csrf(cls, request):
         """
         Enforce CSRF validation for session based authentication.
         """


### PR DESCRIPTION
## Description

Make `enforce_csrf` a class method so it can be used by other code (#8436).
Making this a class-method won't change the API and still offer the flexibility of using this function from outside of `SessionAuthentication`