### PR TITLE
Remove the `_delegate_text` attribute, which is being removed in django 5.0 (#9274)

### DIFF
--- a/rest_framework/utils/representation.py
+++ b/rest_framework/utils/representation.py
@@ -27,8 +27,8 @@ def smart_repr(value):
     if isinstance(value, models.Manager):
         return manager_repr(value)
 
-    if isinstance(value, Promise) and value._delegate_text:
-        value = force_str(value)
+    if isinstance(value, Promise):
+        value = force_str(value, strings_only=True)
 
     value = repr(value)
 


### PR DESCRIPTION
… django 5.0

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

This pull request resolves #9274 

1. the implementation of `force_str` in django 3 and django 5 versions doesn't seem to differ much except for a few code styles (https://www.diffchecker.com/kGpPbE3K/)
Therefore, I don't think we need to add logic in our code to look at the django version.

2. the removed `_delegate_text` being `False` means "don't expect that object to be a string", so I think adding `strings_only` like the code in the original issue is sufficient.

P.S.: If @jayden-arrai can send us a better PR, I'll close this one. I hope this doesn't offend the original issue raiser..
