### PR TITLE
Fix function returns

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -230,3 +230,4 @@ class RemoteUserAuthentication(BaseAuthentication):
         user = authenticate(request=request, remote_user=request.META.get(self.header))
         if user and user.is_active:
             return (user, None)
+        return None

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -708,6 +708,7 @@ class BooleanField(Field):
             elif self._lower_if_str(data) in self.NULL_VALUES and self.allow_null:
                 return None
         self.fail("invalid", input=data)
+        return None
 
     def to_representation(self, value):
         if self._lower_if_str(value) in self.TRUE_VALUES:
@@ -1196,6 +1197,7 @@ class DateTimeField(Field):
 
         humanized_format = humanize_datetime.datetime_formats(input_formats)
         self.fail('invalid', format=humanized_format)
+        return None
 
     def to_representation(self, value):
         if not value:
@@ -1258,6 +1260,7 @@ class DateField(Field):
 
         humanized_format = humanize_datetime.date_formats(input_formats)
         self.fail('invalid', format=humanized_format)
+        return None
 
     def to_representation(self, value):
         if not value:
@@ -1321,6 +1324,7 @@ class TimeField(Field):
 
         humanized_format = humanize_datetime.time_formats(input_formats)
         self.fail('invalid', format=humanized_format)
+        return None
 
     def to_representation(self, value):
         if value in (None, ''):
@@ -1376,6 +1380,7 @@ class DurationField(Field):
         if parsed is not None:
             return parsed
         self.fail('invalid', format='[DD] [HH:[MM:]]ss[.uuuuuu]')
+        return None
 
     def to_representation(self, value):
         return duration_string(value)

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -558,7 +558,7 @@ class LimitOffsetPagination(BasePagination):
         ]
 
     def get_schema_operation_parameters(self, view):
-        parameters = [
+        return [
             {
                 'name': self.limit_query_param,
                 'required': False,
@@ -578,7 +578,6 @@ class LimitOffsetPagination(BasePagination):
                 },
             },
         ]
-        return parameters
 
 
 class CursorPagination(BasePagination):

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -197,8 +197,7 @@ class TemplateHTMLRenderer(BaseRenderer):
         except Exception:
             # Fall back to using eg '404 Not Found'
             body = '%d %s' % (response.status_code, response.status_text.title())
-            template = engines['django'].from_string(body)
-            return template
+            return engines['django'].from_string(body)
 
 
 # Note, subclass TemplateHTMLRenderer simply for the exception behavior
@@ -424,7 +423,7 @@ class BrowsableAPIRenderer(BaseRenderer):
         Returns True if a form should be shown for this method.
         """
         if method not in view.allowed_methods:
-            return  # Not a valid method
+            return None  # Not a valid method
 
         try:
             view.check_permissions(request)
@@ -473,7 +472,7 @@ class BrowsableAPIRenderer(BaseRenderer):
 
         with override_method(view, request, method) as request:
             if not self.show_form_for_method(view, method, request, instance):
-                return
+                return None
 
             if method in ('DELETE', 'OPTIONS'):
                 return True  # Don't actually need to return a form
@@ -485,7 +484,7 @@ class BrowsableAPIRenderer(BaseRenderer):
                 (not has_serializer and not has_serializer_class) or
                 not any(is_form_media_type(parser.media_type) for parser in view.parser_classes)
             ):
-                return
+                return None
 
             if existing_serializer is not None:
                 with contextlib.suppress(TypeError):
@@ -538,7 +537,7 @@ class BrowsableAPIRenderer(BaseRenderer):
         with override_method(view, request, method) as request:
             # Check permissions
             if not self.show_form_for_method(view, method, request, instance):
-                return
+                return None
 
             # If possible, serialize the initial content for the generic form
             default_parser = view.parser_classes[0]
@@ -615,7 +614,7 @@ class BrowsableAPIRenderer(BaseRenderer):
 
     def get_filter_form(self, data, view, request):
         if not hasattr(view, 'get_queryset') or not hasattr(view, 'filter_backends'):
-            return
+            return None
 
         # Infer if this is a list view or not.
         paginator = getattr(view, 'paginator', None)
@@ -625,9 +624,9 @@ class BrowsableAPIRenderer(BaseRenderer):
             try:
                 paginator.get_results(data)
             except (TypeError, KeyError):
-                return
+                return None
         elif not isinstance(data, list):
-            return
+            return None
 
         queryset = view.get_queryset()
         elements = []
@@ -638,7 +637,7 @@ class BrowsableAPIRenderer(BaseRenderer):
                     elements.append(html)
 
         if not elements:
-            return
+            return None
 
         template = loader.get_template(self.filter_template)
         context = {'elements': elements}
@@ -833,7 +832,7 @@ class AdminRenderer(BrowsableAPIRenderer):
         """
         if not hasattr(view, 'reverse_action') or \
            not hasattr(view, 'lookup_field'):
