### PR TITLE
Fix #8771 - Checking for authentication even if `_ignore_model_permissions = True`

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -228,14 +228,14 @@ class DjangoModelPermissions(BasePermission):
         return view.queryset
 
     def has_permission(self, request, view):
+        if not request.user or (
+           not request.user.is_authenticated and self.authenticated_users_only):
+            return False
+
         # Workaround to ensure DjangoModelPermissions are not applied
         # to the root view when using DefaultRouter.
         if getattr(view, '_ignore_model_permissions', False):
             return True
-
-        if not request.user or (
-           not request.user.is_authenticated and self.authenticated_users_only):
-            return False
 
         queryset = self._queryset(view)
         perms = self.get_required_permissions(request.method, queryset.model)


### PR DESCRIPTION
## Description

Refs #8771 , refs #8425 

We should check for authentication even when the `_ignore_model_permissions` flag is set to `True`.
Otherwise it will bypass the check for authentication, not only the one for permissions