### PR TITLE
Async view implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     strategy:
+      fail-fast: false
       matrix:
         python-version:
         - '3.6'

--- a/docs/api-guide/views.md
+++ b/docs/api-guide/views.md
@@ -217,6 +217,22 @@ You may pass `None` in order to exclude the view from schema generation.
     def view(request):
         return Response({"message": "Will not appear in schema!"})
 
+# Async Views
+
+When using Django 4.1 and above, REST framework allows you to work with async class and function based views.
+
+For class based views, all handler methods must be async, otherwise Django will raise an exception. For function based views, the function itself must be async.
+
+For example:
+
+    class AsyncView(APIView):
+        async def get(self, request):
+            return Response({"message": "This is an async class based view."})
+
+
+    @api_view(['GET'])
+    async def async_view(request):
+        return Response({"message": "This is an async function based view."})
 
 [cite]: https://reinout.vanrees.org/weblog/2011/08/24/class-based-views-usage.html
 [cite2]: http://www.boredomandlaziness.org/2012/05/djangos-cbvs-are-not-mistake-but.html

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -41,6 +41,17 @@ except ImportError:
     uritemplate = None
 
 
+# async_to_sync is required for async view support
+if django.VERSION >= (4, 1):
+    from asgiref.sync import async_to_sync, iscoroutinefunction, sync_to_async
+else:
+    async_to_sync = None
+    sync_to_async = None
+
+    def iscoroutinefunction(func):
+        return False
+
+
 # coreschema is optional
 try:
     import coreschema

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -10,6 +10,7 @@ import types
 
 from django.forms.utils import pretty_name
 
+from rest_framework.compat import iscoroutinefunction
 from rest_framework.views import APIView
 
 
@@ -46,8 +47,12 @@ def api_view(http_method_names=None):
         allowed_methods = set(http_method_names) | {'options'}
         WrappedAPIView.http_method_names = [method.lower() for method in allowed_methods]
 
-        def handler(self, *args, **kwargs):
-            return func(*args, **kwargs)
+        if iscoroutinefunction(func):
+            async def handler(self, *args, **kwargs):
+                return await func(*args, **kwargs)
+        else:
+            def handler(self, *args, **kwargs):
+                return func(*args, **kwargs)
 
         for method in http_method_names:
             setattr(WrappedAPIView, method.lower(), handler)

--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -11,6 +11,10 @@ from django.test import override_settings, testcases
 from django.test.client import Client as DjangoClient
 from django.test.client import ClientHandler
 from django.test.client import RequestFactory as DjangoRequestFactory
+
+if django.VERSION >= (4, 1):
+    from django.test.client import AsyncRequestFactory as DjangoAsyncRequestFactory
+
 from django.utils.encoding import force_bytes
 from django.utils.http import urlencode
 
@@ -136,7 +140,7 @@ else:
         raise ImproperlyConfigured('coreapi must be installed in order to use CoreAPIClient.')
 
 
-class APIRequestFactory(DjangoRequestFactory):
+class APIRequestFactoryMixin:
     renderer_classes_list = api_settings.TEST_REQUEST_RENDERER_CLASSES
     default_format = api_settings.TEST_REQUEST_DEFAULT_FORMAT
 
@@ -238,6 +242,15 @@ class APIRequestFactory(DjangoRequestFactory):
         request = super().request(**kwargs)
         request._dont_enforce_csrf_checks = not self.enforce_csrf_checks
         return request
+
+
+class APIRequestFactory(APIRequestFactoryMixin, DjangoRequestFactory):
+    pass
+
+
+if django.VERSION >= (4, 1):
+    class APIAsyncRequestFactory(APIRequestFactoryMixin, DjangoAsyncRequestFactory):
+        pass
 
 
 class ForceAuthClientHandler(ClientHandler):


### PR DESCRIPTION
## Description

This enables async views for #8496. Tests are copied from #8617 but the implementation is different and more aggressively tries to avoid async request paths hitting `sync_to_async` by additionally autodetecting async permission and throttle methods while also avoiding a separate async/sync dispatch class method.

This auto-detection approach seems to be how django itself handles async views.