### PR TITLE
fix get_template_context

### DIFF
--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -22,7 +22,7 @@ To quickly add authentication to the browesable api, add a routes named `"login"
 ```python
 urlpatterns = [
     ...,
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    url(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
 ]
 ```
 

--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -21,7 +21,7 @@ To quickly add authentication to the browesable api, add a routes named `"login"
 
 ```python
 urlpatterns = [
-    // ...
+    ...,
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]
 ```

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -170,11 +170,11 @@ class TemplateHTMLRenderer(BaseRenderer):
 
     def get_template_context(self, data, renderer_context):
         response = renderer_context['response']
-        if isinstance(data, dict):
-            details = list(data['detail'])
-        else:
-            details = data
-        return {'details': details, 'status_code': response.status_code}
+        if isinstance(data, list):
+            return {'details': data, 'status_code': response.status_code}
+        if response.exception:
+            data['status_code'] = response.status_code
+        return data
 
     def get_template_names(self, response, view):
         if response.template_name:

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -170,9 +170,11 @@ class TemplateHTMLRenderer(BaseRenderer):
 
     def get_template_context(self, data, renderer_context):
         response = renderer_context['response']
-        if response.exception:
-            data['status_code'] = response.status_code
-        return data
+        if isinstance(data, dict):
+            details = list(data['detail'])
+        else:
+            details = data
+        return {'details': details, 'status_code': response.status_code}
 
     def get_template_names(self, response, view):
         if response.template_name:


### PR DESCRIPTION
refs #9209
Fixes #9209

## Description

According to this [documentation](https://github.com/encode/django-rest-framework/blob/master/docs/api-guide/renderers.md#html-error-views), the `RequestContext` should have `status_code` and `details` keys. so I changed the `get_template_context` function to set these keys in the context.