### PR TITLE
docs: add a missing renderer import in tutorial 6

### DIFF
--- a/docs/tutorial/6-viewsets-and-routers.md
+++ b/docs/tutorial/6-viewsets-and-routers.md
@@ -27,6 +27,7 @@ Here we've used the `ReadOnlyModelViewSet` class to automatically provide the de
 Next we're going to replace the `SnippetList`, `SnippetDetail` and `SnippetHighlight` view classes.  We can remove the three views, and again replace them with a single class.
 
     from rest_framework import permissions
+    from rest_framework import renderers
     from rest_framework.decorators import action
     from rest_framework.response import Response
 


### PR DESCRIPTION
## Description
added a missing import statement for `renderer` in tutorial 6 (ViewSets & Routers) in the first snippet where renderer is used
