### PR TITLE
Fix Links in Documentation to Django `reverse` and `reverse_lazy`

### DIFF
--- a/docs/api-guide/reverse.md
+++ b/docs/api-guide/reverse.md
@@ -54,5 +54,5 @@ As with the `reverse` function, you should **include the request as a keyword ar
     api_root = reverse_lazy('api-root', request=request)
 
 [cite]: https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm#sec_5_1_5
-[reverse]: https://docs.djangoproject.com/en/stable/topics/http/urls/#reverse
-[reverse-lazy]: https://docs.djangoproject.com/en/stable/topics/http/urls/#reverse-lazy
+[reverse]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#reverse
+[reverse-lazy]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#reverse-lazy

--- a/docs/api-guide/reverse.md
+++ b/docs/api-guide/reverse.md
@@ -54,5 +54,5 @@ As with the `reverse` function, you should **include the request as a keyword ar
     api_root = reverse_lazy('api-root', request=request)
 
 [cite]: https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm#sec_5_1_5
-[reverse]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#reverse
-[reverse-lazy]: https://docs.djangoproject.com/en/4.2/ref/urlresolvers/#reverse-lazy
+[reverse]: https://docs.djangoproject.com/en/stable/ref/urlresolvers/#reverse
+[reverse-lazy]: https://docs.djangoproject.com/en/stable/ref/urlresolvers/#reverse-lazy


### PR DESCRIPTION
## Description
The documentation links to the Django documentation for the `reverse` and `reverse_lazy` functions were broken. Fixes it.
