### PR TITLE
Fix: not working rename with ('name', 'origin name') pattern

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -207,10 +207,11 @@ class OrderingFilter(BaseFilterBackend):
         return self.get_default_ordering(view)
 
     def convert_to_origin_filed_name(self, request, queryset, view, ordering):
-        valid_fields = self.get_valid_fields(queryset, view, {'request': request})
+        valid_fields = getattr(view, 'ordering_fields', self.ordering_fields)
         if valid_fields is None or valid_fields == '__all__':
             return ordering
-        valid_fields = dict(valid_fields)
+
+        valid_fields = dict(self.get_valid_fields(queryset, view, {'request': request}))
         converted_fields = []
         for field in ordering:
             if field.startswith('-'):

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -208,6 +208,8 @@ class OrderingFilter(BaseFilterBackend):
 
     def convert_to_origin_filed_name(self, request, queryset, view, ordering):
         valid_fields = dict(self.get_valid_fields(queryset, view, {'request': request}))
+        if valid_fields is None or valid_fields == '__all__':
+            return ordering
         converted_fields = []
         for field in ordering:
             if field.startswith('-'):

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -207,9 +207,10 @@ class OrderingFilter(BaseFilterBackend):
         return self.get_default_ordering(view)
 
     def convert_to_origin_filed_name(self, request, queryset, view, ordering):
-        valid_fields = dict(self.get_valid_fields(queryset, view, {'request': request}))
+        valid_fields = self.get_valid_fields(queryset, view, {'request': request})
         if valid_fields is None or valid_fields == '__all__':
             return ordering
+        valid_fields = dict(valid_fields)
         converted_fields = []
         for field in ordering:
             if field.startswith('-'):

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -300,7 +300,7 @@ class OrderingFilter(BaseFilterBackend):
                 (field.name, field.verbose_name) for field in queryset.model._meta.fields
             ]
             valid_fields += [
-                (key, key.title().split('__'))
+                (key, key)
                 for key in queryset.query.annotations
             ]
         else:
@@ -315,13 +315,19 @@ class OrderingFilter(BaseFilterBackend):
         valid_fields = {item[1]: item[0] for item in self.get_valid_fields(queryset, view, {'request': request})}
 
         def term_valid(term):
+            negative = ""
             if term.startswith("-"):
+                negative = "-"
                 term = term[1:]
-            return valid_fields.get(term) is not None
+
+            if valid_fields.get(term):
+                return negative + valid_fields.get(term)
+
+            elif term in valid_fields.values():
+                return negative + term
 
         return [
-            valid_fields.get(term) if not term.startswith("-") else '-' + valid_fields.get(term[1:])
-            for term in fields if term_valid(term)
+            term_valid(term) for term in fields if term_valid(term)
         ]
 
     def filter_queryset(self, request, queryset, view):

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -4,13 +4,14 @@ returned by list views.
 """
 import operator
 import warnings
+from functools import reduce
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
-from functools import reduce
 
 from rest_framework import RemovedInDRF317Warning
 from rest_framework.compat import coreapi, coreschema, distinct

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -873,6 +873,7 @@ class OrderingFilterTests(TestCase):
             {'id': 1, 'title': 'zyx', 'text': 'abc'},
         ]
 
+
 class SensitiveOrderingFilterModel(models.Model):
     username = models.CharField(max_length=20)
     password = models.CharField(max_length=100)


### PR DESCRIPTION
get exception when use ordering_fields in ModelViewSet and change field name with another name 
for example:
ordering_fields = [
('created', 'created_at')
]