-            return
+            return None
 
         lookup_field = view.lookup_field
         lookup_url_kwarg = getattr(view, 'lookup_url_kwarg', None) or lookup_field
@@ -842,7 +841,7 @@ class AdminRenderer(BrowsableAPIRenderer):
             kwargs = {lookup_url_kwarg: result[lookup_field]}
             return view.reverse_action('detail', kwargs=kwargs)
         except (KeyError, NoReverseMatch):
-            return
+            return None
 
 
 class DocumentationRenderer(BaseRenderer):

--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -557,8 +557,7 @@ class AutoSchema(ViewInspector):
         by_name = {f.name: f for f in fields}
         for f in update_with:
             by_name[f.name] = f
-        fields = list(by_name.values())
-        return fields
+        return list(by_name.values())
 
     def get_encoding(self, path, method):
         """

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -44,7 +44,7 @@ class BaseThrottle:
         Optionally, return a recommended number of seconds to wait before
         the next request.
         """
-        return None
+        return
 
 
 class SimpleRateThrottle(BaseThrottle):

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -36,8 +36,7 @@ class JSONEncoder(json.JSONEncoder):
         elif isinstance(obj, datetime.time):
             if timezone and timezone.is_aware(obj):
                 raise ValueError("JSON can't represent timezone-aware times.")
-            representation = obj.isoformat()
-            return representation
+            return obj.isoformat()
         elif isinstance(obj, datetime.timedelta):
             return str(obj.total_seconds())
         elif isinstance(obj, decimal.Decimal):

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -188,6 +188,7 @@ class APIView(View):
         authenticators = self.get_authenticators()
         if authenticators:
             return authenticators[0].authenticate_header(request)
+        return None
 
     def get_parser_context(self, http_request):
         """
@@ -252,6 +253,7 @@ class APIView(View):
         """
         if self.settings.FORMAT_SUFFIX_KWARG:
             return kwargs.get(self.settings.FORMAT_SUFFIX_KWARG)
+        return None
 
     def get_renderers(self):
         """

--- a/tests/browsable_api/views.py
+++ b/tests/browsable_api/views.py
@@ -29,5 +29,4 @@ class BasicModelWithUsersViewSet(ModelViewSet):
     renderer_classes = (renderers.BrowsableAPIRenderer, renderers.JSONRenderer)
 
     def get_queryset(self):
-        qs = super().get_queryset().filter(users=self.request.user)
-        return qs
+        return super().get_queryset().filter(users=self.request.user)

--- a/tests/models.py
+++ b/tests/models.py
@@ -131,10 +131,9 @@ class OneToOnePKSource(RESTFrameworkModel):
 class CustomManagerModel(RESTFrameworkModel):
     class CustomManager:
         def __new__(cls, *args, **kwargs):
-            cls = BaseManager.from_queryset(
+            return BaseManager.from_queryset(
                 QuerySet
             )
-            return cls
 
     objects = CustomManager()()
     # `CustomManager()` will return a `BaseManager` class.

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -25,14 +25,12 @@ from . import views
 
 def create_request(path):
     factory = RequestFactory()
-    request = Request(factory.get(path))
-    return request
+    return Request(factory.get(path))
 
 
 def create_view(view_cls, method, request):
     generator = SchemaGenerator()
-    view = generator.create_view(view_cls.as_view(), method, request)
-    return view
+    return generator.create_view(view_cls.as_view(), method, request)
 
 
 class TestBasics(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -32,6 +32,7 @@ def basic_view(request):
         return {'method': 'PUT', 'data': request.data}
     elif request.method == 'PATCH':
         return {'method': 'PATCH', 'data': request.data}
+    return None
 
 
 class ErrorView(APIView):


### PR DESCRIPTION
## Description

Improve the readability and performance of function `return` statements.

% `ruff check --select=RET --statistics`
```
    1	RET501	[*] Do not explicitly `return None` in function if it is the only possible return value
   10	RET502 	[*] Do not implicitly `return None` in function able to return non-`None` value
    9	RET503 	[*] Missing explicit `return` at the end of function able to return non-`None` value
    8	RET504 	[*] Unnecessary assignment to `cls` before `return` statement
```
% `ruff check --select=RET --fix --unsafe-fixes`
```
Found 64 errors (28 fixed, 36 remaining).
```
% `ruff rule RET502`
# implicit-return-value (RET502)

Derived from the **flake8-return** linter.

Fix is always available.

## What it does
Checks for the presence of a `return` statement with no explicit value,
for functions that return non-`None` values elsewhere.

## Why is this bad?
Including a `return` statement with no explicit value can cause confusion
when other `return` statements in the function return non-`None` values.
Python implicitly assumes return `None` if no other return value is present.
Adding an explicit `return None` can make the code more readable by clarifying
intent.

## Example
```python
def foo(bar):
    if not bar:
        return
    return 1
```

Use instead:
```python
def foo(bar):
    if not bar:
        return None
    return 1
```
