### PR TITLE
Revert "Register Django urls (#8778)"

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -132,8 +132,6 @@ Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
         path('', include(router.urls)),
         path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
-    
-    urlpatterns += router.urls
 
 Because we're using viewsets instead of views, we can automatically generate the URL conf for our API, by simply registering the viewsets with a router class.
 


### PR DESCRIPTION
# Description

Hello, this PR reverts the PR #8778.

When I was doing the Quickstart tutorial, I was a bit confused with the `urlpatterns` configurations in the URLs section (https://www.django-rest-framework.org/tutorial/quickstart/#urls) because it includes URL routes for REST framework twice.

I think we don't have to append the same routes to make the REST framework routes working properly.

Here are the routes before and after this PR's change:

**Before**

![Screenshot 2024-02-12 at 20 49 33](https://github.com/encode/django-rest-framework/assets/1425259/6644bd71-95bb-45b0-9b7a-dd034fdac835)

**After**
![Screenshot 2024-02-12 at 20 49 46](https://github.com/encode/django-rest-framework/assets/1425259/eb6b5b70-10a3-44bb-b82e-aa60b2c88d47)


As you can see, `urlpatterns += router.urls` makes the extra duplicated routes unnecessarily.