### PR TITLE
Add Django 5.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 # Requirements
 
 * Python 3.6+
-* Django 4.2, 4.1, 4.0, 3.2, 3.1, 3.0
+* Django 5.0, 4.2, 4.1, 4.0, 3.2, 3.1, 3.0
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ continued development by **[signing up for a paid plan][funding]**.
 REST framework requires the following:
 
 * Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11)
-* Django (3.0, 3.1, 3.2, 4.0, 4.1, 4.2)
+* Django (3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.0)
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1538,7 +1538,8 @@ class TestNoOutputFormatDateTimeField(FieldValues):
     field = serializers.DateTimeField(format=None)
 
 
-class TestNaiveDateTimeField(FieldValues):
+@override_settings(TIME_ZONE='UTC', USE_TZ=False)
+class TestNaiveDateTimeField(FieldValues, TestCase):
     """
     Valid and invalid values for `DateTimeField` with naive datetimes.
     """

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -8,6 +8,7 @@ an appropriate set of serializer fields for each case.
 import datetime
 import decimal
 import json  # noqa
+import re
 import sys
 import tempfile
 
@@ -169,33 +170,32 @@ class TestRegularFieldMappings(TestCase):
                 model = RegularFieldsModel
                 fields = '__all__'
 
-        expected = dedent("""
-            TestSerializer():
-                auto_field = IntegerField(read_only=True)
-                big_integer_field = IntegerField()
-                boolean_field = BooleanField(default=False, required=False)
-                char_field = CharField(max_length=100)
-                comma_separated_integer_field = CharField(max_length=100, validators=[<django.core.validators.RegexValidator object>])
-                date_field = DateField()
-                datetime_field = DateTimeField()
-                decimal_field = DecimalField(decimal_places=1, max_digits=3)
-                email_field = EmailField(max_length=100)
-                float_field = FloatField()
-                integer_field = IntegerField()
-                null_boolean_field = BooleanField(allow_null=True, default=False, required=False)
-                positive_integer_field = IntegerField()
-                positive_small_integer_field = IntegerField()
-                slug_field = SlugField(allow_unicode=False, max_length=100)
-                small_integer_field = IntegerField()
-                text_field = CharField(max_length=100, style={'base_template': 'textarea.html'})
-                file_field = FileField(max_length=100)
-                time_field = TimeField()
-                url_field = URLField(max_length=100)
-                custom_field = ModelField(model_field=<tests.test_model_serializer.CustomField: custom_field>)
-                file_path_field = FilePathField(path=%r)
+        expected = dedent(r"""
+            TestSerializer\(\):
+                auto_field = IntegerField\(read_only=True\)
+                big_integer_field = IntegerField\(.*\)
+                boolean_field = BooleanField\(default=False, required=False\)
+                char_field = CharField\(max_length=100\)
+                comma_separated_integer_field = CharField\(max_length=100, validators=\[<django.core.validators.RegexValidator object>\]\)
+                date_field = DateField\(\)
+                datetime_field = DateTimeField\(\)
+                decimal_field = DecimalField\(decimal_places=1, max_digits=3\)
+                email_field = EmailField\(max_length=100\)
+                float_field = FloatField\(\)
+                integer_field = IntegerField\(.*\)
+                null_boolean_field = BooleanField\(allow_null=True, default=False, required=False\)
+                positive_integer_field = IntegerField\(.*\)
+                positive_small_integer_field = IntegerField\(.*\)
+                slug_field = SlugField\(allow_unicode=False, max_length=100\)
+                small_integer_field = IntegerField\(.*\)
+                text_field = CharField\(max_length=100, style={'base_template': 'textarea.html'}\)
+                file_field = FileField\(max_length=100\)
+                time_field = TimeField\(\)
+                url_field = URLField\(max_length=100\)
+                custom_field = ModelField\(model_field=<tests.test_model_serializer.CustomField: custom_field>\)
+                file_path_field = FilePathField\(path=%r\)
         """ % tempfile.gettempdir())
-
-        self.assertEqual(repr(TestSerializer()), expected)
+        assert re.search(expected, repr(TestSerializer())) is not None
 
     def test_field_options(self):
         class TestSerializer(serializers.ModelSerializer):
@@ -203,19 +203,19 @@ class TestRegularFieldMappings(TestCase):
                 model = FieldOptionsModel
                 fields = '__all__'
 
-        expected = dedent("""
-            TestSerializer():
-                id = IntegerField(label='ID', read_only=True)
-                value_limit_field = IntegerField(max_value=10, min_value=1)
-                length_limit_field = CharField(max_length=12, min_length=3)
-                blank_field = CharField(allow_blank=True, max_length=10, required=False)
-                null_field = IntegerField(allow_null=True, required=False)
-                default_field = IntegerField(default=0, required=False)
-                descriptive_field = IntegerField(help_text='Some help text', label='A label')
-                choices_field = ChoiceField(choices=(('red', 'Red'), ('blue', 'Blue'), ('green', 'Green')))
-                text_choices_field = ChoiceField(choices=(('red', 'Red'), ('blue', 'Blue'), ('green', 'Green')))
+        expected = dedent(r"""
+            TestSerializer\(\):
+                id = IntegerField\(label='ID', read_only=True\)
+                value_limit_field = IntegerField\(max_value=10, min_value=1\)
+                length_limit_field = CharField\(max_length=12, min_length=3\)
+                blank_field = CharField\(allow_blank=True, max_length=10, required=False\)
+                null_field = IntegerField\(allow_null=True,.*required=False\)
+                default_field = IntegerField\(default=0,.*required=False\)
+                descriptive_field = IntegerField\(help_text='Some help text', label='A label'.*\)
+                choices_field = ChoiceField\(choices=(?:\[|\()\('red', 'Red'\), \('blue', 'Blue'\), \('green', 'Green'\)(?:\]|\))\)
+                text_choices_field = ChoiceField\(choices=(?:\[|\()\('red', 'Red'\), \('blue', 'Blue'\), \('green', 'Green'\)(?:\]|\))\)
         """)
-        self.assertEqual(repr(TestSerializer()), expected)
+        assert re.search(expected, repr(TestSerializer())) is not None
 
     def test_nullable_boolean_field_choices(self):
         class NullableBooleanChoicesModel(models.Model):
@@ -1334,12 +1334,12 @@ class TestFieldSource(TestCase):
                     }
                 }
 
