### PR TITLE
Add support for allowed file extensions

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -14,9 +14,9 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import (
-    EmailValidator, MaxLengthValidator, MaxValueValidator, MinLengthValidator,
-    MinValueValidator, ProhibitNullCharactersValidator, RegexValidator,
-    URLValidator
+    EmailValidator, FileExtensionValidator, MaxLengthValidator,
+    MaxValueValidator, MinLengthValidator, MinValueValidator,
+    ProhibitNullCharactersValidator, RegexValidator, URLValidator
 )
 from django.forms import FilePathField as DjangoFilePathField
 from django.forms import ImageField as DjangoImageField
@@ -1516,9 +1516,18 @@ class FileField(Field):
     def __init__(self, **kwargs):
         self.max_length = kwargs.pop('max_length', None)
         self.allow_empty_file = kwargs.pop('allow_empty_file', False)
+        allowed_extensions = kwargs.pop('allowed_extensions', None)
+        assert allowed_extensions is None or isinstance(allowed_extensions, (list, tuple)), (
+                'Invalid value for allowed_extensions. It must be either None or a list/tuple, but %s provided.'
+                % (allowed_extensions.__name__ if inspect.isclass(
+            allowed_extensions) else allowed_extensions.__class__.__name__)
+        )
         if 'use_url' in kwargs:
             self.use_url = kwargs.pop('use_url')
         super().__init__(**kwargs)
+        if allowed_extensions is not None:
+            self.validators.append(
+                FileExtensionValidator(allowed_extensions))
 
     def to_internal_value(self, data):
         try:


### PR DESCRIPTION
In the init method of FileField:

- Added handling for 'allowed_extensions' parameter.
- Ensured 'allowed_extensions' is either None or a valid list/tuple.
- If 'allowed_extensions' is provided, added a FileExtensionValidator to the list of validators.