### PR TITLE
Set pk_field=UUIDField for UUID foreign keys

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1296,6 +1296,10 @@ class ModelSerializer(Serializer):
             field_kwargs['slug_field'] = to_field
             field_class = self.serializer_related_to_field
 
+        # `pk_field` is only valid for PrimaryKeyRelatedField
+        if not issubclass(field_class, PrimaryKeyRelatedField):
+            field_kwargs.pop('pk_field', None)
+
         # `view_name` is only valid for hyperlinked relationships.
         if not issubclass(field_class, HyperlinkedRelatedField):
             field_kwargs.pop('view_name', None)

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -265,6 +265,8 @@ def get_relation_kwargs(field_name, relation_info):
             kwargs.pop('queryset', None)
         if model_field.null:
             kwargs['allow_null'] = True
+        if isinstance(model_field.target_field, models.UUIDField):
+            kwargs['pk_field'] = models.UUIDField()
         if kwargs.get('read_only', False):
             # If this field is read-only, then return early.
             # No further keyword arguments are valid.

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -754,6 +754,20 @@ class TestUUIDForeignKeyMapping(TestCase):
         """)
         self.assertEqual(repr(TestSerializer()), expected)
 
+    def test_uuid_pk_relation_override(self):
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = UUIDForeignKeyModel
+                fields = '__all__'
+                extra_kwargs = {'foreign_key': {'pk_field': serializers.UUIDField(format='int')}}
+
+        expected = dedent("""
+            TestSerializer():
+                id = IntegerField(label='ID', read_only=True)
+                foreign_key = PrimaryKeyRelatedField(pk_field=UUIDField(format='int'), queryset=UUIDForeignKeyTarget.objects.all())
+        """)
+        self.assertEqual(repr(TestSerializer()), expected)
+
 
 class DisplayValueTargetModel(models.Model):
     name = models.CharField(max_length=100)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -27,7 +27,7 @@ from django.test import TestCase
 from rest_framework import serializers
 from rest_framework.compat import postgres_fields
 
-from .models import NestedForeignKeySource
+from .models import NestedForeignKeySource, UUIDForeignKeyTarget
 
 
 def dedent(blocktext):
@@ -732,6 +732,25 @@ class TestRelationalFieldMappings(TestCase):
                 id = IntegerField(label='ID', read_only=True)
                 name = CharField(max_length=100)
                 reverse_through = PrimaryKeyRelatedField(many=True, read_only=True)
+        """)
+        self.assertEqual(repr(TestSerializer()), expected)
+
+
+class UUIDForeignKeyModel(models.Model):
+    foreign_key = models.ForeignKey(UUIDForeignKeyTarget, related_name='reverse_foreign_key', on_delete=models.CASCADE)
+
+
+class TestUUIDForeignKeyMapping(TestCase):
+    def test_uuid_pk_relation(self):
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = UUIDForeignKeyModel
+                fields = '__all__'
+
+        expected = dedent("""
+            TestSerializer():
+                id = IntegerField(label='ID', read_only=True)
+                foreign_key = PrimaryKeyRelatedField(pk_field=<django.db.models.fields.UUIDField>, queryset=UUIDForeignKeyTarget.objects.all())
         """)
         self.assertEqual(repr(TestSerializer()), expected)
 


### PR DESCRIPTION
Updates `ModelSerializer`’s field generation to set `pk_field=UUIDField()` if the related field is `PrimaryKeyRelatedField` and the foreign key field on the model is a `UUIDField`.

[See this discussion for an explanation of why I think this change should be made](https://github.com/encode/django-rest-framework/discussions/8786)

### Compatibility

This could potentially break existing code if that code was relying on getting a `UUID` instance in `serializer.data`. This doesn’t apply once the data has been passed to the renderer, since AFAIK all built-in renderers will stringify `UUID`s.

### Alternatives

A potential alternative to this implementation would be for the behavior to be moved into `PrimaryKeyRelatedField` itself. In that case, the `pk_field` setting would apply even when used outside of `ModelSerializer` (unless overridden).
