### PR TITLE
Fix example of `requires_context` attribute

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -295,13 +295,14 @@ To write a class-based validator, use the `__call__` method. Class-based validat
 
 In some advanced cases you might want a validator to be passed the serializer
 field it is being used with as additional context. You can do so by setting
-a `requires_context = True` attribute on the validator. The `__call__` method
+a `requires_context = True` attribute on the validator class. The `__call__` method
 will then be called with the `serializer_field`
 or `serializer` as an additional argument.
 
-    requires_context = True
+    class MultipleOf:
+        requires_context = True
 
-    def __call__(self, value, serializer_field):
-        ...
+        def __call__(self, value, serializer_field):
+            ...
 
 [cite]: https://docs.djangoproject.com/en/stable/ref/validators/


### PR DESCRIPTION
## Description

Improving code example of `requires_context` attribute in validator classes. No code changes, only one doc change. 