### PR TITLE
Improve integration with Django Debug Toolbar

### DIFF
--- a/rest_framework/static/rest_framework/js/ajax-form.js
+++ b/rest_framework/static/rest_framework/js/ajax-form.js
@@ -3,6 +3,12 @@ function replaceDocument(docString) {
 
   doc.write(docString);
   doc.close();
+
+  if (window.djdt) {
+    // If Django Debug Toolbar is available, reinitialize it so that
+    // it can show updated panels from new `docString`.
+    window.addEventListener("load", djdt.init);
+  }
 }
 
 function doAjaxSubmit(e) {


### PR DESCRIPTION
## Description

Currently, DRF does not work well with `debug_toolbar`, due to the way it handles non-GET and non-POST requests.

To perform `PUT`, `PATCH`, `DELETE` and `OPTIONS` requests in browsable API, we send an ajax request to fetch the resulting HTML. The contents are then dynamically rendered using JavaScript.

During this time, the entire toolbar gets re-rendered (with proper data) but since the related JavaScript code is not executed (normally done on document load), the toolbar is instead hidden.

I added a simple check during JavaScript re-render to load the toolbar. It's unlikely this issue could be solved on `debug_toolbar` side given the way DRF handles content rendering.

IMHO this should be a great QOL improvement given how annoying it becomes to track requests with mentioned methods.

Related:

https://github.com/jazzband/django-debug-toolbar/issues/1743