### PR TITLE
Fix bug in validators documentation

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -271,6 +271,7 @@ A validator may be any callable that raises a `serializers.ValidationError` on f
     def even_number(value):
         if value % 2 != 0:
             raise serializers.ValidationError('This field must be an even number.')
+        return value
 
 #### Field-level validation
 


### PR DESCRIPTION
Function validators seem to have to return their value (which will become part of `validated_data`) as part of their signature.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
