### PR TITLE
Reduce queries for supported ManyRelatedField

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 from urllib import parse
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
-from django.db.models import Manager
+from django.db.models import F, Manager
 from django.db.models.query import QuerySet
 from django.urls import NoReverseMatch, Resolver404, get_script_prefix, resolve
 from django.utils.encoding import smart_str, uri_to_iri
@@ -458,14 +458,25 @@ class SlugRelatedField(RelatedField):
         self.slug_field = slug_field
         super().__init__(**kwargs)
 
-    def to_internal_value(self, data):
+    def to_many_internal_value(self, data):
         queryset = self.get_queryset()
         try:
-            return queryset.get(**{self.slug_field: data})
-        except ObjectDoesNotExist:
-            self.fail('does_not_exist', slug_name=self.slug_field, value=smart_str(data))
+            result = (
+                queryset
+                .filter(**{self.slug_field + "__in": data})
+                .annotate(_slug_field_value=F(self.slug_field))
+                .all()
+            )
+            slugs = [item._slug_field_value for item in result]
+            for item in data:
+                if item not in slugs:
+                    self.fail('does_not_exist', slug_name=self.slug_field, value=smart_str(item))
+            return result
         except (TypeError, ValueError):
             self.fail('invalid')
+
+    def to_internal_value(self, data):
+        return self.to_many_internal_value([data])[0]
 
     def to_representation(self, obj):
         slug = self.slug_field

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -189,6 +189,13 @@ class PKManyToManyTests(TestCase):
         ]
         assert serializer.data == expected
 
+    def test_many_to_many_grouped_queries(self):
+        data = {'id': 4, 'name': 'source-4', 'targets': [1, 3]}
+        serializer = ManyToManySourceSerializer(data=data)
+        # Only one query should be executed even with several targets
+        with self.assertNumQueries(1):
+            assert serializer.is_valid()
+
     def test_many_to_many_unsaved(self):
         source = ManyToManySource(name='source-unsaved')
 

--- a/tests/test_relations_slug.py
+++ b/tests/test_relations_slug.py
@@ -174,6 +174,12 @@ class SlugForeignKeyTests(TestCase):
         ]
         assert serializer.data == expected
 
+    def test_reverse_foreign_key_create_grouped_queries(self):
+        data = {'id': 3, 'name': 'target-3', 'sources': ['source-1', 'source-3']}
+        serializer = ForeignKeyTargetSerializer(data=data)
+        with self.assertNumQueries(1):
+            assert serializer.is_valid()
+
     def test_foreign_key_update_with_invalid_null(self):
         data = {'id': 1, 'name': 'source-1', 'target': None}
         instance = ForeignKeySource.objects.get(pk=1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ class MockQueryset:
         return list(self.items)
 
     def filter(self, **lookup):
-        return MockQueryset(
+        return MockQueryset([
             item
             for item in self.items
             if all([
@@ -44,7 +44,13 @@ class MockQueryset:
                 else attrgetter(key.replace('__', '.'))(item) == value
                 for key, value in lookup.items()
             ])
-        )
+        ])
+
+    def annotate(self, **kwargs):
+        for key, value in kwargs.items():
+            for item in self.items:
+                setattr(item, key, attrgetter(value.name.replace('__', '.'))(item))
+        return self
 
 
 class BadType:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,13 +26,25 @@ class MockQueryset:
         return self.items[val]
 
     def get(self, **lookup):
-        for item in self.items:
-            if all([
-                attrgetter(key.replace('__', '.'))(item) == value
-                for key, value in lookup.items()
-            ]):
-                return item
+        result = self.filter(**lookup).all()
+        if len(result) > 0:
+            return result[0]
         raise ObjectDoesNotExist()
+
+    def all(self):
+        return list(self.items)
+
+    def filter(self, **lookup):
+        return MockQueryset(
+            item
+            for item in self.items
+            if all([
+                attrgetter(key.replace("__in", "").replace('__', '.'))(item) in value
+                if key.endswith("__in")
+                else attrgetter(key.replace('__', '.'))(item) == value
+                for key, value in lookup.items()
+            ])
+        )
 
 
 class BadType:


### PR DESCRIPTION
## Description

From the discussion here https://github.com/encode/django-rest-framework/discussions/8919, a related field with a `many=True` will only execute one query for all items instead of one for every item.

It currently works for:
* PrimaryKeyRelatedField
* SlugRelatedField

There are currently four issues regarding this pull request:
* if someone is inheriting a field with `to_many_internal_value` and only override `to_internal_value`, the overridden value won't be used (because `to_many_internal_value` will be use instead). 
  * We could check if the `to_internal_value` property was overwritten and raise an error / use the old behaviour in this case but I am not sure this is a good idea
* For `PrimaryKeyRelatedField`, when the type is wrong, the type of the first item is raised in the error as it is unclear how to retrieve the problematic item. Some solutions to keep the old behaviour if this is an issue:
  * Check that all items have the same type before querying the database and raise an error if some of them have different type
  * In the exception handling, run the query for every item to check which one has the issue
* For `SlugRelatedField`, I add to annotate the related field to detect if an item does not exist and which one. I don't know if this is acceptable or not.
* The pre-commit check fails for a reason I don't understand