### PR TITLE
Fix Pytest's deprecation warnings about nose usage

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -239,7 +239,7 @@ class TestSource:
 
 
 class TestReadOnly:
-    def setup(self):
+    def setup_method(self):
         class TestSerializer(serializers.Serializer):
             read_only = serializers.ReadOnlyField(default="789")
             writable = serializers.IntegerField()
@@ -271,7 +271,7 @@ class TestReadOnly:
 
 
 class TestWriteOnly:
-    def setup(self):
+    def setup_method(self):
         class TestSerializer(serializers.Serializer):
             write_only = serializers.IntegerField(write_only=True)
             readable = serializers.IntegerField()
@@ -296,7 +296,7 @@ class TestWriteOnly:
 
 
 class TestInitial:
-    def setup(self):
+    def setup_method(self):
         class TestSerializer(serializers.Serializer):
             initial_field = serializers.IntegerField(initial=123)
             blank_field = serializers.IntegerField()
@@ -313,7 +313,7 @@ class TestInitial:
 
 
 class TestInitialWithCallable:
-    def setup(self):
+    def setup_method(self):
         def initial_value():
             return 123
 
@@ -331,7 +331,7 @@ class TestInitialWithCallable:
 
 
 class TestLabel:
-    def setup(self):
+    def setup_method(self):
         class TestSerializer(serializers.Serializer):
             labeled = serializers.IntegerField(label='My label')
         self.serializer = TestSerializer()
@@ -345,7 +345,7 @@ class TestLabel:
 
 
 class TestInvalidErrorKey:
-    def setup(self):
+    def setup_method(self):
         class ExampleField(serializers.Field):
             def to_native(self, data):
                 self.fail('incorrect')
@@ -539,7 +539,7 @@ class TestHTMLInput:
 
 
 class TestCreateOnlyDefault:
-    def setup(self):
+    def setup_method(self):
         default = serializers.CreateOnlyDefault('2001-01-01')
 
         class TestSerializer(serializers.Serializer):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -18,7 +18,7 @@ class TestPaginationIntegration:
     Integration tests.
     """
 
-    def setup(self):
+    def setup_method(self):
         class PassThroughSerializer(serializers.BaseSerializer):
             def to_representation(self, item):
                 return item
@@ -140,7 +140,7 @@ class TestPaginationDisabledIntegration:
     Integration tests for disabled pagination.
     """
 
-    def setup(self):
+    def setup_method(self):
         class PassThroughSerializer(serializers.BaseSerializer):
             def to_representation(self, item):
                 return item
@@ -163,7 +163,7 @@ class TestPageNumberPagination:
     Unit tests for `pagination.PageNumberPagination`.
     """
 
-    def setup(self):
+    def setup_method(self):
         class ExamplePagination(pagination.PageNumberPagination):
             page_size = 5
 
@@ -302,7 +302,7 @@ class TestPageNumberPaginationOverride:
     the Django Paginator Class is overridden.
     """
 
-    def setup(self):
+    def setup_method(self):
         class OverriddenDjangoPaginator(DjangoPaginator):
             # override the count in our overridden Django Paginator
             # we will only return one page, with one item
@@ -358,7 +358,7 @@ class TestLimitOffset:
     Unit tests for `pagination.LimitOffsetPagination`.
     """
 
-    def setup(self):
+    def setup_method(self):
         class ExamplePagination(pagination.LimitOffsetPagination):
             default_limit = 10
             max_limit = 15
@@ -941,7 +941,7 @@ class TestCursorPagination(CursorPaginationTestsMixin):
     Unit tests for `pagination.CursorPagination`.
     """
 
-    def setup(self):
+    def setup_method(self):
         class MockObject:
             def __init__(self, idx):
                 self.created = idx

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -374,7 +374,7 @@ class TestManyRelatedField(APISimpleTestCase):
 
 
 class TestHyperlink:
-    def setup(self):
+    def setup_method(self):
         self.default_hyperlink = serializers.Hyperlink('http://example.com', 'test')
 
     def test_can_be_pickled(self):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -61,7 +61,7 @@ class TestFieldImports:
 # -----------------------------
 
 class TestSerializer:
-    def setup(self):
+    def setup_method(self):
         class ExampleSerializer(serializers.Serializer):
             char = serializers.CharField()
             integer = serializers.IntegerField()
@@ -240,7 +240,7 @@ class TestValidateMethod:
 
 
 class TestBaseSerializer:
-    def setup(self):
+    def setup_method(self):
         class ExampleSerializer(serializers.BaseSerializer):
             def to_representation(self, obj):
                 return {
@@ -337,7 +337,7 @@ class TestStarredSource:
         'nested2': {'c': 3, 'd': 4}
     }
 
-    def setup(self):
+    def setup_method(self):
         class NestedSerializer1(serializers.Serializer):
             a = serializers.IntegerField()
             b = serializers.IntegerField()
@@ -463,7 +463,7 @@ class TestNotRequiredOutput:
 
 
 class TestDefaultOutput:
