### PR TITLE
Remove extraneous word "Both"

### DIFF
--- a/docs/api-guide/parsers.md
+++ b/docs/api-guide/parsers.md
@@ -87,7 +87,7 @@ You will typically want to use both `FormParser` and `MultiPartParser` together 
 
 ## MultiPartParser
 
-Parses multipart HTML form content, which supports file uploads. `request.data` will be populated with a `QueryDict`.
+Parses multipart HTML form content, which supports file uploads. `request.data` and `request.FILES` will be populated with a `QueryDict` and `MultiValueDict` respectively.
 
 You will typically want to use both `FormParser` and `MultiPartParser` together in order to fully support HTML form data.
 

--- a/docs/api-guide/parsers.md
+++ b/docs/api-guide/parsers.md
@@ -87,7 +87,7 @@ You will typically want to use both `FormParser` and `MultiPartParser` together 
 
 ## MultiPartParser
 
-Parses multipart HTML form content, which supports file uploads.  Both `request.data` will be populated with a `QueryDict`.
+Parses multipart HTML form content, which supports file uploads. `request.data` will be populated with a `QueryDict`.
 
 You will typically want to use both `FormParser` and `MultiPartParser` together in order to fully support HTML form data.
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description
- Removes the word "Both" which appears to be out of place.

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
