### PR TITLE
docs: update django requirement to 4.2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ continued development by **[signing up for a paid plan][funding]**.
 REST framework requires the following:
 
 * Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11)
-* Django (3.0, 3.1, 3.2, 4.0, 4.1)
+* Django (3.0, 3.1, 3.2, 4.0, 4.1, 4.2)
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.


### PR DESCRIPTION
## Description

Updates the documentation page to add Django 4.2 requirement. This is consistent with the [README](https://github.com/encode/django-rest-framework/blob/master/README.md).

Here is the current state that is live:
![image](https://github.com/encode/django-rest-framework/assets/83985775/6764c09a-b0f0-4f60-b2f2-67d8a9df87f8)
