### PR TITLE
Use POST method instead of GET to perform logout in browsable API

### DIFF
--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -42,7 +42,7 @@
                 <ul class="nav navbar-nav pull-right">
                   {% block userlinks %}
                     {% if user.is_authenticated %}
-                      {% optional_logout request user %}
+                      {% optional_logout request user csrf_token %}
                     {% else %}
                       {% optional_login request %}
                     {% endif %}

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -46,7 +46,7 @@
             <ul class="nav navbar-nav pull-right">
               {% block userlinks %}
                 {% if user.is_authenticated %}
-                  {% optional_logout request user %}
+                  {% optional_logout request user csrf_token %}
                 {% else %}
                   {% optional_login request %}
                 {% endif %}

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -119,7 +119,7 @@ def optional_docs_login(request):
 
 
 @register.simple_tag
-def optional_logout(request, user):
+def optional_logout(request, user, csrf_token):
     """
     Include a logout snippet if REST framework's logout view is in the URLconf.
     """
@@ -135,11 +135,16 @@ def optional_logout(request, user):
             <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-            <li><a href='{href}?next={next}'>Log out</a></li>
+            <form id="logoutForm" method="post" action="{href}?next={next}">
+                <input type="hidden" name="csrfmiddlewaretoken" value="{csrf_token}">
+            </form>
+            <li>
+                <a href="#" onclick='document.getElementById("logoutForm").submit()'>Log out</a>
+            </li>
         </ul>
     </li>"""
-    snippet = format_html(snippet, user=escape(user), href=logout_url, next=escape(request.path))
-
+    snippet = format_html(snippet, user=escape(user), href=logout_url,
+                          next=escape(request.path), csrf_token=csrf_token)
     return mark_safe(snippet)
 
 

--- a/tests/browsable_api/test_browsable_api.py
+++ b/tests/browsable_api/test_browsable_api.py
@@ -65,6 +65,12 @@ class DropdownWithAuthTests(TestCase):
         content = response.content.decode()
         assert '>Log in<' in content
 
+    def test_dropdown_contains_logout_form(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get('/')
+        content = response.content.decode()
+        assert '<form id="logoutForm" method="post" action="/auth/logout/?next=/">' in content
+
 
 @override_settings(ROOT_URLCONF='tests.browsable_api.no_auth_urls')
 class NoDropdownWithoutAuthTests(TestCase):


### PR DESCRIPTION
## Description

Fixes #9206