### PR TITLE
fix dist test by moving --no-pkgroot to runtests.py

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+import os
 import sys
 
 import pytest
@@ -33,6 +34,18 @@ if __name__ == "__main__":
                 '--cov', '.',
                 '--cov-report', 'xml',
             ] + pytest_args
+
+        try:
+            pytest_args.remove('--no-pkgroot')
+        except ValueError:
+            pass
+        else:
+            sys.path.pop(0)
+
+            # import rest_framework before pytest re-adds the package root directory.
+            import rest_framework
+            package_dir = os.path.join(os.getcwd(), 'rest_framework')
+            assert not rest_framework.__file__.startswith(package_dir)
 
         if first_arg.startswith('-'):
             # `runtests.py [flags]`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,10 @@
 import os
-import sys
 
 import django
 from django.core import management
 
 
 def pytest_addoption(parser):
-    parser.addoption('--no-pkgroot', action='store_true', default=False,
-                     help='Remove package root directory from sys.path, ensuring that '
-                          'rest_framework is imported from the installed site-packages. '
-                          'Used for testing the distribution.')
     parser.addoption('--staticfiles', action='store_true', default=False,
                      help='Run tests with static files collection, using manifest '
                           'staticfiles storage. Used for testing the distribution.')
@@ -87,19 +82,15 @@ def pytest_configure(config):
             'guardian',
         )
 
-    if config.getoption('--no-pkgroot'):
-        sys.path.pop(0)
-
-        # import rest_framework before pytest re-adds the package root directory.
-        import rest_framework
-        package_dir = os.path.join(os.getcwd(), 'rest_framework')
-        assert not rest_framework.__file__.startswith(package_dir)
-
     # Manifest storage will raise an exception if static files are not present (ie, a packaging failure).
     if config.getoption('--staticfiles'):
         import rest_framework
         settings.STATIC_ROOT = os.path.join(os.path.dirname(rest_framework.__file__), 'static-root')
-        settings.STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+        backend = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+        if django.VERSION < (4, 2):
+            settings.STATICFILES_STORAGE = backend
+        else:
+            settings.STORAGES['staticfiles']['BACKEND'] = backend
 
     django.setup()
 


### PR DESCRIPTION
## Description

This change fixes the dist test by moving the --no-pkgroot option from pytest to the runtests script.

The current "filterwarnings" setting for pytest includes rest_framework, which causes an early import of the module. As a result the current --no-pkgroot behavior fails with an assertion error. Trying to remove the module from sys.modules will cause the warning filter to not apply, so this change moves this code before pytest parses the config and loads the "filterwarnings".