### PR TITLE
Use consistent spelling for "authorization"

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -165,7 +165,7 @@ This permission is suitable if you want your API to only be accessible to a subs
 
 ## IsAuthenticatedOrReadOnly
 
-The `IsAuthenticatedOrReadOnly` will allow authenticated users to perform any request.  Requests for unauthorised users will only be permitted if the request method is one of the "safe" methods; `GET`, `HEAD` or `OPTIONS`.
+The `IsAuthenticatedOrReadOnly` will allow authenticated users to perform any request.  Requests for unauthorized users will only be permitted if the request method is one of the "safe" methods; `GET`, `HEAD` or `OPTIONS`.
 
 This permission is suitable if you want to your API to allow read permissions to anonymous users, and only allow write permissions to authenticated users.
 

--- a/rest_framework/templates/rest_framework/docs/error.html
+++ b/rest_framework/templates/rest_framework/docs/error.html
@@ -30,7 +30,7 @@ being applied unexpectedly?</p>
 
 <p>Your response status code is: <code>{{ response.status_code }}</code></p>
 
-<h3>401 Unauthorised.</h3>
+<h3>401 Unauthorized.</h3>
 <ul>
     <li>Do you have SessionAuthentication enabled?</li>
     <li>Are you logged in?</li>


### PR DESCRIPTION
Apart from a few exceptions, django-rest-framework uses the American English spelling "authorization"/"authorized".

    $ git grep -oi authorised | wc -l
    2
    $ git grep -oi authorized | wc -l
    30

Replace the few occurences of the British English spelling with the American English one.