### PR TITLE
Added examples to schema of CursorPagination

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -898,10 +898,16 @@ class CursorPagination(BasePagination):
                 'next': {
                     'type': 'string',
                     'nullable': True,
+                    'format': 'uri',
+                    'example': 'http://api.example.org/accounts/?{cursor_query_param}=cD00ODY%3D"'.format(
+                        cursor_query_param=self.cursor_query_param)
                 },
                 'previous': {
                     'type': 'string',
                     'nullable': True,
+                    'format': 'uri',
+                    'example': 'http://api.example.org/accounts/?{cursor_query_param}=cj0xJnA9NDg3'.format(
+                        cursor_query_param=self.cursor_query_param)
                 },
                 'results': schema,
             },


### PR DESCRIPTION
Fix https://github.com/encode/django-rest-framework/issues/8686

Added missing examples for CursorPagination class to disable warnings in https://github.com/tfranzel/drf-spectacular and make it consistent with other pagination classes.
