### PR TITLE
Changes to make browsable API compatbile with strong CSP

### DIFF
--- a/rest_framework/static/rest_framework/js/load-ajax-form.js
+++ b/rest_framework/static/rest_framework/js/load-ajax-form.js
@@ -1,0 +1,3 @@
+$(document).ready(function() {
+  $('form').ajaxForm();
+});

--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -256,11 +256,7 @@
         <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
         <script src="{% static "rest_framework/js/prettify-min.js" %}"></script>
         <script src="{% static "rest_framework/js/default.js" %}"></script>
-        <script>
-          $(document).ready(function() {
-            $('form').ajaxForm();
-          });
-        </script>
+        <script src="{% static "rest_framework/js/load-ajax-form.js" %}"></script>
       {% endblock %}
     </body>
   {% endblock %}

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -299,11 +299,7 @@
       <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
       <script src="{% static "rest_framework/js/prettify-min.js" %}"></script>
       <script src="{% static "rest_framework/js/default.js" %}"></script>
-      <script>
-        $(document).ready(function() {
-          $('form').ajaxForm();
-        });
-      </script>
+      <script src="{% static "rest_framework/js/load-ajax-form.js" %}"></script>
     {% endblock %}
 
   </body>


### PR DESCRIPTION
(Copied from https://github.com/encode/django-rest-framework/pull/5740, conflicting CSRF changes removed. These were already handled as part of https://github.com/encode/django-rest-framework/pull/7016)

Currently the browsable API contains inline JS for configuring forms and allowing for custom CSRF cookie/header names. Use of CSP with this page requires 'unsafe-inline'.

This patch is a concept for getting rid of all inline scripts from the browsable API. It's not tested, as I just wanted to see if there was interest in merging this before I spend too much time on it.
