### PR TITLE
- Update the message to be consistent with the Django `HttpResponseBa…

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -421,7 +421,7 @@ class APIView(View):
         """
         # Make the error obvious if a proper response is not returned
         assert isinstance(response, HttpResponseBase), (
-            'Expected a `Response`, `HttpResponse` or `HttpStreamingResponse` '
+            'Expected a `Response`, `HttpResponse` or `StreamingHttpResponse` '
             'to be returned from the view, but received a `%s`'
             % type(response)
         )


### PR DESCRIPTION
## Description
I encountered an error with the assert statement due to incorrect logging. Upon reviewing the `HttpResponseBase` class, I discovered that its subclass should be `StreamingHttpResponse` instead of `HttpStreamingResponse`.
![image](https://github.com/encode/django-rest-framework/assets/5876946/9139b3bf-4280-4cc7-bbf5-f5dc24e6a499)

Reference: https://github.com/django/django/blob/b231bcd19e57267ce1fc21d42d46f0b65fdcfcf8/django/http/response.py#L432