### PR TITLE
Added paginate query set as qs method for limit offset pagination

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -386,7 +386,7 @@ class LimitOffsetPagination(BasePagination):
     max_limit = None
     template = 'rest_framework/pagination/numbers.html'
 
-    def paginate_queryset(self, queryset, request, view=None):
+    def paginate_queryset_as_qs(self, queryset, request, view=None):
         self.request = request
         self.limit = self.get_limit(request)
         if self.limit is None:
@@ -399,7 +399,10 @@ class LimitOffsetPagination(BasePagination):
 
         if self.count == 0 or self.offset > self.count:
             return []
-        return list(queryset[self.offset:self.offset + self.limit])
+        return queryset[self.offset:self.offset + self.limit]
+
+    def paginate_queryset(self, queryset, request, view=None):
+        return list(paginate_queryset_as_qs(queryset, request, view))
 
     def get_paginated_response(self, data):
         return Response({


### PR DESCRIPTION
## Description

Have a method in the pagination classes which returns the queryset instead of a list so that users can use the pagination classes even better. 

## Current Behaviour:
We currently have paginate_queryset method which paginates and returns the exact data as a list. 

## Required Behaviour:
Add a new method paginate_queryset_as_qs (name can be changed) which does everything as paginate_queryset but returns a queryset instead of a list. 


This is a rough PR which I'm raising without really putting any efforts just to get inputs from everyone to understand if the proposal is even valid or not. If we think it's useful and can be added to the library, I can try to go in more detail and raise a PR which does changes for all the pagination classes. 

