### PR TITLE
Add NullBooleanField deprecation to docs

### DIFF
--- a/docs/community/3.12-announcement.md
+++ b/docs/community/3.12-announcement.md
@@ -143,6 +143,16 @@ class PublisherSearchView(generics.ListAPIView):
 
 ---
 
+## Deprecations
+
+### `serializers.NullBooleanField`
+
+`serializers.NullBooleanField` is now pending deprecation, and will be removed in 3.14.
+
+Instead use `serializers.BooleanField` field and set `allow_null=True` which does the same thing.
+
+---
+
 ## Funding
 
 REST framework is a *collaboratively funded project*. If you use

--- a/docs/community/3.14-announcement.md
+++ b/docs/community/3.14-announcement.md
@@ -60,3 +60,13 @@ See Pull Request [#7522](https://github.com/encode/django-rest-framework/pull/75
 ## Minor fixes and improvements
 
 There are a number of minor fixes and improvements in this release. See the [release notes](release-notes.md) page for a complete listing.
+
+---
+
+## Deprecations
+
+### `serializers.NullBooleanField`
+
+`serializers.NullBooleanField` was moved to pending deprecation in 3.12, and deprecated in 3.13. It has now been removed from the core framework.
+
+Instead use `serializers.BooleanField` field and set `allow_null=True` which does the same thing.

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -157,6 +157,7 @@ Date: 28th September 2020
 * Fix `PrimaryKeyRelatedField` and `HyperlinkedRelatedField` when source field is actually a property. [#7142]
 * `Token.generate_key` is now a class method. [#7502]
 * `@action` warns if method is wrapped in a decorator that does not preserve information using `@functools.wraps`. [#7098]
+* Deprecate `serializers.NullBooleanField` in favour of `serializers.BooleanField` with `allow_null=True` [#7122]
 
 ---
 


### PR DESCRIPTION
## Description

I noticed that the NullBooleanField deprecation (#7122) wasn't mentioned in the docs, so I've added it to the release announcements and the release notes.
