### PR TITLE
Use a more lenient dependency version range specification for pygments

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -6,5 +6,5 @@ django-guardian>=2.4.0,<2.5
 inflection==0.5.1
 markdown==3.3
 psycopg2-binary>=2.9.5,<2.10
-pygments==2.12
+pygments>=2.7.1,<3.0
 pyyaml>=5.3.1,<5.4

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -41,11 +41,8 @@ MARKDOWN_DOCSTRING = """<h2 id="an-example-docstring">an example docstring</h2>
 </code></pre>
 <p>indented</p>
 <h2 id="hash-style-header">hash style header</h2>
-<p><code>json
-[{
-    "alpha": 1,
-    "beta": "this is a string"
-}]</code></p>"""
+<div class="highlight"><pre><span></span><span class="p">[{</span><br /><span class="w">    </span><span class="nt">&quot;alpha&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">1</span><span class="p">,</span><br /><span class="w">    </span><span class="nt">&quot;beta&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;this is a string&quot;</span><br /><span class="p">}]</span><br /></pre></div>
+<p><br /></p>"""
 
 
 class TestViewNamesAndDescriptions(TestCase):

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -41,8 +41,11 @@ MARKDOWN_DOCSTRING = """<h2 id="an-example-docstring">an example docstring</h2>
 </code></pre>
 <p>indented</p>
 <h2 id="hash-style-header">hash style header</h2>
-<div class="highlight"><pre><span></span><span class="p">[{</span><span class="w"></span><br /><span class="w">    </span><span class="nt">&quot;alpha&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">1</span><span class="p">,</span><span class="w"></span><br /><span class="w">    </span><span class="nt">&quot;beta&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;this is a string&quot;</span><span class="w"></span><br /><span class="p">}]</span><span class="w"></span><br /></pre></div>
-<p><br /></p>"""
+<p><code>json
+[{
+    "alpha": 1,
+    "beta": "this is a string"
+}]</code></p>"""
 
 
 class TestViewNamesAndDescriptions(TestCase):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,6 +1,7 @@
 import re
 from collections import OrderedDict
 from collections.abc import MutableMapping
+from xml.etree import ElementTree
 
 import pytest
 from django.core.cache import cache
@@ -852,7 +853,8 @@ class TestDocumentationRenderer(TestCase):
             'link': coreapi.Link(url='/data/', action='get', fields=[]),
         }
         html = template.render(context)
-        assert 'testcases list' in html
+        text = "".join(ElementTree.fromstring(html).itertext())
+        assert 'testcases list' in text
 
 
 @pytest.mark.skipif(not coreapi, reason='coreapi is not installed')


### PR DESCRIPTION
### Description

Between `pygments` v2.12.0 and v2.13.0, https://github.com/pygments/pygments/commit/147b22face65617514ccfa8512c6b097b07cad4c adjusted the way that whitespace is produced in HTML documents.

This caused a `django-rest-framework` unit test to begin failing, which was resolved in #8530 by configuring a specific dependency version (pin) on [`pygments==2.12.0`](https://github.com/encode/django-rest-framework/blob/2db0c0bf0a97ce42369d5b3474d38cebd274d8ae/requirements/requirements-optionals.txt#L9).

This changeset restores the previous lower-bound-and-beyond (albeit within major) version range for `pygments` and resolves the unit test failure by collecting and concatenating string content from within the HTML produced by `pygments` (including nested elements).

Refs #8530.