### PR TITLE
Upgrade isort version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   - id: check-symlinks
   - id: check-toml
 - repo: https://github.com/pycqa/isort
-  rev: 5.8.0
+  rev: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/PyCQA/flake8


### PR DESCRIPTION
## Description

This fixes recent issues with installing isort via pre-commit that was introduced in recent versions of poetry-core.

See https://github.com/PyCQA/isort/pull/2078
