### PR TITLE
Fixed #7007: Added Deprecation warning for coreapi

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -31,3 +31,7 @@ if django.VERSION < (3, 2):
 
 class RemovedInDRF315Warning(DeprecationWarning):
     pass
+
+
+class RemovedInDRF317Warning(DeprecationWarning):
+    pass

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -3,6 +3,7 @@ Provides generic filtering backends that can be used to filter the results
 returned by list views.
 """
 import operator
+import warnings
 from functools import reduce
 
 from django.core.exceptions import ImproperlyConfigured
@@ -12,6 +13,7 @@ from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
+from rest_framework import RemovedInDRF317Warning
 from rest_framework.compat import coreapi, coreschema, distinct
 from rest_framework.settings import api_settings
 
@@ -29,6 +31,8 @@ class BaseFilterBackend:
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return []
 
@@ -146,6 +150,8 @@ class SearchFilter(BaseFilterBackend):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
@@ -306,6 +312,8 @@ class OrderingFilter(BaseFilterBackend):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -4,6 +4,7 @@ be used for paginated responses.
 """
 
 import contextlib
+import warnings
 from base64 import b64decode, b64encode
 from collections import namedtuple
 from urllib import parse
@@ -15,6 +16,7 @@ from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
+from rest_framework import RemovedInDRF317Warning
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
@@ -152,6 +154,8 @@ class BasePagination:
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         return []
 
     def get_schema_operation_parameters(self, view):
@@ -311,6 +315,8 @@ class PageNumberPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(
@@ -525,6 +531,8 @@ class LimitOffsetPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
@@ -930,6 +938,8 @@ class CursorPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(

--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -5,7 +5,7 @@ from urllib import parse
 from django.db import models
 from django.utils.encoding import force_str
 
-from rest_framework import exceptions, serializers
+from rest_framework import RemovedInDRF317Warning, exceptions, serializers
 from rest_framework.compat import coreapi, coreschema, uritemplate
 from rest_framework.settings import api_settings
 
@@ -118,6 +118,8 @@ class SchemaGenerator(BaseSchemaGenerator):
 
     def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
         assert coreapi, '`coreapi` must be installed for schema support.'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema, '`coreschema` must be installed for schema support.'
 
         super().__init__(title, url, description, patterns, urlconf)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ license_files = LICENSE.md
 
 [tool:pytest]
 addopts=--tb=short --strict-markers -ra
+testspath = tests
+filterwarnings = ignore:CoreAPI compatibility is deprecated*:rest_framework.RemovedInDRF317Warning
 
 [flake8]
 ignore = E501,W503,W504

--- a/tests/schemas/test_coreapi.py
+++ b/tests/schemas/test_coreapi.py
@@ -173,9 +173,15 @@ class TestRouterGeneratedSchema(TestCase):
                         url='/example/',
                         action='get',
                         fields=[
-                            coreapi.Field('page', required=False, location='query', schema=coreschema.Integer(title='Page', description='A page number within the paginated result set.')),
-                            coreapi.Field('page_size', required=False, location='query', schema=coreschema.Integer(title='Page size', description='Number of results to return per page.')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('page', required=False, location='query',
+                                          schema=coreschema.Integer(title='Page',
+                                                                    description='A page number within the paginated result set.')),
+                            coreapi.Field('page_size', required=False, location='query',
+                                          schema=coreschema.Integer(title='Page size',
+                                                                    description='Number of results to return per page.')),
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'custom_list_action': coreapi.Link(
@@ -201,7 +207,9 @@ class TestRouterGeneratedSchema(TestCase):
                         action='get',
                         fields=[
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     )
                 }
@@ -223,9 +231,15 @@ class TestRouterGeneratedSchema(TestCase):
                         url='/example/',
                         action='get',
                         fields=[
-                            coreapi.Field('page', required=False, location='query', schema=coreschema.Integer(title='Page', description='A page number within the paginated result set.')),
-                            coreapi.Field('page_size', required=False, location='query', schema=coreschema.Integer(title='Page size', description='Number of results to return per page.')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('page', required=False, location='query',
+                                          schema=coreschema.Integer(title='Page',
+                                                                    description='A page number within the paginated result set.')),
+                            coreapi.Field('page_size', required=False, location='query',
+                                          schema=coreschema.Integer(title='Page size',
+                                                                    description='Number of results to return per page.')),
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'create': coreapi.Link(
@@ -233,7 +247,8 @@ class TestRouterGeneratedSchema(TestCase):
                         action='post',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description='A field description')),
+                            coreapi.Field('a', required=True, location='form',
+                                          schema=coreschema.String(title='A', description='A field description')),
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
                         ]
                     ),
@@ -242,7 +257,9 @@ class TestRouterGeneratedSchema(TestCase):
                         action='get',
                         fields=[
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'custom_action': coreapi.Link(
@@ -273,8 +290,10 @@ class TestRouterGeneratedSchema(TestCase):
                         description='A custom action using both list field and list serializer in the serializer.',
                         fields=[
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('a', required=True, location='form', schema=coreschema.Array(title='A', items=coreschema.Integer())),
-                            coreapi.Field('b', required=True, location='form', schema=coreschema.Array(title='B', items=coreschema.String())),
+                            coreapi.Field('a', required=True, location='form',
+                                          schema=coreschema.Array(title='A', items=coreschema.Integer())),
+                            coreapi.Field('b', required=True, location='form',
+                                          schema=coreschema.Array(title='B', items=coreschema.String())),
                         ]
                     ),
                     'custom_list_action': coreapi.Link(
@@ -310,7 +329,8 @@ class TestRouterGeneratedSchema(TestCase):
                             description='A description of the post method on the custom action.',
                             encoding='application/json',
                             fields=[
-                                coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description='A field description')),
+                                coreapi.Field('a', required=True, location='form',
+                                              schema=coreschema.String(title='A', description='A field description')),
                                 coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
                             ]
                         ),
@@ -320,7 +340,8 @@ class TestRouterGeneratedSchema(TestCase):
                             description='A description of the put method on the custom action from mapping.',
                             encoding='application/json',
                             fields=[
-                                coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description='A field description')),
+                                coreapi.Field('a', required=True, location='form',
+                                              schema=coreschema.String(title='A', description='A field description')),
                                 coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B'))
                             ]
                         ),
