### PR TITLE
TokenAdmin.autocomplete_fields Breaks Some Use Cases, Revert

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -28,7 +28,6 @@ class TokenAdmin(admin.ModelAdmin):
     search_help_text = _('Username')
     ordering = ('-created',)
     actions = None  # Actions not compatible with mapped IDs.
-    autocomplete_fields = ("user",)
 
     def get_changelist(self, request, **kwargs):
         return TokenChangeList


### PR DESCRIPTION
## Description

Fixes #9300. From the discussion in that issue, the PR ([here](https://github.com/encode/django-rest-framework/pull/8534)) that added `autocomplete_fields` to `TokenAdmin` does not work in all cases and should be reverted.
