### PR TITLE
Docs: Show how to add URLs for authentication for the browseable API.

### DIFF
--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -15,6 +15,18 @@ If you include fully-qualified URLs in your resource output, they will be 'urliz
 
 By default, the API will return the format specified by the headers, which in the case of the browser is HTML.  The format can be specified using `?format=` in the request, so you can look at the raw JSON response in a browser by adding `?format=json` to the URL.  There are helpful extensions for viewing JSON in [Firefox][ffjsonview] and [Chrome][chromejsonview].
 
+## Authentication
+
+To quickly add authentication to the browesable api, add a routes named `"login"` and `"logout"` under the namespace `"rest_framework"`. DRF provides default routes for this which you can add to your urlconf:
+
+```python
+urlpatterns = [
+    // ...
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+]
+```
+
+
 ## Customizing
 
 The browsable API is built with [Twitter's Bootstrap][bootstrap] (v 3.4.1), making it easy to customize the look-and-feel.


### PR DESCRIPTION
I spent several hours tonight looking for how to easily add the Login button to the browseable api. This PR adds a code snippet directly to the browseable api topic to show how to do this quickly. I found this solution from an older version of the tutorial linked from [this question on Stack Overflow](https://stackoverflow.com/questions/28044219/urest-framework-is-not-a-registered-namespace). I pulled up the version of the docs at that time from [the Internet Archive](http://web.archive.org/web/20150114020613/https://www.django-rest-framework.org/tutorial/6-viewsets-and-routers/). I am happy for suggestions about the exact placement of the section I added or wording describing the snippet.