-        expected = dedent("""
-            TestSerializer():
-                number_field = IntegerField(source='integer_field')
+        expected = dedent(r"""
+            TestSerializer\(\):
+                number_field = IntegerField\(.*source='integer_field'\)
         """)
         self.maxDiff = None
-        self.assertEqual(repr(TestSerializer()), expected)
+        assert re.search(expected, repr(TestSerializer())) is not None
 
 
 class Issue6110TestModel(models.Model):

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
        {py36,py37,py38,py39}-django31
        {py36,py37,py38,py39,py310}-django32
        {py38,py39,py310}-{django40,django41,django42,djangomain}
-       {py311}-{django41,django42,djangomain}
-       {py312}-{django42,djangomain}
+       {py311}-{django41,django42,django50,djangomain}
+       {py312}-{django42,djanggo50,djangomain}
        base
        dist
        docs
@@ -23,6 +23,7 @@ deps =
         django40: Django>=4.0,<4.1
         django41: Django>=4.1,<4.2
         django42: Django>=4.2,<5.0
+        django50: Django>=5.0,<5.1
         djangomain: https://github.com/django/django/archive/main.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
This PR (based on https://github.com/encode/django-rest-framework/pull/9230) fixes the test suite for supporting Django 5.0, enables it on the CI, and updates the documentation.

It also fixes the tests for djangomain (up to https://github.com/django/django/commit/e412d85b4626bc56eb25206a40c3529162ce5dfc)