### PR TITLE
request.py: E714 Test for object identity should be `is not`

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -87,7 +87,7 @@ class Empty:
 
 
 def _hasattr(obj, name):
-    return not getattr(obj, name) is Empty
+    return getattr(obj, name) is not Empty
 
 
 def clone_request(request, method):


### PR DESCRIPTION
As discussed in PEP8...
```diff
-    return not getattr(obj, name) is Empty
+    return getattr(obj, name) is not Empty
```
% `ruff rule E714`
# not-is-test (E714)

Derived from the **pycodestyle** linter.

Fix is always available.

## What it does
Checks for negative comparison using `not {foo} is {bar}`.

## Why is this bad?
Negative comparison should be done using `is not`.

## Example
```python
if not X is Y:
    pass
Z = not X.B is Y
```

Use instead:
```python
if X is not Y:
    pass
Z = X.B is not Y
```

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
