### PR TITLE
Fixes documentation link test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.9'
 
     - name: Install dependencies
       run: pip install -r requirements/requirements-documentation.txt


### PR DESCRIPTION
The `test-docs` workflow added with https://github.com/encode/django-rest-framework/pull/6967 needs to be reverted to Python 3.9, otherwiese the docs cannot be served. This might be related to the version of [mkdocs](https://github.com/encode/django-rest-framework/blob/master/requirements/requirements-documentation.txt) that is currently in use. 

```
Run mkdocs serve &
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.[12](https://github.com/nezhar/django-rest-framework/actions/runs/5888078513/job/15968572627#step:5:13)/x64/bin/mkdocs", line 5, in <module>
    from mkdocs.__main__ import cli
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mkdocs/__main__.py", line 16, in <module>
    from mkdocs import config                                 # noqa: E402
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mkdocs/config/__init__.py", line 2, in <module>
    from mkdocs.config.defaults import DEFAULT_SCHEMA
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mkdocs/config/defaults.py", line 1, in <module>
    from mkdocs.config import config_options
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mkdocs/config/config_options.py", line 2, in <module>
    from collections import Sequence, namedtuple
ImportError: cannot import name 'Sequence' from 'collections' (/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/collections/__init__.py)
```