### PR TITLE
Document support for http.HTTPMethod in the @action decorator added in Python 3.11.

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -178,6 +178,13 @@ The `action` decorator will route `GET` requests by default, but may also accept
         def unset_password(self, request, pk=None):
            ...
 
+Argument `methods` also supports HTTP methods defined as [HTTPMethod](https://docs.python.org/3/library/http.html#http.HTTPMethod). Example below is identical to the one above: 
+
+        from http import HTTPMethod
+
+        @action(detail=True, methods=[HTTPMethod.POST, HTTPMethod.DELETE])
+        def unset_password(self, request, pk=None):
+           ...
 
 The decorator allows you to override any viewset-level configuration such as `permission_classes`, `serializer_class`, `filter_backends`...:
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from django.test import TestCase
 
@@ -186,6 +188,20 @@ class ActionDecoratorTestCase(TestCase):
                 raise NotImplementedError
 
         assert str(excinfo.value) == "@action() missing required argument: 'detail'"
+
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="HTTPMethod was added in Python 3.11")
+    def test_method_mapping_http_method(self):
+        from http import HTTPMethod
+
+        method_names = [getattr(HTTPMethod, name.upper()) for name in APIView.http_method_names]
+
+        @action(detail=False, methods=method_names)
+        def test_action():
+            raise NotImplementedError
+
+        expected_mapping = {name: test_action.__name__ for name in APIView.http_method_names}
+
+        assert test_action.mapping == expected_mapping
 
     def test_method_mapping_http_methods(self):
         # All HTTP methods should be mappable


### PR DESCRIPTION
This pull request ensures that the `http.HTTPMethod` added in Python 3.11 is fully supported in the `@action` decorator, as mentioned in issue #8995.

## Description

Only one test and documentation update is needed, since `http.HTTPMethod` already functions as is.

The reason for this is that `@action` already invokes `lower()` on each `method`, which converts `http.HTTPMethod` to a `str` a format that is already supported.

<img width="742" alt="action" src="https://github.com/encode/django-rest-framework/assets/4248287/a7fc42bc-91eb-4482-946a-04ec378b03de">
