### PR TITLE
Docs: describe "public" attribute in get_schema_view() docuentation.

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -122,6 +122,7 @@ The `get_schema_view()` helper takes the following keyword arguments:
             url='https://www.example.org/api/',
             patterns=schema_url_patterns,
         )
+* `public`: May be used to specify if schema should bypass views permissions. Default to False
 
 * `generator_class`: May be used to specify a `SchemaGenerator` subclass to be
   passed to the `SchemaView`.


### PR DESCRIPTION
I was doing docs for my API and unfortunately run into issue with some endpoints. It turned out that because of required permissions few of the classes wasn't included in *api schema*. I was looking for some help in documentation, but for nothing. After some time I found in source code `public` that i needed. This attribute wasn't described anywhere in the docs so I thought it will be nice to describe it.