### PR TITLE
Router viewset registration via decorator (#8917)

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -49,7 +49,12 @@ class BaseRouter:
     def __init__(self):
         self.registry = []
 
-    def register(self, prefix, viewset, basename=None):
+    def register(self, prefix, viewset=None, basename=None):
+        if viewset is None:
+            def decorator(viewset):
+                self.register(prefix, viewset, basename=basename)
+                return viewset
+            return decorator
         if basename is None:
             basename = self.get_default_basename(viewset)
 


### PR DESCRIPTION
## Description

PR that implements changes from discussion #8917.

This adds a decorator style syntax for registering viewsets with routers, enabling the following:

```python
@router.register('some-path')
class MyViewSet(viewsets.ViewSet):
    ...
```