### PR TITLE
Fix mapping for choice values

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -9,7 +9,6 @@ import uuid
 from collections import OrderedDict
 from collections.abc import Mapping
 
-from django.db.models import IntegerChoices
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -18,6 +17,7 @@ from django.core.validators import (
     MinValueValidator, ProhibitNullCharactersValidator, RegexValidator,
     URLValidator, ip_address_validators
 )
+from django.db.models import IntegerChoices
 from django.forms import FilePathField as DjangoFilePathField
 from django.forms import ImageField as DjangoImageField
 from django.utils import timezone

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -17,7 +17,7 @@ from django.core.validators import (
     MinValueValidator, ProhibitNullCharactersValidator, RegexValidator,
     URLValidator, ip_address_validators
 )
-from django.db.models import IntegerChoices
+from django.db.models import IntegerChoices, TextChoices
 from django.forms import FilePathField as DjangoFilePathField
 from django.forms import ImageField as DjangoImageField
 from django.utils import timezone
@@ -1399,7 +1399,8 @@ class ChoiceField(Field):
         if data == '' and self.allow_blank:
             return ''
 
-        if isinstance(data, IntegerChoices) and str(data) != str(data.value):
+        if isinstance(data, (IntegerChoices, TextChoices)) and str(data) != \
+                str(data.value):
             data = data.value
 
         try:
@@ -1411,7 +1412,8 @@ class ChoiceField(Field):
         if value in ('', None):
             return value
 
-        if isinstance(value, IntegerChoices) and str(value) != str(value.value):
+        if isinstance(value, (IntegerChoices, TextChoices)) and str(value) != \
+                str(value.value):
             value = value.value
 
         return self.choice_strings_to_values.get(str(value), value)
@@ -1437,7 +1439,8 @@ class ChoiceField(Field):
         # Allows us to deal with eg. integer choices while supporting either
         # integer or string input, but still get the correct datatype out.
         self.choice_strings_to_values = {
-            str(key.value) if isinstance(key, IntegerChoices) and str(key) != str(
+            str(key.value) if isinstance(key, (IntegerChoices, TextChoices))
+                              and str(key) != str(
                 key.value) else str(key): key for key in self.choices
         }
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1440,8 +1440,7 @@ class ChoiceField(Field):
         # integer or string input, but still get the correct datatype out.
         self.choice_strings_to_values = {
             str(key.value) if isinstance(key, (IntegerChoices, TextChoices))
-                              and str(key) != str(
-                key.value) else str(key): key for key in self.choices
+            and str(key) != str(key.value) else str(key): key for key in self.choices
         }
 
     choices = property(_get_choices, _set_choices)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1836,8 +1836,8 @@ class TestChoiceField(FieldValues):
             (ChoiceCase.first, "1"),
             (ChoiceCase.second, "2")
         ]
-        field = serializers.ChoiceField(choices=choices)
 
+        field = serializers.ChoiceField(choices=choices)
         assert field.run_validation(1) == 1
         assert field.run_validation(ChoiceCase.first) == 1
         assert field.run_validation("1") == 1

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,11 +5,13 @@ import re
 import sys
 import uuid
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
+from enum import auto
 from unittest.mock import patch
 
 import pytest
 import pytz
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db.models import IntegerChoices
 from django.http import QueryDict
 from django.test import TestCase, override_settings
 from django.utils.timezone import activate, deactivate, override
@@ -1825,9 +1827,6 @@ class TestChoiceField(FieldValues):
         assert exc_info.value.detail == ['"2" is not a valid choice.']
 
     def test_enum_choices(self):
-        from enum import auto
-        from django.db.models import IntegerChoices
-
         class ChoiceCase(IntegerChoices):
             first = auto()
             second = auto()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 import pytest
 import pytz
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db.models import IntegerChoices
+from django.db.models import IntegerChoices, TextChoices
 from django.http import QueryDict
 from django.test import TestCase, override_settings
 from django.utils.timezone import activate, deactivate, override
@@ -1826,7 +1826,7 @@ class TestChoiceField(FieldValues):
             field.run_validation(2)
         assert exc_info.value.detail == ['"2" is not a valid choice.']
 
-    def test_enum_choices(self):
+    def test_integer_choices(self):
         class ChoiceCase(IntegerChoices):
             first = auto()
             second = auto()
@@ -1850,6 +1850,29 @@ class TestChoiceField(FieldValues):
         assert field.run_validation(1) == 1
         assert field.run_validation(ChoiceCase.first) == 1
         assert field.run_validation("1") == 1
+
+    def test_text_choices(self):
+        class ChoiceCase(TextChoices):
+            first = auto()
+            second = auto()
+        # Enum validate
+        choices = [
+            (ChoiceCase.first, "first"),
+            (ChoiceCase.second, "second")
+        ]
+
+        field = serializers.ChoiceField(choices=choices)
+        assert field.run_validation(ChoiceCase.first) == "first"
+        assert field.run_validation("first") == "first"
+
+        choices = [
+            (ChoiceCase.first.value, "first"),
+            (ChoiceCase.second.value, "second")
+        ]
+
+        field = serializers.ChoiceField(choices=choices)
+        assert field.run_validation(ChoiceCase.first) == "first"
+        assert field.run_validation("first") == "first"
 
 
 class TestChoiceFieldWithType(FieldValues):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1824,6 +1824,34 @@ class TestChoiceField(FieldValues):
             field.run_validation(2)
         assert exc_info.value.detail == ['"2" is not a valid choice.']
 
+    def test_enum_choices(self):
+        from enum import auto
+        from django.db.models import IntegerChoices
+
+        class ChoiceCase(IntegerChoices):
+            first = auto()
+            second = auto()
+        # Enum validate
+        choices = [
+            (ChoiceCase.first, "1"),
+            (ChoiceCase.second, "2")
+        ]
+        field = serializers.ChoiceField(choices=choices)
+
+        assert field.run_validation(1) == 1
+        assert field.run_validation(ChoiceCase.first) == 1
+        assert field.run_validation("1") == 1
+
+        choices = [
+            (ChoiceCase.first.value, "1"),
+            (ChoiceCase.second.value, "2")
+        ]
+
+        field = serializers.ChoiceField(choices=choices)
+        assert field.run_validation(1) == 1
+        assert field.run_validation(ChoiceCase.first) == 1
+        assert field.run_validation("1") == 1
+
 
 class TestChoiceFieldWithType(FieldValues):
     """


### PR DESCRIPTION
## Description

This pull request fixes the mapping between the human-labels and the database-values for the `ChoiceField` class. This PR has been mutated from [8955](https://github.com/encode/django-rest-framework/pull/8955)

Discussion [8965](https://github.com/encode/django-rest-framework/discussions/8965)
