### PR TITLE
Inherit from faked classes in tests to satisfy mypy

### DIFF
--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -3,6 +3,7 @@ from django.urls import NoReverseMatch, path
 
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory
+from rest_framework.versioning import BaseVersioning
 
 factory = APIRequestFactory()
 
@@ -16,7 +17,7 @@ urlpatterns = [
 ]
 
 
-class MockVersioningScheme:
+class MockVersioningScheme(BaseVersioning):
 
     def __init__(self, raise_error=False):
         self.raise_error = raise_error

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,6 +1,6 @@
 import pytest
 from django.test import override_settings
-from django.urls import include, path, re_path, ResolverMatch
+from django.urls import ResolverMatch, include, path, re_path
 
 from rest_framework import serializers, status, versioning
 from rest_framework.decorators import APIView

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,6 +1,6 @@
 import pytest
 from django.test import override_settings
-from django.urls import include, path, re_path
+from django.urls import include, path, re_path, ResolverMatch
 
 from rest_framework import serializers, status, versioning
 from rest_framework.decorators import APIView
@@ -126,7 +126,7 @@ class TestRequestVersion:
         assert response.data == {'version': None}
 
     def test_namespace_versioning(self):
-        class FakeResolverMatch:
+        class FakeResolverMatch(ResolverMatch):
             namespace = 'v1'
 
         scheme = versioning.NamespaceVersioning
@@ -199,7 +199,7 @@ class TestURLReversing(URLPatternsTestCase, APITestCase):
         assert response.data == {'url': 'http://testserver/another/'}
 
     def test_reverse_namespace_versioning(self):
-        class FakeResolverMatch:
+        class FakeResolverMatch(ResolverMatch):
             namespace = 'v1'
 
         scheme = versioning.NamespaceVersioning
@@ -250,7 +250,7 @@ class TestInvalidVersion:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_invalid_namespace_versioning(self):
-        class FakeResolverMatch:
+        class FakeResolverMatch(ResolverMatch):
             namespace = 'v3'
 
         scheme = versioning.NamespaceVersioning


### PR DESCRIPTION
After adding typing of `APIClient.get` method to drf stubs project https://github.com/typeddjango/djangorestframework-stubs/pull/330 mypy started complaining about these classes in tests:

```
drf_source/tests/test_reverse.py:43: error: Incompatible types in assignment (expression has type "MockVersioningScheme", variable has type "Optional[BaseVersioning]")
drf_source/tests/test_reverse.py:50: error: Incompatible types in assignment (expression has type "MockVersioningScheme", variable has type "Optional[BaseVersioning]")
drf_source/tests/test_versioning.py:136: error: Incompatible types in assignment (expression has type "Type[FakeResolverMatch]", variable has type "Optional[ResolverMatch]")
drf_source/tests/test_versioning.py:209: error: Incompatible types in assignment (expression has type "Type[FakeResolverMatch]", variable has type "Optional[ResolverMatch]")
drf_source/tests/test_versioning.py:260: error: Incompatible types in assignment (expression has type "Type[FakeResolverMatch]", variable has type "Optional[ResolverMatch]")
```

This PR fixes these errors:

- `FakeResolverMatch` now inherits `ResolverMatch`, 
- `MockVersioningScheme` now inherits from `BaseVersioning` 

what satisfies the type system.