### PR TITLE
Resolve setup-python deprecation warnings on Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -64,7 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

This PR resolves the deprecation warnings for `setup-python` in Github actions. An example of them appearing is here: https://github.com/encode/django-rest-framework/actions/runs/8065738414

Showing that the deprecation warnings are now removed: https://github.com/encode/django-rest-framework/actions/runs/8069177070?pr=9266
