### PR TITLE
added nullIfNotAuthed arg to CurrentUserDefault

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -262,8 +262,12 @@ class CreateOnlyDefault:
 
 class CurrentUserDefault:
     requires_context = True
+    def __init__(self, nullIfNotAuthed = False):
+        self.nullIfNotAuthed = nullIfNotAuthed
 
     def __call__(self, serializer_field):
+        if self.nullIfNotAuthed and not serializer_field.context['request'].user.is_authenticated:
+            return None
         return serializer_field.context['request'].user
 
     def __repr__(self):


### PR DESCRIPTION
simple change

to not reinvent the wheel, in case of a model that might have an optional user field, added an arg that by default changes nothing but when nullIfNotAuthed is set to true then returns null if a user is not authenticated.

this prevents an error that the anonymous user is not a user model