-    def setup(self):
+    def setup_method(self):
         class ExampleSerializer(serializers.Serializer):
             has_default = serializers.CharField(default='x')
             has_default_callable = serializers.CharField(default=lambda: 'y')
@@ -584,7 +584,7 @@ class TestCacheSerializerData:
 
 
 class TestDefaultInclusions:
-    def setup(self):
+    def setup_method(self):
         class ExampleSerializer(serializers.Serializer):
             char = serializers.CharField(default='abc')
             integer = serializers.IntegerField()
@@ -612,7 +612,7 @@ class TestDefaultInclusions:
 
 
 class TestSerializerValidationWithCompiledRegexField:
-    def setup(self):
+    def setup_method(self):
         class ExampleSerializer(serializers.Serializer):
             name = serializers.RegexField(re.compile(r'\d'), required=True)
         self.Serializer = ExampleSerializer
@@ -641,7 +641,7 @@ class Test2555Regression:
 
 
 class Test4606Regression:
-    def setup(self):
+    def setup_method(self):
         class ExampleSerializer(serializers.Serializer):
             name = serializers.CharField(required=True)
             choices = serializers.CharField(required=True)

--- a/tests/test_serializer_lists.py
+++ b/tests/test_serializer_lists.py
@@ -32,7 +32,7 @@ class TestListSerializer:
     Note that this is in contrast to using ListSerializer as a field.
     """
 
-    def setup(self):
+    def setup_method(self):
         class IntegerListSerializer(serializers.ListSerializer):
             child = serializers.IntegerField()
         self.Serializer = IntegerListSerializer
@@ -70,7 +70,7 @@ class TestListSerializerContainingNestedSerializer:
     Tests for using a ListSerializer containing another serializer.
     """
 
-    def setup(self):
+    def setup_method(self):
         class TestSerializer(serializers.Serializer):
             integer = serializers.IntegerField()
             boolean = serializers.BooleanField()
@@ -156,7 +156,7 @@ class TestNestedListSerializer:
     Tests for using a ListSerializer as a field.
     """
 
-    def setup(self):
+    def setup_method(self):
         class TestSerializer(serializers.Serializer):
             integers = serializers.ListSerializer(child=serializers.IntegerField())
             booleans = serializers.ListSerializer(child=serializers.BooleanField())
@@ -278,7 +278,7 @@ class TestNestedListSerializerAllowEmpty:
 
 
 class TestNestedListOfListsSerializer:
-    def setup(self):
+    def setup_method(self):
         class TestSerializer(serializers.Serializer):
             integers = serializers.ListSerializer(
                 child=serializers.ListSerializer(
@@ -594,7 +594,7 @@ class TestEmptyListSerializer:
     Tests the behaviour of ListSerializers when there is no data passed to it
     """
 
-    def setup(self):
+    def setup_method(self):
         class ExampleListSerializer(serializers.ListSerializer):
             child = serializers.IntegerField()
 
@@ -623,7 +623,7 @@ class TestMaxMinLengthListSerializer:
     Tests the behaviour of ListSerializers when max_length and min_length are used
     """
 
-    def setup(self):
+    def setup_method(self):
         class IntegerSerializer(serializers.Serializer):
             some_int = serializers.IntegerField()
 

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -9,7 +9,7 @@ from rest_framework.serializers import raise_errors_on_nested_writes
 
 
 class TestNestedSerializer:
-    def setup(self):
+    def setup_method(self):
         class NestedSerializer(serializers.Serializer):
             one = serializers.IntegerField(max_value=10)
             two = serializers.IntegerField(max_value=10)
@@ -54,7 +54,7 @@ class TestNestedSerializer:
 
 
 class TestNotRequiredNestedSerializer:
-    def setup(self):
+    def setup_method(self):
         class NestedSerializer(serializers.Serializer):
             one = serializers.IntegerField(max_value=10)
 
@@ -83,7 +83,7 @@ class TestNotRequiredNestedSerializer:
 
 
 class TestNestedSerializerWithMany:
-    def setup(self):
+    def setup_method(self):
         class NestedSerializer(serializers.Serializer):
             example = serializers.IntegerField(max_value=10)
 
@@ -181,7 +181,7 @@ class TestNestedSerializerWithMany:
 
 
 class TestNestedSerializerWithList:
-    def setup(self):
+    def setup_method(self):
         class NestedSerializer(serializers.Serializer):
             example = serializers.MultipleChoiceField(choices=[1, 2, 3])
 
@@ -210,7 +210,7 @@ class TestNestedSerializerWithList:
 
 
 class TestNotRequiredNestedSerializerWithMany:
-    def setup(self):
+    def setup_method(self):
         class NestedSerializer(serializers.Serializer):
             one = serializers.IntegerField(max_value=10)
 


### PR DESCRIPTION
Pytest 7.2.0 deprecated plain `setup` and `teardown` functions and methods as nose idioms:
https://docs.pytest.org/en/latest/changelog.html#pytest-7-2-0-2022-10-23

`setup` can be safely replaced with `setup_method`:
https://docs.pytest.org/en/stable/deprecations.html#setup-teardown

Closes #8757
