### PR TITLE
Create individual mixins for update actions embedded in `UpdateModelMixin`

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -58,11 +58,8 @@ class RetrieveModelMixin:
         return Response(serializer.data)
 
 
-class UpdateModelMixin:
-    """
-    Update a model instance.
-    """
-    def update(self, request, *args, **kwargs):
+class BaseUpdateModelMixin:
+    def get_update_response(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
@@ -82,6 +79,29 @@ class UpdateModelMixin:
     def perform_update(self, serializer):
         serializer.save()
 
+
+class FullUpdateModelMixin(BaseUpdateModelMixin):
+    """
+    Update a model instance. Only allowing 'PUT' method.
+    """
+    def update(self, request, *args, **kwargs):
+        return self.get_update_response(request, *args, **kwargs)
+
+
+class PartialUpdateModelMixin(BaseUpdateModelMixin):
+    """
+    Update a model instance. Only allowing 'PATCH' method.
+    """
+
+    def partial_update(self, request, *args, **kwargs):
+        kwargs['partial'] = True
+        return self.get_update_response(request, *args, **kwargs)
+
+
+class UpdateModelMixin(FullUpdateModelMixin, PartialUpdateModelMixin):
+    """
+    Update a model instance. Allowing both 'PATCH' and 'PUT' methods.
+    """
     def partial_update(self, request, *args, **kwargs):
         kwargs['partial'] = True
         return self.update(request, *args, **kwargs)


### PR DESCRIPTION
This is a long running issue that has been discussed many times:

https://stackoverflow.com/questions/43529555/how-to-not-allow-the-put-method-at-all-but-allow-patch-in-a-drf-viewset

https://stackoverflow.com/questions/59735869/django-rest-framework-allow-patch-but-not-put

https://github.com/encode/django-rest-framework/pull/3081

https://github.com/encode/django-rest-framework/pull/9057

I added 2 new mixins, each handling one http method. The behavior of existing `UpdateModelMixin` should remain unchanged.

Reading all the discussions above, I think this is the least disruptive way to handle this, what do you think?