### PR TITLE
Upgrade to tox 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       run: tox --py current
 
     - name: Run extra tox targets
-      if: ${{ matrix.python-version == '3.10' }}
+      if: ${{ matrix.python-version == '3.9' }}
       run: |
         python setup.py bdist_wheel
         rm -r djangorestframework.egg-info  # see #6139

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,7 @@ jobs:
     - name: Run extra tox targets
       if: ${{ matrix.python-version == '3.9' }}
       run: |
-        python setup.py bdist_wheel
-        rm -r djangorestframework.egg-info  # see #6139
         tox -e base,dist,docs
-        tox -e dist --installpkg ./dist/djangorestframework-*.whl
 
     - name: Upload coverage
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,17 @@ jobs:
     - name: Install dependencies
       run: python -m pip install --upgrade codecov tox
 
+    - name: Install tox-py
+      if: ${{ matrix.python-version == '3.6' }}
+      run: python -m pip install --upgrade tox-py
+
     - name: Run tox targets for ${{ matrix.python-version }}
+      if: ${{ matrix.python-version != '3.6' }}
       run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
+
+    - name: Run tox targets for ${{ matrix.python-version }}
+      if: ${{ matrix.python-version == '3.6' }}
+      run: tox --py current
 
     - name: Run extra tox targets
       if: ${{ matrix.python-version == '3.9' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       run: tox --py current
 
     - name: Run extra tox targets
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version == '3.11' }}
       run: |
         python setup.py bdist_wheel
         rm -r djangorestframework.egg-info  # see #6139

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       run: tox --py current
 
     - name: Run extra tox targets
-      if: ${{ matrix.python-version == '3.11' }}
+      if: ${{ matrix.python-version == '3.10' }}
       run: |
         python setup.py bdist_wheel
         rm -r djangorestframework.egg-info  # see #6139

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,10 @@ jobs:
       run: python -m pip install --upgrade pip setuptools virtualenv wheel
 
     - name: Install dependencies
-      run: python -m pip install --upgrade codecov tox tox-py
+      run: python -m pip install --upgrade codecov tox
 
     - name: Run tox targets for ${{ matrix.python-version }}
-      run: tox --py current
+      run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
 
     - name: Run extra tox targets
       if: ${{ matrix.python-version == '3.9' }}

--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,6 @@ envlist =
        {py311}-{django41,djangomain},
        base,dist,docs,
 
-[travis:env]
-DJANGO =
-    3.0: django30
-    3.1: django31
-    3.2: django32
-    4.0: django40
-    4.1: django41
-    main: djangomain
-
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning runtests.py --coverage {posargs}
 envdir = {toxworkdir}/venvs/{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
         -rrequirements/requirements-testing.txt
 
 [testenv:dist]
-commands = ./runtests.py --no-pkgroot --staticfiles {posargs}
+commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning runtests.py --no-pkgroot --staticfiles {posargs}
 deps =
         django
         -rrequirements/requirements-testing.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 envlist =
-       {py36,py37,py38,py39}-django30,
-       {py36,py37,py38,py39}-django31,
-       {py36,py37,py38,py39,py310}-django32,
-       {py38,py39,py310}-{django40,django41,djangomain},
-       {py311}-{django41,djangomain},
-       base,dist,docs,
+       {py36,py37,py38,py39}-django30
+       {py36,py37,py38,py39}-django31
+       {py36,py37,py38,py39,py310}-django32
+       {py38,py39,py310}-{django40,django41,djangomain}
+       {py311}-{django41,djangomain}
+       base
+       dist
+       docs
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning runtests.py --coverage {posargs}


### PR DESCRIPTION
Copy of [#458](https://github.com/django/daphne/pull/458) for this repo.

tox 4 has just been released: https://fosstodon.org/@gaborbernat/109473528072009278

tox-py no longer works with it, but that’s okay since the new `-f` factor option fills the need to run Python 3.X tests in the Python 3.X CI run. I documented this pattern in the package install instructions: https://github.com/adamchainz/tox-py/#installation . Plus, I’ve already changed all the projects I maintain to use it, for example: https://github.com/adamchainz/django-htmx/pull/296

tox 4 only supports Python 3.7+. I’ve added a temporary fork on Python version to retain running with old tox and tox-py on Python 3.6. I think we should drop Python 3.6 in a follow-up PR since it’s been EOL for a while now.