### PR TITLE
Fix choices in ChoiceField to support IntEnum

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1875,6 +1875,31 @@ class TestChoiceField(FieldValues):
             field.run_validation(2)
         assert exc_info.value.detail == ['"2" is not a valid choice.']
 
+    def test_enum_integer_choices(self):
+        from enum import IntEnum
+
+        class ChoiceCase(IntEnum):
+            first = auto()
+            second = auto()
+        # Enum validate
+        choices = [
+            (ChoiceCase.first, "1"),
+            (ChoiceCase.second, "2")
+        ]
+        field = serializers.ChoiceField(choices=choices)
+        assert field.run_validation(1) == 1
+        assert field.run_validation(ChoiceCase.first) == 1
+        assert field.run_validation("1") == 1
+        # Enum.value validate
+        choices = [
+            (ChoiceCase.first.value, "1"),
+            (ChoiceCase.second.value, "2")
+        ]
+        field = serializers.ChoiceField(choices=choices)
+        assert field.run_validation(1) == 1
+        assert field.run_validation(ChoiceCase.first) == 1
+        assert field.run_validation("1") == 1
+
     def test_integer_choices(self):
         class ChoiceCase(IntegerChoices):
             first = auto()


### PR DESCRIPTION
## Description
Python support Enum in version 3.4, but changed `__str__` to `int.__str__` until version 3.11 to better support the replacement of existing constants use-case. [https://docs.python.org/3/library/enum.html#enum.IntEnum](https://docs.python.org/3/library/enum.html#enum.IntEnum)

rest_framework support Python 3.6+, this commit will support the Enum as datatype of choices in Field.

Discussions: [https://github.com/encode/django-rest-framework/discussions/8945](https://github.com/encode/django-rest-framework/discussions/8945)