### PR TITLE
Fix OpenAPI Schema yaml rendering for timedelta

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -13,7 +13,7 @@ __title__ = 'Django REST framework'
 __version__ = '3.14.0'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 3-Clause'
-__copyright__ = 'Copyright 2011-2019 Encode OSS Ltd'
+__copyright__ = 'Copyright 2011-2023 Encode OSS Ltd'
 
 # Version synonym
 VERSION = __version__

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -31,3 +31,7 @@ if django.VERSION < (3, 2):
 
 class RemovedInDRF315Warning(DeprecationWarning):
     pass
+
+
+class RemovedInDRF317Warning(PendingDeprecationWarning):
+    pass

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -3,6 +3,7 @@ Provides generic filtering backends that can be used to filter the results
 returned by list views.
 """
 import operator
+import warnings
 from functools import reduce
 
 from django.core.exceptions import ImproperlyConfigured
@@ -12,6 +13,7 @@ from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
+from rest_framework import RemovedInDRF317Warning
 from rest_framework.compat import coreapi, coreschema, distinct
 from rest_framework.settings import api_settings
 
@@ -29,6 +31,8 @@ class BaseFilterBackend:
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return []
 
@@ -146,6 +150,8 @@ class SearchFilter(BaseFilterBackend):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
@@ -306,6 +312,8 @@ class OrderingFilter(BaseFilterBackend):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -4,6 +4,8 @@ be used for paginated responses.
 """
 
 import contextlib
+import warnings
+
 from base64 import b64decode, b64encode
 from collections import namedtuple
 from urllib import parse
@@ -15,6 +17,7 @@ from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
+from rest_framework import RemovedInDRF317Warning
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
@@ -152,6 +155,8 @@ class BasePagination:
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         return []
 
     def get_schema_operation_parameters(self, view):
