### PR TITLE
Use comprehensions

### DIFF
--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -380,7 +380,7 @@ class AutoSchema(ViewInspector):
         manual_fields = self.get_manual_fields(path, method)
         fields = self.update_fields(fields, manual_fields)
 
-        if fields and any([field.location in ('form', 'body') for field in fields]):
+        if fields and any(field.location in ('form', 'body') for field in fields):
             encoding = self.get_encoding(path, method)
         else:
             encoding = None

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -67,7 +67,7 @@ def get_unique_validators(field_name, model_field):
     """
     Returns a list of UniqueValidators that should be applied to the field.
     """
-    field_set = set([field_name])
+    field_set = {field_name}
     conditions = {
         c.condition
         for c in model_field.model._meta.constraints

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -354,10 +354,10 @@ class APIView(View):
         Check if request should be throttled.
         Raises an appropriate exception if the request is throttled.
         """
-        throttle_durations = []
-        for throttle in self.get_throttles():
-            if not throttle.allow_request(request, self):
-                throttle_durations.append(throttle.wait())
+        throttle_durations = [
+            throttle.wait() for throttle in self.get_throttles()
+            if not throttle.allow_request(request, self)
+        ]
 
         if throttle_durations:
             # Filter out `None` values which may happen in case of config / rate

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -262,7 +262,7 @@ class TestOperationIntrospection(TestCase):
 
         components = inspector.get_components(path, method)
         assert components['Item']['required'] == ['text']
-        assert sorted(list(components['Item']['properties'].keys())) == ['read_only', 'text']
+        assert sorted(components['Item']['properties'].keys()) == ['read_only', 'text']
 
     def test_invalid_serializer_class_name(self):
         path = '/'
@@ -366,7 +366,7 @@ class TestOperationIntrospection(TestCase):
 
         components = inspector.get_components(path, method)
         assert sorted(components['Item']['required']) == ['text', 'write_only']
-        assert sorted(list(components['Item']['properties'].keys())) == ['text', 'write_only']
+        assert sorted(components['Item']['properties'].keys()) == ['text', 'write_only']
         assert 'description' in responses['201']
 
     def test_response_body_nested_serializer(self):
@@ -398,7 +398,7 @@ class TestOperationIntrospection(TestCase):
 
         schema = components['Item']
         assert sorted(schema['required']) == ['nested', 'text']
-        assert sorted(list(schema['properties'].keys())) == ['nested', 'text']
+        assert sorted(schema['properties'].keys()) == ['nested', 'text']
         assert schema['properties']['nested']['type'] == 'object'
         assert list(schema['properties']['nested']['properties'].keys()) == ['number']
         assert schema['properties']['nested']['required'] == ['number']

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -232,9 +232,7 @@ class TestRegularFieldMappings(TestCase):
                 model = NullableBooleanChoicesModel
                 fields = ['field']
 
-        serializer = NullableBooleanChoicesSerializer(data=dict(
-            field=None,
-        ))
+        serializer = NullableBooleanChoicesSerializer(data={'field': None})
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.errors, {})
 

--- a/tests/test_requests_client.py
+++ b/tests/test_requests_client.py
@@ -55,16 +55,12 @@ class HeadersView(APIView):
 
 class SessionView(APIView):
     def get(self, request):
-        return Response({
-            key: value for key, value in request.session.items()
-        })
+        return Response(dict(request.session.items()))
 
     def post(self, request):
         for key, value in request.data.items():
             request.session[key] = value
-        return Response({
-            key: value for key, value in request.session.items()
-        })
+        return Response(dict(request.session.items()))
 
 
 class AuthView(APIView):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -115,13 +115,13 @@ class TestUniquenessValidation(TestCase):
         instance = AnotherUniquenessModel.objects.create(code='100')
         serializer = AnotherUniquenessSerializer(instance)
         assert all(
-            ["Unique" not in repr(v) for v in AnotherUniquenessModel._meta.get_field('code').validators]
+            "Unique" not in repr(v) for v in AnotherUniquenessModel._meta.get_field('code').validators
         )
 
         # Accessing data shouldn't effect validators on the model
         serializer.data
         assert all(
-            ["Unique" not in repr(v) for v in AnotherUniquenessModel._meta.get_field('code').validators]
+            "Unique" not in repr(v) for v in AnotherUniquenessModel._meta.get_field('code').validators
         )
 
     def test_related_model_is_unique(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,10 +27,8 @@ class MockQueryset:
 
     def get(self, **lookup):
         for item in self.items:
-            if all([
-                attrgetter(key.replace('__', '.'))(item) == value
-                for key, value in lookup.items()
-            ]):
+            if all(attrgetter(key.replace('__', '.'))(item) == value
+                    for key, value in lookup.items()):
                 return item
         raise ObjectDoesNotExist()
 


### PR DESCRIPTION
## Description

Use `dict`, `list`, and `set` comprehensions to improve the readability and performance of Python code.

% `ruff check --select=C4,PERF401`
```
rest_framework/schemas/coreapi.py:383:27: C419 Unnecessary list comprehension
rest_framework/utils/field_mapping.py:70:17: C405 Unnecessary `list` literal (rewrite as a `set` literal)
rest_framework/views.py:360:17: PERF401 Use a list comprehension to create a transformed list
tests/schemas/test_openapi.py:265:16: C414 Unnecessary `list` call within `sorted()`
tests/schemas/test_openapi.py:369:16: C414 Unnecessary `list` call within `sorted()`
tests/schemas/test_openapi.py:401:16: C414 Unnecessary `list` call within `sorted()`
tests/test_model_serializer.py:235:60: C408 Unnecessary `dict` call (rewrite as a literal)
tests/test_requests_client.py:58:25: C416 Unnecessary `dict` comprehension (rewrite using `dict()`)
tests/test_requests_client.py:65:25: C416 Unnecessary `dict` comprehension (rewrite using `dict()`)
tests/test_validators.py:118:13: C419 Unnecessary list comprehension
tests/test_validators.py:124:13: C419 Unnecessary list comprehension
tests/utils.py:30:20: C419 Unnecessary list comprehension
```
% `ruff check --select=C4 --fix --unsafe-fixes`
```
Found 11 errors (11 fixed, 0 remaining).
```
% `ruff rule C414`
# unnecessary-double-cast-or-process (C414)

Derived from the **flake8-comprehensions** linter.

Fix is always available.

## What it does
Checks for unnecessary `list`, `reversed`, `set`, `sorted`, and `tuple`
call within `list`, `set`, `sorted`, and `tuple` calls.

## Why is this bad?
It's unnecessary to double-cast or double-process iterables by wrapping
the listed functions within an additional `list`, `set`, `sorted`, or
`tuple` call. Doing so is redundant and can be confusing for readers.

## Examples
```python
list(tuple(iterable))
```

Use instead:
```python
list(iterable)
```

This rule applies to a variety of functions, including `list`, `reversed`,
`set`, `sorted`, and `tuple`. For example:

- Instead of `list(list(iterable))`, use `list(iterable)`.
- Instead of `list(tuple(iterable))`, use `list(iterable)`.
- Instead of `tuple(list(iterable))`, use `tuple(iterable)`.
- Instead of `tuple(tuple(iterable))`, use `tuple(iterable)`.
- Instead of `set(set(iterable))`, use `set(iterable)`.
- Instead of `set(list(iterable))`, use `set(iterable)`.
- Instead of `set(tuple(iterable))`, use `set(iterable)`.
- Instead of `set(sorted(iterable))`, use `set(iterable)`.
- Instead of `set(reversed(iterable))`, use `set(iterable)`.
- Instead of `sorted(list(iterable))`, use `sorted(iterable)`.
- Instead of `sorted(tuple(iterable))`, use `sorted(iterable)`.
- Instead of `sorted(sorted(iterable))`, use `sorted(iterable)`.
- Instead of `sorted(reversed(iterable))`, use `sorted(iterable)`.

## Fix safety
This rule's fix is marked as unsafe, as it may occasionally drop comments
when rewriting the call. In most cases, though, comments will be preserved.
