### PR TITLE
Add missing import in /api-guide/viewsets/ example

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -311,7 +311,7 @@ You may need to provide custom `ViewSet` classes that do not have the full set o
 
 To create a base viewset class that provides `create`, `list` and `retrieve` operations, inherit from `GenericViewSet`, and mixin the required actions:
 
-    from rest_framework import mixins
+    from rest_framework import mixins, viewsets
 
     class CreateListRetrieveViewSet(mixins.CreateModelMixin,
                                     mixins.ListModelMixin,


### PR DESCRIPTION
## Description

Add missing import in https://www.django-rest-framework.org/api-guide/viewsets/#example_3

To be a correct example in case of a quick copy/paste it requires import `viewsets` to work as expected