### PR TITLE
mitigate global dependency on inflection #8017

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -11,7 +11,6 @@ from django.core.validators import (
 )
 from django.db import models
 from django.utils.encoding import force_str
-from inflection import pluralize
 
 from rest_framework import (
     RemovedInDRF315Warning, exceptions, renderers, serializers
@@ -249,6 +248,8 @@ class AutoSchema(ViewInspector):
                 name = name[:-len(action)]
 
         if action == 'list':
+            from inflection import pluralize
+
             name = pluralize(name)
 
         return name


### PR DESCRIPTION
#8017 indirectly introduced a new hard dependency. `rest_framework.openapi.AutoSchema` is imported in the default settings, which makes this a new dependency for nearly everyone. That is the reason why the builds are failing at the moment, as the `tox -e base` target does not install the optionals.

So either we move that newly introduced import out of the main code path or DRF needs to gain that dependency in `setup.py`, which would probably be excessive.
