### PR TITLE
Updated links to CSRF/AJAX Django documentation

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -454,7 +454,7 @@ More information can be found in the [Documentation](https://django-rest-durin.r
 [basicauth]: https://tools.ietf.org/html/rfc2617
 [permission]: permissions.md
 [throttling]: throttling.md
-[csrf-ajax]: https://docs.djangoproject.com/en/stable/ref/csrf/#ajax
+[csrf-ajax]: https://docs.djangoproject.com/en/stable/howto/csrf/#using-csrf-protection-with-ajax
 [mod_wsgi_official]: https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIPassAuthorization.html
 [django-oauth-toolkit-getting-started]: https://django-oauth-toolkit.readthedocs.io/en/latest/rest-framework/getting_started.html
 [django-rest-framework-oauth]: https://jpadilla.github.io/django-rest-framework-oauth/

--- a/docs/topics/ajax-csrf-cors.md
+++ b/docs/topics/ajax-csrf-cors.md
@@ -35,7 +35,7 @@ The best way to deal with CORS in REST framework is to add the required response
 
 [cite]: https://blog.codinghorror.com/preventing-csrf-and-xsrf-attacks/
 [csrf]: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
-[csrf-ajax]: https://docs.djangoproject.com/en/stable/ref/csrf/#ajax
+[csrf-ajax]: https://docs.djangoproject.com/en/stable/howto/csrf/#using-csrf-protection-with-ajax
 [cors]: https://www.w3.org/TR/cors/
 [adamchainz]: https://github.com/adamchainz
 [django-cors-headers]: https://github.com/adamchainz/django-cors-headers


### PR DESCRIPTION
## Description

Hi!

`https://docs.djangoproject.com/en/stable/ref/csrf/#ajax` link is no longer valid and is referenced in:
- https://www.django-rest-framework.org/api-guide/authentication/#:~:text=Django%20CSRF%20documentation
- https://www.django-rest-framework.org/topics/ajax-csrf-cors/#:~:text=described%20in%20the%20Django%20documentation 

I think was moved to ["How-to" guides](https://docs.djangoproject.com/en/4.2/howto/#:~:text=How%20to%20use%20Django%E2%80%99s%20CSRF%20protection) so I updated to -> `https://docs.djangoproject.com/en/stable/howto/csrf/#using-csrf-protection-with-ajax`

Thank you!
