### PR TITLE
Add support for denominators to throttle strings

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -56,6 +56,8 @@ class SimpleRateThrottle(BaseThrottle):
     class.  The attribute is a string of the form 'number_of_requests/period'.
 
     Period should be one of: ('s', 'sec', 'm', 'min', 'h', 'hour', 'd', 'day')
+    You may prefix period with a number. For example '1/30s' would be one 
+    request every 30 seconds.
 
     Previous request information used for throttling is stored in the cache.
     """
@@ -103,7 +105,10 @@ class SimpleRateThrottle(BaseThrottle):
             return (None, None)
         num, period = rate.split('/')
         num_requests = int(num)
-        duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[period[0]]
+        denominator_num = period[:-1]
+        denominator_num = int(denominator) if len(denominator_num)>0 else 1
+        duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[period[-1]]
+        duration *= denominator_num
         return (num_requests, duration)
 
     def allow_request(self, request, view):

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -68,7 +68,7 @@ class SimpleRateThrottle(BaseThrottle):
     cache_format = 'throttle_%(scope)s_%(ident)s'
     scope = None
     THROTTLE_RATES = api_settings.DEFAULT_THROTTLE_RATES
-    _RATE_DENOMINATOR_REGEX= re.compile("^(\d*)(\D+)$")
+    _RATE_DENOMINATOR_REGEX = re.compile(r"^(\d*)(\D+)$")
 
     def __init__(self):
         if not getattr(self, 'rate', None):
@@ -113,8 +113,8 @@ class SimpleRateThrottle(BaseThrottle):
         m = re.search(self._RATE_DENOMINATOR_REGEX, denominator)
         dg = m.groups()
 
-        dn= int(m[0]) if len(m[0]) > 0 else 1
-        du = m[1][0]
+        dn= int(dg[0]) if len(dg[0]) > 0 else 1
+        du = dg[1][0]
 
         duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[du]
         duration *= dn

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -56,7 +56,7 @@ class SimpleRateThrottle(BaseThrottle):
     class.  The attribute is a string of the form 'number_of_requests/period'.
 
     Period should be one of: ('s', 'sec', 'm', 'min', 'h', 'hour', 'd', 'day')
-    You may prefix period with a number. For example '1/30s' would be one 
+    You may prefix period with a number. For example '1/30s' would be one
     request every 30 seconds.
 
     Previous request information used for throttling is stored in the cache.
@@ -106,7 +106,7 @@ class SimpleRateThrottle(BaseThrottle):
         num, period = rate.split('/')
         num_requests = int(num)
         denominator_num = period[:-1]
-        denominator_num = int(denominator_num) if len(denominator_num)>0 else 1
+        denominator_num = int(denominator_num) if len(denominator_num) > 0 else 1
         duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[period[-1]]
         duration *= denominator_num
         return (num_requests, duration)

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -1,8 +1,8 @@
 """
 Provides various throttling policies.
 """
-import time
 import re
+import time
 
 from django.core.cache import cache as default_cache
 from django.core.exceptions import ImproperlyConfigured
@@ -113,7 +113,7 @@ class SimpleRateThrottle(BaseThrottle):
         m = re.search(self._RATE_DENOMINATOR_REGEX, denominator)
         dg = m.groups()
 
-        dn= int(m[0]) if len(m[0])>0 else 1
+        dn= int(m[0]) if len(m[0]) > 0 else 1
         du = m[1][0]
 
         duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[du]

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -108,7 +108,7 @@ class SimpleRateThrottle(BaseThrottle):
             return (None, None)
         num, period = rate.split('/')
         num_requests = int(num)
-        
+
         denominator = period[:-1]
         m = re.search(self._RATE_DENOMINATOR_REGEX, denominator)
         dg = m.groups()

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -106,7 +106,7 @@ class SimpleRateThrottle(BaseThrottle):
         num, period = rate.split('/')
         num_requests = int(num)
         denominator_num = period[:-1]
-        denominator_num = int(denominator) if len(denominator_num)>0 else 1
+        denominator_num = int(denominator_num) if len(denominator_num)>0 else 1
         duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[period[-1]]
         duration *= denominator_num
         return (num_requests, duration)


### PR DESCRIPTION
## Description

Improved denominator string parser so you can for example write `1/30s` for 1 request every 30 seconds instead of being limited to throttling by to the closest time unit.  Since the current code just uses a lookup table on the denominator, it's pretty straightforward just to jiggle the indexing to look at the end of the string for the suffix, and see if there is a number in the denominator.

I imagine some documentation would also need to be updated. But I figured I would get the ball rolling since it seems a straightforward feature.