### PR TITLE
fix: double namespace

### DIFF
--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -135,8 +135,10 @@ class NamespaceVersioning(BaseVersioning):
         )
 
     def get_versioned_viewname(self, viewname, request):
-        return request.version + ':' + viewname
-
+        if not ":" in viewname:
+            return request.version + ":" + viewname
+        else:
+            return viewname
 
 class HostNameVersioning(BaseVersioning):
     """

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -135,10 +135,11 @@ class NamespaceVersioning(BaseVersioning):
         )
 
     def get_versioned_viewname(self, viewname, request):
-        if not ":" in viewname:
+        if ":" not in viewname:
             return request.version + ":" + viewname
         else:
             return viewname
+
 
 class HostNameVersioning(BaseVersioning):
     """


### PR DESCRIPTION
## Description

When using namespaces on my apps and rest framework generic relation https://github.com/LilyFoote/rest-framework-generic-relations project with the  i get a double name space : in relations.py i added this print statement on the line 383 before the matching viewname test
```
print(
    f"Comparing '{match.view_name}' to '{expected_viewname}', self.view_name = {self.view_name} "
)
```
and this is what i get in the console 
```
Comparing invoices:invoice-detail to reminders:invoices:invoice-detail, self.view_name = invoices:invoice-detail 
```
### solution
so i just added a test in ```def get_versioned_viewname(self, viewname, request):``` to not change the view name if there is already a namespace.

### alternative 
we could take out the existing namespace to replace it with the required one or we could make a more precise error message to explain how to bypass this behavior.

My use case required the reminder namespace to not be added.