@@ -311,6 +316,8 @@ class PageNumberPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(
@@ -525,6 +532,8 @@ class LimitOffsetPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
@@ -930,6 +939,8 @@ class CursorPagination(BasePagination):
 
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -9,6 +9,7 @@ REST framework also provides an HTML renderer that renders the browsable API.
 
 import base64
 import contextlib
+import datetime
 from urllib import parse
 
 from django import forms
@@ -1062,6 +1063,7 @@ class OpenAPIRenderer(BaseRenderer):
             def ignore_aliases(self, data):
                 return True
         Dumper.add_representer(SafeString, Dumper.represent_str)
+        Dumper.add_representer(datetime.timedelta, encoders.CustomScalar.represent_timedelta)
         return yaml.dump(data, default_flow_style=False, sort_keys=False, Dumper=Dumper).encode('utf-8')
 
 

--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -5,7 +5,7 @@ from urllib import parse
 from django.db import models
 from django.utils.encoding import force_str
 
-from rest_framework import exceptions, serializers
+from rest_framework import RemovedInDRF317Warning, exceptions, serializers
 from rest_framework.compat import coreapi, coreschema, uritemplate
 from rest_framework.settings import api_settings
 
@@ -118,6 +118,8 @@ class SchemaGenerator(BaseSchemaGenerator):
 
     def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
         assert coreapi, '`coreapi` must be installed for schema support.'
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
         assert coreschema, '`coreschema` must be installed for schema support.'
 
         super().__init__(title, url, description, patterns, urlconf)
@@ -351,6 +353,9 @@ class AutoSchema(ViewInspector):
             will be added to auto-generated fields, overwriting on `Field.name`
         """
         super().__init__()
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+
         if manual_fields is None:
             manual_fields = []
         self._manual_fields = manual_fields
@@ -592,6 +597,9 @@ class ManualSchema(ViewInspector):
         * `description`: String description for view. Optional.
         """
         super().__init__()
+        if coreapi is not None:
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+
         assert all(isinstance(f, coreapi.Field) for f in fields), "`fields` must be a list of coreapi.Field instances"
         self._fields = fields
         self._description = description
@@ -613,4 +621,6 @@ class ManualSchema(ViewInspector):
 
 def is_enabled():
     """Is CoreAPI Mode enabled?"""
+    if coreapi is not None:
+        warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
     return issubclass(api_settings.DEFAULT_SCHEMA_CLASS, AutoSchema)

--- a/rest_framework/templates/rest_framework/horizontal/select_multiple.html
+++ b/rest_framework/templates/rest_framework/horizontal/select_multiple.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   <div class="col-sm-10">
-    <select multiple {{ field.choices|yesno:",disabled" }} class="form-control" name="{{ field.name }}">
+    <select multiple class="form-control" name="{{ field.name }}">
       {% for select in field.iter_options %}
         {% if select.start_option_group %}
           <optgroup label="{{ select.label }}">

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -65,3 +65,14 @@ class JSONEncoder(json.JSONEncoder):
         elif hasattr(obj, '__iter__'):
             return tuple(item for item in obj)
         return super().default(obj)
+
+
+class CustomScalar:
+    """
+    CustomScalar that knows how to encode timedelta that renderer
+    can understand.
+    """
+    @classmethod
+    def represent_timedelta(cls, dumper, data):
+        value = str(data.total_seconds())
+        return dumper.represent_scalar('tag:yaml.org,2002:str', value)

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -119,15 +119,16 @@ class NamespaceVersioning(BaseVersioning):
 
     def determine_version(self, request, *args, **kwargs):
         resolver_match = getattr(request, 'resolver_match', None)
-        if resolver_match is None or not resolver_match.namespace:
-            return self.default_version
+        if resolver_match is not None and resolver_match.namespace:
+            # Allow for possibly nested namespaces.
+            possible_versions = resolver_match.namespace.split(':')
+            for version in possible_versions:
+                if self.is_allowed_version(version):
+                    return version
 
-        # Allow for possibly nested namespaces.
-        possible_versions = resolver_match.namespace.split(':')
-        for version in possible_versions:
-            if self.is_allowed_version(version):
-                return version
-        raise exceptions.NotFound(self.invalid_version_message)
+        if not self.is_allowed_version(self.default_version):
+            raise exceptions.NotFound(self.invalid_version_message)
+        return self.default_version
 
     def reverse(self, viewname, args=None, kwargs=None, request=None, format=None, **extra):
         if request.version is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ license_files = LICENSE.md
 
 [tool:pytest]
 addopts=--tb=short --strict-markers -ra
+testspath = tests
+filterwarnings = ignore:CoreAPI compatibility is deprecated*:rest_framework.RemovedInDRF317Warning
 
 [flake8]
 ignore = E501,W503,W504

--- a/tests/schemas/test_coreapi.py
+++ b/tests/schemas/test_coreapi.py
@@ -7,16 +7,24 @@ from django.test import TestCase, override_settings
 from django.urls import include, path
 
 from rest_framework import (
-    filters, generics, pagination, permissions, serializers
+    RemovedInDRF317Warning, filters, generics, pagination, permissions,
+    serializers
 )
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.decorators import action, api_view, schema
+from rest_framework.filters import (
+    BaseFilterBackend, OrderingFilter, SearchFilter
+)
+from rest_framework.pagination import (
+    BasePagination, CursorPagination, LimitOffsetPagination,
+    PageNumberPagination
+)
 from rest_framework.request import Request
 from rest_framework.routers import DefaultRouter, SimpleRouter
 from rest_framework.schemas import (
     AutoSchema, ManualSchema, SchemaGenerator, get_schema_view
 )
-from rest_framework.schemas.coreapi import field_to_schema
+from rest_framework.schemas.coreapi import field_to_schema, is_enabled
 from rest_framework.schemas.generators import EndpointEnumerator
 from rest_framework.schemas.utils import is_list_view
 from rest_framework.test import APIClient, APIRequestFactory
@@ -1433,3 +1441,46 @@ def test_schema_handles_exception():
     response.render()
     assert response.status_code == 403
     assert b"You do not have permission to perform this action." in response.content
+
+
+@pytest.mark.skipif(not coreapi, reason='coreapi is not installed')
+def test_coreapi_deprecation():
+    with pytest.warns(RemovedInDRF317Warning):
+        SchemaGenerator()
+
+    with pytest.warns(RemovedInDRF317Warning):
+        AutoSchema()
+
+    with pytest.warns(RemovedInDRF317Warning):
+        ManualSchema({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        deprecated_filter = OrderingFilter()
+        deprecated_filter.get_schema_fields({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        deprecated_filter = BaseFilterBackend()
+        deprecated_filter.get_schema_fields({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        deprecated_filter = SearchFilter()
+        deprecated_filter.get_schema_fields({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        paginator = BasePagination()
+        paginator.get_schema_fields({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        paginator = PageNumberPagination()
+        paginator.get_schema_fields({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        paginator = LimitOffsetPagination()
+        paginator.get_schema_fields({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        paginator = CursorPagination()
+        paginator.get_schema_fields({})
+
+    with pytest.warns(RemovedInDRF317Warning):
+        is_enabled()

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -1162,6 +1162,18 @@ class TestGenerator(TestCase):
         assert b'"openapi": "' in ret
         assert b'"default": "0.0"' in ret
 
+    def test_schema_rendering_to_yaml(self):
+        patterns = [
+            path('example/', views.ExampleGenericAPIView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=patterns)
+
+        request = create_request('/')
+        schema = generator.get_schema(request=request)
+        ret = OpenAPIRenderer().render(schema)
+        assert b"openapi: " in ret
+        assert b"default: '0.0'" in ret
+
     def test_schema_with_no_paths(self):
         patterns = []
         generator = SchemaGenerator(patterns=patterns)

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -1174,6 +1174,19 @@ class TestGenerator(TestCase):
         assert b"openapi: " in ret
         assert b"default: '0.0'" in ret
 
+    def test_schema_rendering_timedelta_to_yaml_with_validator(self):
+
+        patterns = [
+            path('example/', views.ExampleValidatedAPIView.as_view()),
+        ]
+        generator = SchemaGenerator(patterns=patterns)
+
+        request = create_request('/')
+        schema = generator.get_schema(request=request)
+        ret = OpenAPIRenderer().render(schema)
+        assert b"openapi: " in ret
+        assert b"duration:\n          type: string\n          minimum: \'10.0\'\n" in ret
+
     def test_schema_with_no_paths(self):
         patterns = []
         generator = SchemaGenerator(patterns=patterns)

--- a/tests/schemas/views.py
+++ b/tests/schemas/views.py
@@ -134,6 +134,11 @@ class ExampleValidatedSerializer(serializers.Serializer):
     ip4 = serializers.IPAddressField(protocol='ipv4')
     ip6 = serializers.IPAddressField(protocol='ipv6')
     ip = serializers.IPAddressField()
+    duration = serializers.DurationField(
+        validators=(
+            MinValueValidator(timedelta(seconds=10)),
+        )
+    )
 
 
 class ExampleValidatedAPIView(generics.GenericAPIView):

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -272,7 +272,7 @@ class TestInvalidVersion:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-class TestAllowedAndDefaultVersion:
+class TestAcceptHeaderAllowedAndDefaultVersion:
     def test_missing_without_default(self):
         scheme = versioning.AcceptHeaderVersioning
         view = AllowedVersionsView.as_view(versioning_class=scheme)
@@ -313,6 +313,97 @@ class TestAllowedAndDefaultVersion:
         view = AllowedWithNoneAndDefaultVersionsView.as_view(versioning_class=scheme)
 
         request = factory.get('/endpoint/', HTTP_ACCEPT='application/json')
+        response = view(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'version': 'v2'}
+
+
+class TestNamespaceAllowedAndDefaultVersion:
+    def test_no_namespace_without_default(self):
+        class FakeResolverMatch:
+            namespace = None
+
+        scheme = versioning.NamespaceVersioning
+        view = AllowedVersionsView.as_view(versioning_class=scheme)
+
+        request = factory.get('/endpoint/')
+        request.resolver_match = FakeResolverMatch
+        response = view(request)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_no_namespace_with_default(self):
+        class FakeResolverMatch:
+            namespace = None
+
+        scheme = versioning.NamespaceVersioning
+        view = AllowedAndDefaultVersionsView.as_view(versioning_class=scheme)
+
+        request = factory.get('/endpoint/')
+        request.resolver_match = FakeResolverMatch
+        response = view(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'version': 'v2'}
+
+    def test_no_match_without_default(self):
+        class FakeResolverMatch:
+            namespace = 'no_match'
+
+        scheme = versioning.NamespaceVersioning
+        view = AllowedVersionsView.as_view(versioning_class=scheme)
+
+        request = factory.get('/endpoint/')
+        request.resolver_match = FakeResolverMatch
+        response = view(request)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_no_match_with_default(self):
+        class FakeResolverMatch:
+            namespace = 'no_match'
+
+        scheme = versioning.NamespaceVersioning
+        view = AllowedAndDefaultVersionsView.as_view(versioning_class=scheme)
+
+        request = factory.get('/endpoint/')
+        request.resolver_match = FakeResolverMatch
+        response = view(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'version': 'v2'}
+
+    def test_with_default(self):
+        class FakeResolverMatch:
+            namespace = 'v1'
+
+        scheme = versioning.NamespaceVersioning
+        view = AllowedAndDefaultVersionsView.as_view(versioning_class=scheme)
+
+        request = factory.get('/endpoint/')
+        request.resolver_match = FakeResolverMatch
+        response = view(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'version': 'v1'}
+
+    def test_no_match_without_default_but_none_allowed(self):
+        class FakeResolverMatch:
+            namespace = 'no_match'
+
+        scheme = versioning.NamespaceVersioning
+        view = AllowedWithNoneVersionsView.as_view(versioning_class=scheme)
+
+        request = factory.get('/endpoint/')
+        request.resolver_match = FakeResolverMatch
+        response = view(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'version': None}
+
+    def test_no_match_with_default_and_none_allowed(self):
+        class FakeResolverMatch:
+            namespace = 'no_match'
+
+        scheme = versioning.NamespaceVersioning
+        view = AllowedWithNoneAndDefaultVersionsView.as_view(versioning_class=scheme)
+
+        request = factory.get('/endpoint/')
+        request.resolver_match = FakeResolverMatch
         response = view(request)
         assert response.status_code == status.HTTP_200_OK
         assert response.data == {'version': 'v2'}


### PR DESCRIPTION
1. fixed openapi schema yaml rendering for timedelta
2. yaml default scalar convert timedelta into python tag !!python/object/apply:datetime.timedelta which is cant be rendered into swagger and redoc.
3. added custom scalar which convert python tag into str