### PR TITLE
Add ModelSerializer `Meta.include` option

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1137,7 +1137,7 @@ class ModelSerializer(Serializer):
             "and is now disallowed. Add an explicit fields = '__all__' to the "
             "{serializer_class} serializer.".format(
                 serializer_class=self.__class__.__name__
-            ),
+            )
         )
 
         if fields == ALL_FIELDS:

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1100,6 +1100,32 @@ class ModelSerializer(Serializer):
         instantiating this serializer class. This is based on the default
         set of fields, but also takes into account the `Meta.fields` or
         `Meta.exclude` options if they have been specified.
+
+        Additionally, you can use the `Meta.extra_fields` attribute to include
+        fields that are not included when setting `Meta.fields` to `ALL_FIELDS`
+        or when using `Meta.exclude`. For example, to include a related field:
+
+            class Something(models.Model):
+                owner = models.ForeignKey(
+                    User,
+                    on_delete=models.CASCADE,
+                    related_name='user_stuff',
+                )
+
+            class UserSerializer(serializers.ModelSerializer):
+                class Meta:
+                    model = User
+                    exclude = [
+                        'email',
+                        'password',
+                    ]
+                    extra_fields = [
+                        'user_stuff',
+                    ]
+
+        Note that the `Meta.extra_fields` option has no effect if `Meta.fields`
+        is set to an explicit list or tuple of field names. In that case, you
+        must include all the desired fields in that list or tuple.
         """
         fields = getattr(self.Meta, 'fields', None)
         exclude = getattr(self.Meta, 'exclude', None)

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1130,6 +1130,13 @@ class ModelSerializer(Serializer):
             )
         )
 
+        assert set(exclude or []).isdisjoint(include or []), (
+            "Cannot set the same field name in both 'exclude' and 'include' options "
+            "on serializer {serializer_class}.".format(
+                serializer_class=self.__class__.__name__
+            )
+        )
+
         # TODO Review the message of this assertion.
         assert not (fields is None and exclude is None and include is None), (
             "Creating a ModelSerializer without either the 'fields', 'exclude' "

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1103,6 +1103,7 @@ class ModelSerializer(Serializer):
         """
         fields = getattr(self.Meta, 'fields', None)
         exclude = getattr(self.Meta, 'exclude', None)
+        extra_fields = getattr(self.Meta, 'extra_fields', None)
 
         if fields and fields != ALL_FIELDS and not isinstance(fields, (list, tuple)):
             raise TypeError(
@@ -1114,6 +1115,12 @@ class ModelSerializer(Serializer):
             raise TypeError(
                 'The `exclude` option must be a list or tuple. Got %s.' %
                 type(exclude).__name__
+            )
+
+        if extra_fields and not isinstance(extra_fields, (list, tuple)):
+            raise TypeError(
+                'The `extra_fields` option must be a list or tuple. Got %s.' %
+                type(extra_fields).__name__
             )
 
         assert not (fields and exclude), (
@@ -1159,6 +1166,9 @@ class ModelSerializer(Serializer):
 
         # Use the default set of field names if `Meta.fields` is not specified.
         fields = self.get_default_field_names(declared_fields, info)
+        # Add extra field names, if any.
+        if extra_fields is not None:
+            fields += list(extra_fields)
 
         if exclude is not None:
             # If `Meta.exclude` is included, then remove those fields.

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -979,7 +979,7 @@ class TestSerializerMetaClass(TestCase):
                 fields = ('text',)
                 exclude = ('text',)
 
-        msginitial = "Cannot set both 'fields' and 'exclude' options on serializer ExampleSerializer."
+        msginitial = "Cannot set 'fields' together with 'exclude' or 'include' options on serializer ExampleSerializer."
         with self.assertRaisesMessage(AssertionError, msginitial):
             ExampleSerializer().fields
 


### PR DESCRIPTION
*Edit: Updating description to use `include` instead of `extra_fields` thanks to @Igonato feedback. Adding observations and TODO list.*

## Description

This PR somehow refs #6389 

*Somehow* because it implements an alternative way to achieve what is requested, not the exact code posted in the issue: Making use of a new `Meta.include` attribute, instead of extending the behavior of the existing `Meta.fields` option (to avoid breaking changes).

## Motivation

Inspired in [this Stack Overflow answer](https://stackoverflow.com/a/41063577). The community seems to need this feature.

An example use case:

```python
class Something(models.Model):
    owner = models.ForeignKey(
        User,
        on_delete=models.CASCADE,
        related_name='user_stuff',
    )

class UserSerializer(serializers.ModelSerializer):
    class Meta:
        model = User
        exclude = [
            'email',
            'password',
        ]
        include = [
            'user_stuff',
        ]
```

## Some considerations

- In the example above, setting for example `include = ['username']` is redundant, since that field would be included anyway.
- Setting `include = []` (empty list) is the same as `fields = '__all__'`. This is consistent with the current behavior obtained when `exclude = []`.
- The implementation doesn't care about duplicates (including many times the same field name) since the current code seems to work fine even if doing so in the `fields` attribute.

## TODO

- Documentation in the api-guide.