### PR TITLE
Update documentation regarding arguments of ValidationError

### DIFF
--- a/docs/api-guide/exceptions.md
+++ b/docs/api-guide/exceptions.md
@@ -217,11 +217,10 @@ By default this exception results in a response with the HTTP status code "429 T
 
 ## ValidationError
 
-**Signature:** `ValidationError(detail, code=None)`
+**Signature:** `ValidationError(detail=None, code=None)`
 
 The `ValidationError` exception is slightly different from the other `APIException` classes:
 
-* The `detail` argument is mandatory, not optional.
 * The `detail` argument may be a list or dictionary of error details, and may also be a nested data structure. By using a dictionary, you can specify field-level errors while performing object-level validation in the `validate()` method of a serializer. For example. `raise serializers.ValidationError({'name': 'Please enter a valid name.'})`
 * By convention you should import the serializers module and use a fully qualified `ValidationError` style, in order to differentiate it from Django's built-in validation error. For example. `raise serializers.ValidationError('This field must be an integer value.')`
 


### PR DESCRIPTION
The documentation used to state that the `detail` argument was mandatory, but in fact it currently is not.

Here is the line that defines the default argument:
https://github.com/encode/django-rest-framework/blob/master/rest_framework/exceptions.py#L148