### PR TITLE
Fix unknown field error in ModelSerializer

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1372,8 +1372,8 @@ class ModelSerializer(Serializer):
         Raise an error on any unknown fields.
         """
         raise ImproperlyConfigured(
-            'Field name `%s` is not valid for model `%s`.' %
-            (field_name, model_class.__name__)
+            'Field name `%s` is not valid for model `%s` in `%s.%s`.' %
+            (field_name, model_class.__name__, self.__class__.__module__, self.__class__.__name__)
         )
 
     def include_extra_kwargs(self, kwargs, extra_kwargs):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -315,7 +315,8 @@ class TestRegularFieldMappings(TestCase):
                 model = RegularFieldsModel
                 fields = ('auto_field', 'invalid')
 
-        expected = 'Field name `invalid` is not valid for model `RegularFieldsModel`.'
+        expected = 'Field name `invalid` is not valid for model `RegularFieldsModel` ' \
+                   'in `tests.test_model_serializer.TestSerializer`.'
         with self.assertRaisesMessage(ImproperlyConfigured, expected):
             TestSerializer().fields
 


### PR DESCRIPTION
My real scenario is when I include some fields that does not exists in the model. For example assume that I have a model called `Store`, which does not have `token` field.

In this example, if I have a `ModelSerializer` like this:
```python
class StoreSerializer(ModelSerializer):
    ...
    class Meta:
        fields = (
            ...
            "token"
        )
```
Then I will face an exception like: ```'Field name `token` is not valid for model `Store`.'``` .

This can really be a headache, when I have multiple serializers for `Store` model. So I suggest to simply have the model path, to be more clear about which serializer is corrupt.