### PR TITLE
Remove a bit of inline CSS. Add CSP nonce where it might be required and is available.

### DIFF
--- a/rest_framework/static/rest_framework/css/bootstrap-tweaks.css
+++ b/rest_framework/static/rest_framework/css/bootstrap-tweaks.css
@@ -231,3 +231,7 @@ body a:hover {
   margin-left: 5px;
   margin-right: 5px;
 }
+
+.pagination {
+  margin: 5px 0 10px 0;
+}

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -158,19 +158,19 @@
               <div class="page-header">
                 <h1>{{ name }}</h1>
               </div>
-              <div style="float:left">
+              <div class="pull-left">
                 {% block description %}
                   {{ description }}
                 {% endblock %}
               </div>
 
               {% if paginator %}
-                <nav style="float: right">
+                <nav class="pull-right">
                   {% get_pagination_html paginator %}
                 </nav>
               {% endif %}
 
-              <div class="request-info" style="clear: both" aria-label="{% trans "request info" %}">
+              <div class="request-info" aria-label="{% trans "request info" %}">
                 <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
               </div>
 

--- a/rest_framework/templates/rest_framework/pagination/numbers.html
+++ b/rest_framework/templates/rest_framework/pagination/numbers.html
@@ -1,4 +1,4 @@
-<ul class="pagination" style="margin: 5px 0 10px 0">
+<ul class="pagination">
   {% if previous_url %}
     <li>
       <a href="{{ previous_url }}" aria-label="Previous">


### PR DESCRIPTION
(Copied from https://github.com/encode/django-rest-framework/pull/7960, but nonce removed to avoid conflicts with user-defined policies)

Remove a few instances of inline CSS which could trigger Content Security Policies (CSPs) and replace with classes where required.

Part of https://github.com/encode/django-rest-framework/issues/6069.

I've left JavaScript alone as it's covered by https://github.com/encode/django-rest-framework/pull/5740 and https://github.com/encode/django-rest-framework/pull/7016 (which I think are duplicates of each other?).