### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Install using `pip`...
 
     pip install djangorestframework
 
+...or clone the project from GitHub.
+
+    git clone https://github.com/encode/django-rest-framework
+
 Add `'rest_framework'` to your `INSTALLED_APPS` setting.
 ```python
 INSTALLED_APPS = [


### PR DESCRIPTION
I'm adding an option of installing the framework that's included in the website but not on GitHub's README.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

In the official website (https://www.django-rest-framework.org/), the guide gives an option besides `pip` to install the Django REST package. It tells the user how to do it by cloning the project from the GitHub repository. In the README.md file, there's no such option, so I'm adding it by copying almost the exact text (the only difference is that I styled "github" as "GitHub").
