### PR TITLE
Use ZoneInfo as primary source of timezone data

### DIFF
--- a/rest_framework/utils/timezone.py
+++ b/rest_framework/utils/timezone.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone, tzinfo
+
+
+def datetime_exists(dt):
+    """Check if a datetime exists. Taken from: https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html"""
+    # There are no non-existent times in UTC, and comparisons between
+    # aware time zones always compare absolute times; if a datetime is
+    # not equal to the same datetime represented in UTC, it is imaginary.
+    return dt.astimezone(timezone.utc) == dt
+
+
+def datetime_ambiguous(dt: datetime):
+    """Check whether a datetime is ambiguous. Taken from: https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html"""
+    # If a datetime exists and its UTC offset changes in response to
+    # changing `fold`, it is ambiguous in the zone specified.
+    return datetime_exists(dt) and (
+        dt.replace(fold=not dt.fold).utcoffset() != dt.utcoffset()
+    )
+
+
+def valid_datetime(dt):
+    """Returns True if the datetime is not ambiguous or imaginary, False otherwise."""
+    if isinstance(dt.tzinfo, tzinfo) and not datetime_ambiguous(dt):
+        return True
+    return False

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author_email='tom@tomchristie.com',  # SEE NOTE BELOW (*)
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=["django>=3.0", "pytz"],
+    install_requires=["django>=3.0", "pytz", 'backports.zoneinfo;python_version<"3.9"'],
     python_requires=">=3.6",
     zip_safe=False,
     classifiers=[

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,6 +5,7 @@ import re
 import sys
 import uuid
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
+from unittest.mock import patch
 
 import pytest
 import pytz
@@ -20,6 +21,11 @@ from rest_framework.fields import (
     is_simple_callable
 )
 from tests.models import UUIDForeignKeyTarget
+
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+else:
+    from backports.zoneinfo import ZoneInfo
 
 utc = datetime.timezone.utc
 
@@ -651,7 +657,7 @@ class FieldValues:
     """
     Base class for testing valid and invalid input values.
     """
-    def test_valid_inputs(self):
+    def test_valid_inputs(self, *args):
         """
         Ensure that valid values return the expected validated data.
         """
@@ -659,7 +665,7 @@ class FieldValues:
             assert self.field.run_validation(input_value) == expected_output, \
                 'input value: {}'.format(repr(input_value))
 
-    def test_invalid_inputs(self):
+    def test_invalid_inputs(self, *args):
         """
         Ensure that invalid values raise the expected validation error.
         """
@@ -669,7 +675,7 @@ class FieldValues:
             assert exc_info.value.detail == expected_failure, \
                 'input value: {}'.format(repr(input_value))
 
-    def test_outputs(self):
+    def test_outputs(self, *args):
         for output_value, expected_output in get_items(self.outputs):
             assert self.field.to_representation(output_value) == expected_output, \
                 'output value: {}'.format(repr(output_value))
@@ -1505,12 +1511,12 @@ class TestTZWithDateTimeField(FieldValues):
     @classmethod
     def setup_class(cls):
         # use class setup method, as class-level attribute will still be evaluated even if test is skipped
-        kolkata = pytz.timezone('Asia/Kolkata')
+        kolkata = ZoneInfo('Asia/Kolkata')
 
         cls.valid_inputs = {
-            '2016-12-19T10:00:00': kolkata.localize(datetime.datetime(2016, 12, 19, 10)),
-            '2016-12-19T10:00:00+05:30': kolkata.localize(datetime.datetime(2016, 12, 19, 10)),
-            datetime.datetime(2016, 12, 19, 10): kolkata.localize(datetime.datetime(2016, 12, 19, 10)),
+            '2016-12-19T10:00:00': datetime.datetime(2016, 12, 19, 10, tzinfo=kolkata),
+            '2016-12-19T10:00:00+05:30': datetime.datetime(2016, 12, 19, 10, tzinfo=kolkata),
+            datetime.datetime(2016, 12, 19, 10): datetime.datetime(2016, 12, 19, 10, tzinfo=kolkata),
         }
         cls.invalid_inputs = {}
         cls.outputs = {
@@ -1529,7 +1535,7 @@ class TestDefaultTZDateTimeField(TestCase):
     @classmethod
     def setup_class(cls):
         cls.field = serializers.DateTimeField()
-        cls.kolkata = pytz.timezone('Asia/Kolkata')
+        cls.kolkata = ZoneInfo('Asia/Kolkata')
 
     def assertUTC(self, tzinfo):
         """
@@ -1551,18 +1557,17 @@ class TestDefaultTZDateTimeField(TestCase):
         self.assertUTC(self.field.default_timezone())
 
 
-@pytest.mark.skipif(pytz is None, reason='pytz not installed')
 @override_settings(TIME_ZONE='UTC', USE_TZ=True)
 class TestCustomTimezoneForDateTimeField(TestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.kolkata = pytz.timezone('Asia/Kolkata')
+        cls.kolkata = ZoneInfo('Asia/Kolkata')
         cls.date_format = '%d/%m/%Y %H:%M'
 
     def test_should_render_date_time_in_default_timezone(self):
         field = serializers.DateTimeField(default_timezone=self.kolkata, format=self.date_format)
-        dt = datetime.datetime(2018, 2, 8, 14, 15, 16, tzinfo=pytz.utc)
+        dt = datetime.datetime(2018, 2, 8, 14, 15, 16, tzinfo=ZoneInfo("UTC"))
 
         with override(self.kolkata):
             rendered_date = field.to_representation(dt)
@@ -1572,7 +1577,8 @@ class TestCustomTimezoneForDateTimeField(TestCase):
         assert rendered_date == rendered_date_in_timezone
 
 
-class TestNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
+@pytest.mark.skipif(pytz is None, reason="As Django 5.0 is deprecating pytz, this test should eventually be able to get removed.")
+class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     """
     Invalid values for `DateTimeField` with datetime in DST shift (non-existing or ambiguous) and timezone with DST.
     Timezone America/New_York has DST shift from 2017-03-12T02:00:00 to 2017-03-12T03:00:00 and
@@ -1594,6 +1600,27 @@ class TestNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
             return 'America/New_York'
 
     field = serializers.DateTimeField(default_timezone=MockTimezone())
+
+
+@patch('rest_framework.utils.timezone.datetime_ambiguous', return_value=True)
+class TestNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
+    """
+    Invalid values for `DateTimeField` with datetime in DST shift (non-existing or ambiguous) and timezone with DST.
+    Timezone America/New_York has DST shift from 2017-03-12T02:00:00 to 2017-03-12T03:00:00 and
+     from 2017-11-05T02:00:00 to 2017-11-05T01:00:00 in 2017.
+    """
+    valid_inputs = {}
+    invalid_inputs = {
+        '2017-03-12T02:30:00': ['Invalid datetime for the timezone "America/New_York".'],
+        '2017-11-05T01:30:00': ['Invalid datetime for the timezone "America/New_York".']
+    }
+    outputs = {}
+
+    class MockZoneInfoTimezone(datetime.tzinfo):
+        def __str__(self):
+            return 'America/New_York'
+
+    field = serializers.DateTimeField(default_timezone=MockZoneInfoTimezone())
 
 
 class TestTimeField(FieldValues):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1577,7 +1577,7 @@ class TestCustomTimezoneForDateTimeField(TestCase):
         assert rendered_date == rendered_date_in_timezone
 
 
-@pytest.mark.skipif(pytz is None, reason="As Django 5.0 is deprecating pytz, this test should eventually be able to get removed.")
+@pytest.mark.skipif(pytz is None, reason="As Django 4.0 has deprecated pytz, this test should eventually be able to get removed.")
 class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     """
     Invalid values for `DateTimeField` with datetime in DST shift (non-existing or ambiguous) and timezone with DST.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

This PRs switches over to `ZoneInfo` as the primary source of timezone data in DRF. This PR accomplishes several things:
- Adds deprecation warning for a test that relies off `pytz`.
- Switches over tests that do not rely on `pytz` functionality over to `ZoneInfo`.
- Add additional error handling for `ZoneInfo` timezones. This is because unlike `pytz`, error checking has to be done more or less manually in able to determine ambiguous and imaginary timezones (see [this doc](https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html#detecting-ambiguous-and-imaginary-times) on migrating to `ZoneInfo`). We previously had exception handling in `DateTimeField` for `pytz` errors, but I added manually checking that will cover `ZoneInfo` timezones.

Django will provide us `ZoneInfo` instances as long as `USE_DEPRECATED_PYTZ` is not enabled

Fixes https://github.com/encode/django-rest-framework/issues/8577