### PR TITLE
Register Django urls

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -132,6 +132,8 @@ Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
         path('', include(router.urls)),
         path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
+    
+    urlpatterns += router.urls
 
 Because we're using viewsets instead of views, we can automatically generate the URL conf for our API, by simply registering the viewsets with a router class.
 


### PR DESCRIPTION
Without adding the URLs manually, the users and groups APIs were not usable.

My env:
(venv) ➜  tutorial pip freeze
asgiref==3.5.2
astroid==2.12.13
autopep8==2.0.0
dill==0.3.6
Django==4.1.3
djangorestframework==3.14.0
isort==5.10.1
lazy-object-proxy==1.8.0
mccabe==0.7.0
platformdirs==2.5.4
pycodestyle==2.10.0
pylint==2.15.6
pylint-django==2.5.3
pylint-plugin-utils==0.7
pytz==2022.6
sqlparse==0.4.3
tomli==2.0.1
tomlkit==0.11.6
wrapt==1.14.1

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