@@ -331,9 +352,12 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         fields=[
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('a', required=True, location='form', schema=coreschema.String(title='A', description=('A field description'))),
+                            coreapi.Field('a', required=True, location='form',
+                                          schema=coreschema.String(title='A', description=('A field description'))),
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'partial_update': coreapi.Link(
@@ -342,9 +366,12 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         fields=[
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('a', required=False, location='form', schema=coreschema.String(title='A', description='A field description')),
+                            coreapi.Field('a', required=False, location='form',
+                                          schema=coreschema.String(title='A', description='A field description')),
                             coreapi.Field('b', required=False, location='form', schema=coreschema.String(title='B')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'delete': coreapi.Link(
@@ -352,7 +379,9 @@ class TestRouterGeneratedSchema(TestCase):
                         action='delete',
                         fields=[
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     )
                 }
@@ -597,9 +626,15 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
                         url='/example1/',
                         action='get',
                         fields=[
-                            coreapi.Field('page', required=False, location='query', schema=coreschema.Integer(title='Page', description='A page number within the paginated result set.')),
-                            coreapi.Field('page_size', required=False, location='query', schema=coreschema.Integer(title='Page size', description='Number of results to return per page.')),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('page', required=False, location='query',
+                                          schema=coreschema.Integer(title='Page',
+                                                                    description='A page number within the paginated result set.')),
+                            coreapi.Field('page_size', required=False, location='query',
+                                          schema=coreschema.Integer(title='Page size',
+                                                                    description='Number of results to return per page.')),
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     ),
                     'custom_list_action': coreapi.Link(
@@ -625,7 +660,9 @@ class TestSchemaGeneratorWithMethodLimitedViewSets(TestCase):
                         action='get',
                         fields=[
                             coreapi.Field('id', required=True, location='path', schema=coreschema.String()),
-                            coreapi.Field('ordering', required=False, location='query', schema=coreschema.String(title='Ordering', description='Which field to use when ordering the results.'))
+                            coreapi.Field('ordering', required=False, location='query',
+                                          schema=coreschema.String(title='Ordering',
+                                                                   description='Which field to use when ordering the results.'))
                         ]
                     )
                 }
@@ -706,8 +743,10 @@ class TestSchemaGeneratorWithForeignKey(TestCase):
                         action='post',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('name', required=True, location='form', schema=coreschema.String(title='Name')),
-                            coreapi.Field('target', required=True, location='form', schema=coreschema.Integer(description='Target', title='Target')),
+                            coreapi.Field('name', required=True, location='form',
+                                          schema=coreschema.String(title='Name')),
+                            coreapi.Field('target', required=True, location='form',
+                                          schema=coreschema.Integer(description='Target', title='Target')),
                         ]
                     )
                 }
