### PR TITLE
Add custom_many_related_field to RelatedField

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -92,6 +92,7 @@ class RelatedField(Field):
     queryset = None
     html_cutoff = None
     html_cutoff_text = None
+    custom_many_related_field = None
 
     def __init__(self, **kwargs):
         self.queryset = kwargs.pop('queryset', self.queryset)
@@ -137,16 +138,19 @@ class RelatedField(Field):
         and child classes in order to try to cover the general case. If you're
         overriding this method you'll probably want something much simpler, eg:
 
-        @classmethod
-        def many_init(cls, *args, **kwargs):
-            kwargs['child'] = cls()
-            return CustomManyRelatedField(*args, **kwargs)
+        ex:
+
+        class SafePrimaryKeyRelatedField(PrimaryKeyRelatedField):
+            custom_many_related_field = CustomManyRelatedField
+
+        will override ManyRelatedField with CustomManyRelatedField
         """
+        many_related_field_cls = cls.custom_many_related_field or ManyRelatedField
         list_kwargs = {'child_relation': cls(*args, **kwargs)}
         for key in kwargs:
             if key in MANY_RELATION_KWARGS:
                 list_kwargs[key] = kwargs[key]
-        return ManyRelatedField(**list_kwargs)
+        return many_related_field_cls(**list_kwargs)
 
     def run_validation(self, data=empty):
         # We force empty strings to None values for relational fields.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

I was using PrimaryKeyRelatedField with source='item.services' but `item` is a nullable entity in database when its null endpoint is raising 500 error on serialization. In order to fix that I have created custom SafeManyRelatedField  wrapped get_attribute and returned empty_list in case attribute exceptions (Happens when accessing multiple relations). In implementation below you can see that Many init is copied from source directly so in order to make it dry I have opened this pr. I think this way would be easier to override with CustomManyRelatedField. 

implementation:

```
class SafeManyRelatedField(ManyRelatedField):
    """
    A custom ManyRelatedField that safely retrieves related fields.
    This field is designed to handle cases where the related field might not exist,
    returning an empty list when the related field is nullable or doesn't exist.
    """

    def get_attribute(self, instance):
        try:
            return super().get_attribute(instance)
        except AttributeError:
            return []


class SafePrimaryKeyRelatedField(PrimaryKeyRelatedField):
    """
    A custom PrimaryKeyRelatedField that safely retrieves related fields.
    This field is designed to handle cases where the related field might not exist,
    ensuring that it can be used safely without raising exceptions.
    """

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

    @classmethod
    def many_init(cls, *args, **kwargs):
        list_kwargs = {'child_relation': cls(*args, **kwargs)}
        for key in kwargs:
            if key in MANY_RELATION_KWARGS:
                list_kwargs[key] = kwargs[key]
        return SafeManyRelatedField(**list_kwargs)
```

and usecase 
```
services = SafePrimaryKeyRelatedField(
        source='item.services',
        many=True, read_only=True,
    )
```
