### PR TITLE
GitHub Actions: Upgrade pre-commit and drop the removed token

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,14 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - uses: pre-commit/action@v3.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Removes some warnings at the bottom right of https://github.com/encode/django-rest-framework/actions/runs/8079303418
* https://github.com/pre-commit/action/releases
* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-python/releases

https://github.com/pre-commit/action#using-this-action-in-private-repositories explains why `token` was removed but is a bit difficult to understand.

Moving to running pre-commit on https://pre-commit.ci has proved to be the best solution on other projects.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
