### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -303,7 +303,7 @@ Corresponds to `django.db.models.fields.DecimalField`.
 * `min_value` Validate that the number provided is no less than this value.
 * `localize` Set to `True` to enable localization of input and output based on the current locale. This will also force `coerce_to_string` to `True`. Defaults to `False`. Note that data formatting is enabled if you have set `USE_L10N=True` in your settings file.
 * `rounding` Sets the rounding mode used when quantizing to the configured precision. Valid values are [`decimal` module rounding modes][python-decimal-rounding-modes]. Defaults to `None`.
-* `normalize_output` Will normalize the decimal value when serialized. This will strip all trailing zeroes and change the value's precision to the minimum required precision to be able to represent the value without loosing data. Defaults to `False`.
+* `normalize_output` Will normalize the decimal value when serialized. This will strip all trailing zeroes and change the value's precision to the minimum required precision to be able to represent the value without losing data. Defaults to `False`.
 
 #### Example usage
 

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -47,7 +47,7 @@ Date: 22nd September 2022
 * Stop calling `set_context` on Validators. [[#8589](https://github.com/encode/django-rest-framework/pull/8589)]
 * Return `NotImplemented` from `ErrorDetails.__ne__`. [[#8538](https://github.com/encode/django-rest-framework/pull/8538)]
 * Don't evaluate `DateTimeField.default_timezone` when a custom timezone is set. [[#8531](https://github.com/encode/django-rest-framework/pull/8531)]
-* Make relative URLs clickable in Browseable API. [[#8464](https://github.com/encode/django-rest-framework/pull/8464)]
+* Make relative URLs clickable in Browsable API. [[#8464](https://github.com/encode/django-rest-framework/pull/8464)]
 * Support `ManyRelatedField` falling back to the default value when the attribute specified by dot notation doesn't exist. Matches `ManyRelatedField.get_attribute` to `Field.get_attribute`. [[#7574](https://github.com/encode/django-rest-framework/pull/7574)]
 * Make `schemas.openapi.get_reference` public. [[#7515](https://github.com/encode/django-rest-framework/pull/7515)]
 * Make `ReturnDict` support `dict` union operators on Python 3.9 and later. [[#8302](https://github.com/encode/django-rest-framework/pull/8302)]
@@ -65,7 +65,7 @@ Date: 15th December 2021
 
 Date: 13th December 2021
 
-* Django 4.0 compatability. [#8178]
+* Django 4.0 compatibility. [#8178]
 * Add `max_length` and `min_length` options to `ListSerializer`. [#8165]
 * Add `get_request_serializer` and `get_response_serializer` hooks to `AutoSchema`. [#7424]
 * Fix OpenAPI representation of null-able read only fields. [#8116]
@@ -954,7 +954,7 @@ See the [release announcement][3.6-release].
 * Prevent raising exception when limit is 0. ([#4098][gh4098])
 * TokenAuthentication: Allow custom keyword in the header. ([#4097][gh4097])
 * Handle incorrectly padded HTTP basic auth header. ([#4090][gh4090])
-* LimitOffset pagination crashes Browseable API when limit=0. ([#4079][gh4079])
+* LimitOffset pagination crashes Browsable API when limit=0. ([#4079][gh4079])
 * Fixed DecimalField arbitrary precision support. ([#4075][gh4075])
 * Added support for custom CSRF cookie names. ([#4049][gh4049])
 * Fix regression introduced by #4035. ([#4041][gh4041])

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -21,14 +21,14 @@ from rest_framework.settings import api_settings
 
 
 def search_smart_split(search_terms):
-    """generator that first splits string by spaces, leaving quoted phrases togheter,
+    """generator that first splits string by spaces, leaving quoted phrases together,
     then it splits non-quoted phrases by commas.
     """
     for term in smart_split(search_terms):
         # trim commas to avoid bad matching for quoted phrases
         term = term.strip(',')
         if term.startswith(('"', "'")) and term[0] == term[-1]:
-            # quoted phrases are kept togheter without any other split
+            # quoted phrases are kept together without any other split
             yield unescape_string_literal(term)
         else:
             # non-quoted tokens are split by comma, keeping only non-empty ones

--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -102,12 +102,12 @@ class EndpointEnumerator:
         Given a URL conf regex, return a URI template string.
         """
         # ???: Would it be feasible to adjust this such that we generate the
-        # path, plus the kwargs, plus the type from the convertor, such that we
+        # path, plus the kwargs, plus the type from the converter, such that we
         # could feed that straight into the parameter schema object?
 
         path = simplify_regex(path_regex)
 
-        # Strip Django 2.0 convertors as they are incompatible with uritemplate format
+        # Strip Django 2.0 converters as they are incompatible with uritemplate format
         return re.sub(_PATH_PARAMETER_COMPONENT_RE, r'{\g<parameter>}', path)
 
     def should_include_endpoint(self, path, callback):

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -84,7 +84,7 @@ class SchemaGenerator(BaseSchemaGenerator):
                     continue
                 if components_schemas[k] == components[k]:
                     continue
-                warnings.warn('Schema component "{}" has been overriden with a different value.'.format(k))
+                warnings.warn('Schema component "{}" has been overridden with a different value.'.format(k))
 
             components_schemas.update(components)
 

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -116,7 +116,7 @@ DEFAULTS = {
     'COERCE_DECIMAL_TO_STRING': True,
     'UPLOADED_FILES_USE_URL': True,
 
-    # Browseable API
+    # Browsable API
     'HTML_SELECT_CUTOFF': 1000,
     'HTML_SELECT_CUTOFF_TEXT': "More than {count} items...",
 

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -1347,7 +1347,7 @@ class TestGenerator(TestCase):
 
             assert len(w) == 1
             assert issubclass(w[-1].category, UserWarning)
-            assert 'has been overriden with a different value.' in str(w[-1].message)
+            assert 'has been overridden with a different value.' in str(w[-1].message)
 
         assert 'components' in schema
         assert 'schemas' in schema['components']

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -132,7 +132,7 @@ urlpatterns = [
 ]
 
 
-# TODO: Clean tests bellow - remove duplicates with above, better unit testing, ...
+# TODO: Clean tests below - remove duplicates with above, better unit testing, ...
 @override_settings(ROOT_URLCONF='tests.test_response')
 class RendererIntegrationTests(TestCase):
     """

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -223,7 +223,7 @@ class TestNotRequiredNestedSerializerWithMany:
         input_data = {}
         serializer = self.Serializer(data=input_data)
 
-        # request is empty, therefor 'nested' should not be in serializer.data
+        # request is empty, therefore 'nested' should not be in serializer.data
         assert serializer.is_valid()
         assert 'nested' not in serializer.validated_data
 
@@ -237,7 +237,7 @@ class TestNotRequiredNestedSerializerWithMany:
         input_data = QueryDict('')
         serializer = self.Serializer(data=input_data)
 
-        # the querydict is empty, therefor 'nested' should not be in serializer.data
+        # the querydict is empty, therefore 'nested' should not be in serializer.data
         assert serializer.is_valid()
         assert 'nested' not in serializer.validated_data
 


### PR DESCRIPTION
## Description

% `codespell --ignore-words-list=childs,fo,malcom,ser --skip="*.js,*/kickstarter-announcement.md,*.map,*.po" --write-changes`
* https://pypi.org/project/codespell