### PR TITLE
Add support for multiple authentication challenges in WWW-Authenticate header

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -84,7 +84,7 @@ When an unauthenticated request is denied permission there are two different err
 * [HTTP 401 Unauthorized][http401]
 * [HTTP 403 Permission Denied][http403]
 
-HTTP 401 responses must always include a `WWW-Authenticate` header, that instructs the client how to authenticate.  HTTP 403 responses do not include the `WWW-Authenticate` header.
+HTTP 401 responses must always include a `WWW-Authenticate` header, that instructs the client how to authenticate.  The `www_authenticate_behavior` setting controls how the header is generated: if set to `'first'` (the default), then only the text for the first scheme in the list will be used; if set to `'all'`, then a comma-separated list of the text for all the schemes will be used (see [MDN WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate) for more details).  HTTP 403 responses do not include the `WWW-Authenticate` header.
 
 The kind of response that will be used depends on the authentication scheme.  Although multiple authentication schemes may be in use, only one scheme may be used to determine the type of response.  **The first authentication class set on the view is used when determining the type of response**.
 

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -189,6 +189,13 @@ The class that should be used to initialize `request.auth` for unauthenticated r
 
 Default: `None`
 
+#### WWW_AUTHENTICATE_BEHAVIOR
+
+Determines whether a single or multiple challenges are presented in the `WWW-Authenticate` header.
+
+This should be set to `'first'` (the default value) or `'all'`. When set to `'first'`, the `WWW-Authenticate` header will be set to an appropriate challenge for the first authentication scheme in the list.
+When set to `'all'`, a comma-separated list of the challenge for all specified authentication schemes will be used instead (following the [syntax specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate)).
+
 ---
 
 ## Test settings

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -78,6 +78,7 @@ DEFAULTS = {
     # Authentication
     'UNAUTHENTICATED_USER': 'django.contrib.auth.models.AnonymousUser',
     'UNAUTHENTICATED_TOKEN': None,
+    'WWW_AUTHENTICATE_BEHAVIOR': 'first',
 
     # View configuration
     'VIEW_NAME_FUNCTION': 'rest_framework.views.get_view_name',

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -107,6 +107,7 @@ class APIView(View):
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES
     parser_classes = api_settings.DEFAULT_PARSER_CLASSES
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
+    www_authenticate_behavior = api_settings.WWW_AUTHENTICATE_BEHAVIOR
     throttle_classes = api_settings.DEFAULT_THROTTLE_CLASSES
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES
     content_negotiation_class = api_settings.DEFAULT_CONTENT_NEGOTIATION_CLASS
@@ -186,8 +187,13 @@ class APIView(View):
         header to use for 401 responses, if any.
         """
         authenticators = self.get_authenticators()
+        www_authenticate_behavior = self.www_authenticate_behavior
         if authenticators:
-            return authenticators[0].authenticate_header(request)
+            if www_authenticate_behavior == 'first':
+                return authenticators[0].authenticate_header(request)
+            elif www_authenticate_behavior == 'all':
+                challenges = (a.authenticate_header(request) for a in authenticators)
+                return ', '.join((c for c in challenges if c is not None))
 
     def get_parser_context(self, http_request):
         """


### PR DESCRIPTION
This adds a setting to enable emitting a comma-separated list of challenges in the `WWW-Authenticate` header that is returned with a 401 response.

Fixes #7328 and resolves #7812.