### PR TITLE
Provide support for disabling actions in child viewsets.

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -231,7 +231,7 @@ class SimpleRouter(BaseRouter):
         """
         bound_methods = {}
         for method, action in method_map.items():
-            if hasattr(viewset, action):
+            if getattr(viewset, action, None) is not None:
                 bound_methods[method] = action
         return bound_methods
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -110,8 +110,8 @@ notes_router.register(r'notes', NoteViewSet)
 notes_path_router = SimpleRouter(use_regex_path=False)
 notes_path_router.register('notes', NoteViewSet)
 
-notes_without_patch_path_router = SimpleRouter(use_regex_path=False)
-notes_without_patch_path_router.register('notes', NotesWithoutPatchViewSet)
+notes_only_put = SimpleRouter(use_regex_path=False)
+notes_only_put.register('notes', NotesWithoutPatchViewSet)
 
 notes_path_default_router = DefaultRouter(use_regex_path=False)
 notes_path_default_router.register('notes', NoteViewSet)
@@ -505,8 +505,8 @@ class TestUrlPath(URLPatternsTestCase, TestCase):
     urlpatterns = [
         path('path/', include(url_path_router.urls)),
         path('default/', include(notes_path_default_router.urls)),
+        path('methods/', include(notes_only_put.urls)),
         path('example/', include(notes_path_router.urls)),
-        path('methods/', include(notes_without_patch_path_router.urls)),
     ]
 
     def setUp(self):


### PR DESCRIPTION
## Description

This is required for disabling some actions in child viewset. For example, if we use `UpdateModelMixin` we have to override method with `MethodNotAllowed` exception. This change provide support to disable methods by setting it to `None` value.
