### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
+        - '3.12'
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
        {py36,py37,py38,py39,py310}-django32
        {py38,py39,py310}-{django40,django41,django42,djangomain}
        {py311}-{django41,django42,djangomain}
+       {py312}-{django42,djangomain}
        base
        dist
        docs
@@ -25,6 +26,7 @@ deps =
         djangomain: https://github.com/django/django/archive/main.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt
+        setuptools
 
 [testenv:base]
 ; Ensure optional dependencies are not required
@@ -56,4 +58,7 @@ ignore_outcome = true
 ignore_outcome = true
 
 [testenv:py311-djangomain]
+ignore_outcome = true
+
+[testenv:py312-djangomain]
 ignore_outcome = true


### PR DESCRIPTION
This is a test for the CI of python 3.12 since I can't commit to auvipy:py312 nor make a pull request to that branch (#9157). The tests pass locally, if confirmed on the CI, @auvipy can apply the commit to his branch and then merge. Otherwise, please ignore and close.
