### PR TITLE
feat: introduce middleware classes

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -61,6 +61,9 @@ def api_view(http_method_names=None):
         WrappedAPIView.parser_classes = getattr(func, 'parser_classes',
                                                 APIView.parser_classes)
 
+        WrappedAPIView.middleware_classes = getattr(func, 'middleware_classes',
+                                                    APIView.middleware_classes)
+
         WrappedAPIView.authentication_classes = getattr(func, 'authentication_classes',
                                                         APIView.authentication_classes)
 

--- a/rest_framework/middleware.py
+++ b/rest_framework/middleware.py
@@ -1,0 +1,26 @@
+class BaseMiddleware:
+    """
+    All middleware classes should extend BaseMiddleware.
+    """
+
+    def process_request(self, request):
+        pass
+
+    def process_response(self, response):
+        pass
+
+
+class FooMiddleware(BaseMiddleware):
+    def process_request(self, request):
+        request._foo = "foo"
+
+    def process_response(self, response):
+        pass
+
+
+class BarMiddleware(BaseMiddleware):
+    def process_request(self, request):
+        pass
+
+    def process_response(self, response):
+        response._bar = "bar"

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -37,6 +37,10 @@ DEFAULTS = {
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser'
     ],
+    'DEFAULT_MIDDLEWARE_CLASSES': [
+        'rest_framework.middleware.FooMiddleware',
+        'rest_framework.middleware.BarMiddleware'
+    ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication'
@@ -133,6 +137,7 @@ DEFAULTS = {
 IMPORT_STRINGS = [
     'DEFAULT_RENDERER_CLASSES',
     'DEFAULT_PARSER_CLASSES',
+    'DEFAULT_MIDDLEWARE_CLASSES',
     'DEFAULT_AUTHENTICATION_CLASSES',
     'DEFAULT_PERMISSION_CLASSES',
     'DEFAULT_THROTTLE_CLASSES',

--- a/tests/test_rest_middleware.py
+++ b/tests/test_rest_middleware.py
@@ -1,0 +1,71 @@
+from django.test import TestCase, override_settings
+from django.urls import path
+
+from rest_framework import status
+from rest_framework.middleware import (
+    BarMiddleware, BaseMiddleware, FooMiddleware
+)
+from rest_framework.response import Response
+from rest_framework.test import APIClient, APIRequestFactory
+from rest_framework.views import APIView
+
+factory = APIRequestFactory()
+
+
+class DummyRequestMiddleware(BaseMiddleware):
+    def process_request(self, request):
+        request._dummy = "dummy"
+
+
+class DummyResponseMiddleware(BarMiddleware):
+    def process_response(self, response):
+        response._dummy = "dummy"
+
+
+class MockView(APIView):
+    def get(self, request):
+        response = Response(status=status.HTTP_200_OK)
+        response._request = request  # test client sets `request` input
+        return response
+
+
+urlpatterns = [
+    path('foo/', MockView.as_view(middleware_classes=[FooMiddleware])),
+    path('bar/', MockView.as_view(middleware_classes=[BarMiddleware])),
+    path('multiple/', MockView.as_view(middleware_classes=[DummyRequestMiddleware, DummyResponseMiddleware])),
+    path('none/', MockView.as_view(middleware_classes=[]))
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class FooMiddlewareTests(TestCase):
+    def test_foo_middleware_process_request(self):
+        response = APIClient().get('/foo/')
+        request = response._request
+        assert getattr(request, "_foo") == "foo"
+        assert response.status_code == status.HTTP_200_OK
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class BarMiddlewareTests(TestCase):
+    def test_bar_middleware_process_response(self):
+        response = APIClient().get('/bar/')
+        assert getattr(response, "_bar") == "bar"
+        assert response.status_code == status.HTTP_200_OK
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class MultipleMiddlewareClassesTests(TestCase):
+    def test_multiple_middleware_classes_process_request_and_response(self):
+        response = APIClient().get('/multiple/')
+        request = response._request
+        assert getattr(request, "_dummy") == "dummy"
+        assert getattr(response, "_dummy") == "dummy"
+        assert response.status_code == status.HTTP_200_OK
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class NoMiddlewareClassesTests(TestCase):
+    def test_bar_middleware_process_request(self):
+        response = APIClient().get('/none/')
+        assert response.status_code == status.HTTP_200_OK

--- a/tests/test_rest_middleware.py
+++ b/tests/test_rest_middleware.py
@@ -66,6 +66,6 @@ class MultipleMiddlewareClassesTests(TestCase):
 
 @override_settings(ROOT_URLCONF=__name__)
 class NoMiddlewareClassesTests(TestCase):
-    def test_bar_middleware_process_request(self):
+    def test_no_middleware_classes(self):
         response = APIClient().get('/none/')
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Description

Since we can't process the request and response produced by django rest framework in an intuitive way currently,
so I try to introduce the middleware classes to django rest framework discussed in #7770.

If we can have the middleware classes for django rest framework **only**, then we don't have to implement the django middleware. The most important thing is we can process the request and response in django rest framework just like how middleware mechanism works in django, but without coupling the context between django and django rest freamwork.