### PR TITLE
fix: fallback on CursorPagination ordering if unset on the view

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -632,6 +632,24 @@ class CursorPaginationTestsMixin:
         ordering = self.pagination.get_ordering(request, [], MockView())
         assert ordering == ('created',)
 
+    def test_use_with_ordering_filter_without_ordering_default_value(self):
+        class MockView:
+            filter_backends = (filters.OrderingFilter,)
+            ordering_fields = ['username', 'created']
+
+        request = Request(factory.get('/'))
+        ordering = self.pagination.get_ordering(request, [], MockView())
+        # it gets the value of `ordering` provided by CursorPagination
+        assert ordering == ('created',)
+
+        request = Request(factory.get('/', {'ordering': 'username'}))
+        ordering = self.pagination.get_ordering(request, [], MockView())
+        assert ordering == ('username',)
+
+        request = Request(factory.get('/', {'ordering': 'invalid'}))
+        ordering = self.pagination.get_ordering(request, [], MockView())
+        assert ordering == ('created',)
+
     def test_cursor_pagination(self):
         (previous, current, next, previous_url, next_url) = self.get_pages('/')
 


### PR DESCRIPTION
## Description

https://github.com/encode/django-rest-framework/discussions/8953

* this commit fixes the usage of a CursorPagination combined with a view implementing an ordering filter, without a default ordering value.
* former behavior was to fetch the ordering value from the filter, and raises an error if the value was None, preventing the fallback on the ordering set on the CursorPagination class itself.
* we reversed the logic by getting first the value set on the class, and override it by the ordering filter if the parameter is present
