### PR TITLE
Add search_fields attribute to SearchFilter

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -48,6 +48,7 @@ class SearchFilter(BaseFilterBackend):
     }
     search_title = _('Search')
     search_description = _('A search term.')
+    search_fields = None
 
     def get_search_fields(self, view, request):
         """
@@ -55,7 +56,7 @@ class SearchFilter(BaseFilterBackend):
         passed to this method. Sub-classes can override this method to
         dynamically change the search fields based on request content.
         """
-        return getattr(view, 'search_fields', None)
+        return getattr(view, 'search_fields', getattr(self, 'search_fields'))
 
     def get_search_terms(self, request):
         """


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

I suggest a small change in the API (backwards compatible) that will simplify some popular notation to express it as:

```
class CatOwnerNameSearchFilter(filters.SearchFilter):
    search_param = "owner"
    search_fields = ["first_name", "second_name"]


class CatNameSearchFilter(filters.SearchFilter):
    search_param = "name"
    search_fields = ["name"]

class CatViewSet(
    viewsets.ModelViewSet
):
    queryset = Cat.objects.order_by("pk")
    filter_backends = [
        CatOwnerNameSearchFilter,
        CatNameSearchFilter,
    ]
```

I can add the tests after I get preliminary approval for such a change in the API.