### PR TITLE
Add amount of period for throttling

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -154,7 +154,7 @@ For example, multiple user throttle rates could be implemented by using the foll
             'example.throttles.SustainedRateThrottle'
         ],
         'DEFAULT_THROTTLE_RATES': {
-            'burst': '60/min',
+            'burst': '60/30-min',
             'sustained': '1000/day'
         }
     }

--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -45,7 +45,16 @@ The default throttling policy may be set globally, using the `DEFAULT_THROTTLE_C
         }
     }
 
-The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `second`, `minute`, `hour` or `day` as the throttle period.
+The rate descriptions used in `DEFAULT_THROTTLE_RATES` may include `second`, `minute`, `hour` or `day` as the throttle period,
+and period also can has amount. For example.
+    
+    ...
+    'DEFAULT_THROTTLE_RATES': {
+            'anon': '100/3-day',
+            'user': '2000/2-day'
+        }
+    ...
+
 
 You can also set the throttling policy on a per-view or per-viewset basis,
 using the `APIView` class-based views.

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -103,7 +103,13 @@ class SimpleRateThrottle(BaseThrottle):
             return (None, None)
         num, period = rate.split('/')
         num_requests = int(num)
-        duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}[period[0]]
+        duration = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400}
+        if "-" in period:
+            num_period, period = period.split("-")
+            duration = duration[period[0]] * int(num_period)
+            return (num_requests, duration)
+        duration = duration[period[0]]
+
         return (num_requests, duration)
 
     def allow_request(self, request, view):

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -179,6 +179,19 @@ class ThrottlingTests(TestCase):
         assert response.status_code == 429
         assert int(response['retry-after']) == 60
 
+        previous_rate = User3SecRateThrottle.rate
+        try:
+            User3SecRateThrottle.rate = '1/sec'
+
+            for dummy in range(24):
+                response = MockView_DoubleThrottling.as_view()(request)
+
+            assert response.status_code == 429
+            assert int(response['retry-after']) == 60
+        finally:
+            # reset
+            User3SecRateThrottle.rate = previous_rate
+
     def test_request_throttling_with_amount_of_period(self):
         self.set_throttle_timer(MockView_1RequestIn2SecondThrottling, 0)
         request = self.factory.get('/')


### PR DESCRIPTION
## Description

Use amount of period for more flexible configure throttling.

Now we can use like that:

```
REST_FRAMEWORK = {
        'DEFAULT_THROTTLE_CLASSES': [
            'example.throttles.BurstRateThrottle',
            'example.throttles.SustainedRateThrottle'
        ],
        'DEFAULT_THROTTLE_RATES': {
            'burst': '60/30-min',
            'sustained': '1000/day'
        }
    }
```
For burst scope we set 60 requests per 30 minutes, we also can set for seconds and hours like above.
Also taken care of backward compatibility.