### PR TITLE
test codecov gha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -34,7 +34,7 @@ jobs:
       run: python -m pip install --upgrade pip setuptools virtualenv wheel
 
     - name: Install dependencies
-      run: python -m pip install --upgrade codecov tox
+      run: python -m pip install --upgrade tox
 
     - name: Install tox-py
       if: ${{ matrix.python-version == '3.6' }}
@@ -54,5 +54,8 @@ jobs:
         tox -e base,dist,docs
 
     - name: Upload coverage
-      run: |
-        codecov -e TOXENV,DJANGO
+    - uses: codecov/codecov-action@v3.1.0
+      with:
+        flags: unittests # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)


### PR DESCRIPTION
might need to try part of the following in another PR if needed

 - name: Generate coverage report
      run: |
        pip install pytest
        pip install pytest-cov
        pytest --cov=./ --cov-report=xml
    - name: Upload coverage to Codecov
      uses: codecov/codecov-action@v3
      with:
        token: ${{ secrets.CODECOV_TOKEN }}
        directory: ./coverage/reports/
        env_vars: OS,PYTHON
        fail_ci_if_error: true
        files: ./coverage1.xml,./coverage2.xml,!./cache
        flags: unittests
        name: codecov-umbrella
        verbose: true