### PR TITLE
Update serializers.py

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -486,9 +486,9 @@ class Serializer(BaseSerializer, metaclass=SerializerMetaclass):
                 if validate_method is not None:
                     validated_value = validate_method(validated_value)
             except ValidationError as exc:
-                errors[field.field_name] = exc.detail
+                errors[field.label] = exc.detail
             except DjangoValidationError as exc:
-                errors[field.field_name] = get_error_detail(exc)
+                errors[field.label] = get_error_detail(exc)
             except SkipField:
                 pass
             else:


### PR DESCRIPTION
When the LANGUAGE_CODE changes, the serializer field name error does not change. You need to change field_name to label to show the translated field name (actually verbose_name).
For example, when LANGUAGE_CODE is 'fa', before changing the code, the error is:
```
{
  "post": [
    "pk نامعتبر \"0\" - این Object وجود ندارد"
  ]
}
```
After changing the code:
```
{
  "پست": [
    "pk نامعتبر \"0\" - این Object وجود ندارد"
  ]
}
```
In this example, "post" translated to "پست".