### PR TITLE
fix transifex-client version in packaging requirements.

### DIFF
--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -5,4 +5,4 @@ wheel>=0.35.1,<0.36
 twine>=3.2.0,<3.3
 
 # Transifex client for managing translation resources.
-transifex-client>=0.13.12,<0.14
+transifex-client


### PR DESCRIPTION
Hello, first of all thanks for developing this great package!

## Description
During the setup of django-rest-framework on local environment, I observed that version of package 'transifex-client` throwing following error.

```
ERROR: Ignored the following versions that require a different python version: 0.13.0 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.6; 0.13.1 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.7; 0.13.10 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9; 0.13.11 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9; 0.13.12 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9; 0.13.2 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.7; 0.13.3 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.7; 0.13.4 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.8; 0.13.5 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.8; 0.13.6 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.8; 0.13.7 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9; 0.13.8 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9; 0.13.9 Requires-Python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9
ERROR: Could not find a version that satisfies the requirement transifex-client<0.14,>=0.13.12 (from versions: 0.1, 0.2, 0.2.1, 0.3, 0.4, 0.4.1, 0.5, 0.5.1, 0.5.2, 0.6, 0.6.1, 0.7, 0.7.2, 0.7.3, 0.8, 0.9, 0.9.1, 0.10, 0.11b0, 0.11b3, 0.11, 0.11.1b0, 0.12b0, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.14.0, 0.14.1, 0.14.2, 0.14.3, 0.14.4)
ERROR: No matching distribution found for transifex-client<0.14,>=0.13.12
```

However I am able to install the package by removing the version constraints (**transifex-client>=0.13.12,<0.14**) in requirements-packaging file. 

This PR fixes the version of transifex-client package.