### PR TITLE
Removed usage of field.choices that triggered full table load

### DIFF
--- a/rest_framework/templates/rest_framework/horizontal/select_multiple.html
+++ b/rest_framework/templates/rest_framework/horizontal/select_multiple.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   <div class="col-sm-10">
-    <select multiple {{ field.choices|yesno:",disabled" }} class="form-control" name="{{ field.name }}">
+    <select multiple class="form-control" name="{{ field.name }}">
       {% for select in field.iter_options %}
         {% if select.start_option_group %}
           <optgroup label="{{ select.label }}">


### PR DESCRIPTION
## Description

Removed the `{{ field.choices|yesno:",disabled" }}` block because this triggers the loading of full database table worth of objects just to determine whether the multi-select widget should be set as disabled or not.

Since this "disabled" marking feature is not present in the normal select field, then I propose to remove it also from the multi-select.

The reason why I found this was that HTML forms in the browsable API became extremely slow, but only when relation fields with many=True were being used.
