### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to REST framework
 
-At this point in it's lifespan we consider Django REST framework to be essentially feature-complete. We may accept pull requests that track the continued development of Django versions, but would prefer not to accept new features or code formatting changes.
+At this point in its lifespan we consider Django REST framework to be essentially feature-complete. We may accept pull requests that track the continued development of Django versions, but would prefer not to accept new features or code formatting changes.
 
 Apart from minor documentation changes, the [GitHub discussions page](https://github.com/encode/django-rest-framework/discussions) should generally be your starting point. Please only raise an issue or pull request if you've been recommended to do so after discussion.
 


### PR DESCRIPTION
Removed apostrophe from "it's".

## Description

The correct form here is "its", since we're talking about something the framework (it) possesses. "Its" is the possessive form of it, while "it's" means "it is/has". Here's a link to a [page explaining it better](https://www.grammarly.com/blog/its-vs-its/).