@@ -752,8 +791,10 @@ class TestSchemaGeneratorWithManyToMany(TestCase):
                         action='post',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('name', required=True, location='form', schema=coreschema.String(title='Name')),
-                            coreapi.Field('targets', required=True, location='form', schema=coreschema.Array(title='Targets', items=coreschema.Integer())),
+                            coreapi.Field('name', required=True, location='form',
+                                          schema=coreschema.String(title='Name')),
+                            coreapi.Field('targets', required=True, location='form',
+                                          schema=coreschema.Array(title='Targets', items=coreschema.Integer())),
                         ]
                     )
                 }
@@ -769,6 +810,7 @@ class TestSchemaGeneratorActionKeysViewSets(TestCase):
         """
         Ensure that action name is preserved when action map contains "head".
         """
+
         class CustomViewSet(GenericViewSet):
             serializer_class = EmptySerializer
 
@@ -856,7 +898,8 @@ class TestAutoSchema(TestCase):
         assert isinstance(view.schema, CustomViewInspector)
 
     def test_set_custom_inspector_class_via_settings(self):
-        with override_settings(REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'tests.schemas.test_coreapi.CustomViewInspector'}):
+        with override_settings(
+                REST_FRAMEWORK={'DEFAULT_SCHEMA_CLASS': 'tests.schemas.test_coreapi.CustomViewInspector'}):
             view = APIView()
             assert isinstance(view.schema, CustomViewInspector)
 
@@ -963,7 +1006,6 @@ class TestAutoSchema(TestCase):
 
     @pytest.mark.skipif(not coreapi, reason='coreapi is not installed')
     def test_view_with_manual_schema(self):
-
         path = '/example'
         method = 'get'
         base_url = None
@@ -1198,6 +1240,7 @@ class TestURLNamingCollisions(TestCase):
     """
     Ref: https://github.com/encode/django-rest-framework/issues/4704
     """
+
     def test_manually_routing_nested_routes(self):
         @api_view(["GET"])
         def simple_fbv(request):
@@ -1444,6 +1487,11 @@ def test_schema_handles_exception():
 
 
 class CoreapiDeprecationTestCase(TestCase):
+    def __init__(self, *args, **kwargs):
+        if not coreapi:
+            pytest.skip("coreapi is not installed")
+        super().__init__(*args, **kwargs)
+
     def assert_deprecation_warning(self, obj):
         with pytest.warns(RemovedInDRF317Warning) as warning_list:
             obj.get_schema_fields({})


### PR DESCRIPTION
Fixed #7007 

Added Deprecation warning for coreapi for version 3.17
Because 3.15 is already running so added it for version 3.17 and I saw @auvipy commented on the same point for version 3.17
https://github.com/encode/django-rest-framework/issues/7007#issuecomment-1399430927 

