### PR TITLE
Add `__eq__` method for `permissions.OperandHolder` class

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -46,6 +46,14 @@ class OperandHolder(OperationHolderMixin):
         op2 = self.op2_class(*args, **kwargs)
         return self.operator_class(op1, op2)
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, OperandHolder) and
+            self.operator_class == other.operator_class and
+            self.op1_class == other.op1_class and
+            self.op2_class == other.op2_class
+        )
+
 
 class AND:
     def __init__(self, op1, op2):


### PR DESCRIPTION
The reason behind this proposal is to fully enable `permission_classes` comparison, e.g. in tests:

```python
# myapp/views.py

from rest_framework.views import APIView
from rest_framework.permissions import IsAdminUser
from myapp.permissions import MyPermission


class MyView(APIView):
    permission_classes = [MyPermission | IsAdminUser]
    # ...
```

```python
# myapp/tests/views/test_my_view.py

from myapp.views import MyView
from rest_framework.permissions import IsAdminUser
from myapp.permissions import MyPermission


def test__permission_classes():
    cls = MyView
    assert cls.permission_classes == [MyPermission | IsAdminUser]
```

I'd love to submit an actual test, but being a first-time contributor here I'm not sure where and how exactly would it fit in just by looking at `tests/test_permissions.py`.

Have a nice day!