### PR TITLE
Fix settings.md strftime URL

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -454,4 +454,4 @@ Default: `None`
 [cite]: https://www.python.org/dev/peps/pep-0020/
 [rfc4627]: https://www.ietf.org/rfc/rfc4627.txt
 [heroku-minified-json]: https://github.com/interagent/http-api-design#keep-json-minified-in-all-responses
-[strftime]: https://docs.python.org/3/library/time.html#time.strftime
+[strftime]: https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior


### PR DESCRIPTION
Fix settings.md strftime URL from https://docs.python.org/3.10/library/time.html#time.strftime to https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior