### PR TITLE
Fix use of ip_address_validators for Django 5.1+

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -169,6 +169,21 @@ else:
         }
 
 
+if django.VERSION >= (5, 0):
+    # Django 5.0+: use the stock ip_address_validators function
+    # Note: Before Django 5.0, ip_address_validators returns a tuple containing
+    #       1) the list of validators and 2) the error message. Starting from
+    #       Django 5.0 ip_address_validators only returns the list of validators
+    from django.core.validators import ip_address_validators
+else:
+    # Django <= 5.0: create a compatibility shim for ip_address_validators
+    from django.core.validators import \
+        ip_address_validators as _ip_address_validators
+
+    def ip_address_validators(protocol, unpack_ipv4):
+        return _ip_address_validators(protocol, unpack_ipv4)[0]
+
+
 # `separators` argument to `json.dumps()` differs between 2.x and 3.x
 # See: https://bugs.python.org/issue22767
 SHORT_SEPARATORS = (',', ':')

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -169,14 +169,14 @@ else:
         }
 
 
-if django.VERSION >= (5, 0):
-    # Django 5.0+: use the stock ip_address_validators function
-    # Note: Before Django 5.0, ip_address_validators returns a tuple containing
+if django.VERSION >= (5, 1):
+    # Django 5.1+: use the stock ip_address_validators function
+    # Note: Before Django 5.1, ip_address_validators returns a tuple containing
     #       1) the list of validators and 2) the error message. Starting from
-    #       Django 5.0 ip_address_validators only returns the list of validators
+    #       Django 5.1 ip_address_validators only returns the list of validators
     from django.core.validators import ip_address_validators
 else:
-    # Django <= 5.0: create a compatibility shim for ip_address_validators
+    # Django <= 5.1: create a compatibility shim for ip_address_validators
     from django.core.validators import \
         ip_address_validators as _ip_address_validators
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -16,7 +16,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import (
     EmailValidator, MaxLengthValidator, MaxValueValidator, MinLengthValidator,
     MinValueValidator, ProhibitNullCharactersValidator, RegexValidator,
-    URLValidator, ip_address_validators
+    URLValidator
 )
 from django.forms import FilePathField as DjangoFilePathField
 from django.forms import ImageField as DjangoImageField
@@ -36,6 +36,7 @@ except ImportError:
     pytz = None
 
 from rest_framework import ISO_8601
+from rest_framework.compat import ip_address_validators
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.utils import html, humanize_datetime, json, representation
@@ -866,7 +867,7 @@ class IPAddressField(CharField):
         self.protocol = protocol.lower()
         self.unpack_ipv4 = (self.protocol == 'both')
         super().__init__(**kwargs)
-        validators, error_message = ip_address_validators(protocol, self.unpack_ipv4)
+        validators = ip_address_validators(protocol, self.unpack_ipv4)
         self.validators.extend(validators)
 
     def to_internal_value(self, data):


### PR DESCRIPTION
## Description

`ip_address_validators` return value changed in Django 5.1. Before Django 5.1, `ip_address_validators` returns a tuple containing 1) the list of validators and 2) the error message. Starting from Django 5.1 `ip_address_validators` only returns the list of validators. See django/django#17305. This make tests fail with `ValueError: not enough values to unpack (expected 2, got 1)`.

This PR creates a compatibility shim for `ip_address_validators` for Django < 5.1 to behave the same way as in Django >= 5.1.