### PR TITLE
Add missing `DEFAULT_VERSIONING_CLASS` entry to API docs

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -163,6 +163,12 @@ The string that should used for any versioning parameters, such as in the media 
 
 Default: `'version'`
 
+#### DEFAULT_VERSIONING_CLASS
+
+The default versioning scheme to use.
+
+Default: `None`
+
 ---
 
 ## Authentication settings


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Let me know what description you'd like to put