### PR TITLE
Fix ordering  duplication on non-unique field

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -624,15 +624,15 @@ class CursorPaginationTestsMixin:
 
         request = Request(factory.get('/', {'ordering': 'username'}))
         ordering = self.pagination.get_ordering(request, [], MockView())
-        assert ordering == ('username',)
+        assert ordering == ('username', 'pk')
 
         request = Request(factory.get('/', {'ordering': '-username'}))
         ordering = self.pagination.get_ordering(request, [], MockView())
-        assert ordering == ('-username',)
+        assert ordering == ('-username', 'pk')
 
         request = Request(factory.get('/', {'ordering': 'invalid'}))
         ordering = self.pagination.get_ordering(request, [], MockView())
-        assert ordering == ('created',)
+        assert ordering == ('created', 'pk')
 
     def test_use_with_ordering_filter_without_ordering_default_value(self):
         class MockView:
@@ -646,7 +646,7 @@ class CursorPaginationTestsMixin:
 
         request = Request(factory.get('/', {'ordering': 'username'}))
         ordering = self.pagination.get_ordering(request, [], MockView())
-        assert ordering == ('username',)
+        assert ordering == ('username', "pk")
 
         request = Request(factory.get('/', {'ordering': 'invalid'}))
         ordering = self.pagination.get_ordering(request, [], MockView())


### PR DESCRIPTION
## Description

Always add "pk" as last parameter for ordering.
For example, we have following QS
| pk | name |
|----|------|
|  1 | Bob  |
|  2 | Dan  |
|  3 | Bob  |
|  4 | Joe  |

And we want to order it by name and take 2nd element.
We can get following results: `qs.order_by('name')`

| pk | name |
|----|------|
|  1 | Bob  |
|  3 | Bob  |  <- pk 3 is 2nd element
|  2 | Dan  |
|  4 | Joe  |

Or we can get:

| pk | name |
|----|------|
|  3 | Bob  |
|  1 | Bob  |  <- pk 1 is 2nd element
|  2 | Dan  |
|  4 | Joe  |

As you see, QS is correctly ordered, but order is not consistent, and
pagination is also inconsistent since we are using fields which doesn't
have unique restriction. So we always add "pk" as last ordering param.

Unfornualy I couldn't reproduce this behavior for tests, might be the is that in tests sqlite in memory is used. But on postgress result is stable. Here is an example:

```python
from django_extensions.db.models import TimeStampedModel


class BaseModel(TimeStampedModel):
    """Base model for apps' models."""

    class Meta:
        abstract = True

class Genre(BaseModel):
    """Model defines data for genre from MAL."""
    name = CICharField(
        max_length=255,
        unique=True,
        verbose_name=_("Name"),
    )

    class Type(models.TextChoices):
        """Define possible genre types."""

        GENRES = "GENRES", _("Genres")
        EXPLICIT_GENRES = "EXPLICIT_GENRES", _("Explicit genres")
        THEMES = "THEMES", _("Themes")
        DEMOGRAPHICS = "DEMOGRAPHICS", _("Demographics")

    type = models.CharField(
        choices=Type.choices,
        max_length=15,
        verbose_name=_("Type"),
    )

    class Meta:
        verbose_name = _("Genre")
        verbose_name_plural = _("Genres")

print(
    list(Genre.objects.order_by("type").values_list("pk", "type")[0:2]), 
    list(Genre.objects.order_by("type").values_list("pk", "type")[2:4])
)
# Prints
# [(1454, 'DEMOGRAPHICS'), (1455, 'DEMOGRAPHICS')] [(1454, 'DEMOGRAPHICS'), (1460, 'DEMOGRAPHICS')]
print(
    list(Genre.objects.order_by("type", "pk").values_list("pk", "type")[0:2]), 
    list(Genre.objects.order_by("type", "pk").values_list("pk", "type")[2:4])
)
# Prints
# [(1750, 'DEMOGRAPHICS'), (1763, 'DEMOGRAPHICS')] [(1778, 'DEMOGRAPHICS'), (1785, 'DEMOGRAPHICS')]
```