### PR TITLE
Make `inflection` package truly optional

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -56,10 +56,11 @@ The following sections explain more.
 
 ### Install dependencies
 
-    pip install pyyaml uritemplate
+    pip install pyyaml uritemplate inflection
 
 * `pyyaml` is used to generate schema into YAML-based OpenAPI format.
 * `uritemplate` is used internally to get parameters in path.
+* `inflection` is used to pluralize operations more appropriately in the list endpoints.
 
 ### Generating a static schema with the `generateschema` management command
 

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -48,12 +48,9 @@ except ImportError:
 
 # inflection is optional
 try:
-    from inflection import pluralize
+    import inflection
 except ImportError:
-    def pluralize(text):
-        if not text.endswith('s'):
-            text += "s"
-        return text
+    inflection = None
 
 
 # requests is optional

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -46,6 +46,15 @@ try:
 except ImportError:
     yaml = None
 
+# inflection is optional
+try:
+    from inflection import pluralize
+except ImportError:
+    def pluralize(text):
+        if not text.endswith('s'):
+            text += "s"
+        return text
+
 
 # requests is optional
 try:

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -14,7 +14,7 @@ from django.utils.encoding import force_str
 from rest_framework import (
     RemovedInDRF315Warning, exceptions, renderers, serializers
 )
-from rest_framework.compat import uritemplate
+from rest_framework.compat import pluralize, uritemplate
 from rest_framework.fields import _UnvalidatedField, empty
 from rest_framework.settings import api_settings
 
@@ -247,8 +247,6 @@ class AutoSchema(ViewInspector):
                 name = name[:-len(action)]
 
         if action == 'list':
-            from inflection import pluralize
-
             name = pluralize(name)
 
         return name

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -14,7 +14,7 @@ from django.utils.encoding import force_str
 from rest_framework import (
     RemovedInDRF315Warning, exceptions, renderers, serializers
 )
-from rest_framework.compat import pluralize, uritemplate
+from rest_framework.compat import inflection, uritemplate
 from rest_framework.fields import _UnvalidatedField, empty
 from rest_framework.settings import api_settings
 
@@ -247,7 +247,8 @@ class AutoSchema(ViewInspector):
                 name = name[:-len(action)]
 
         if action == 'list':
-            name = pluralize(name)
+            assert inflection, '`inflection` must be installed for OpenAPI schema support.'
+            name = inflection.pluralize(name)
 
         return name
 


### PR DESCRIPTION
- [x] *Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Fix #9291

The 3.15 release started to use the `inflection` package (https://github.com/encode/django-rest-framework/pull/8017), but this was neither added as a dependency from DRF nor properly documented.

Since this is only needed for generating the OpenAPI schema ([which is deprecated](https://www.django-rest-framework.org/api-guide/schemas/)), I don't think it's worth introducing this package as a hard dependency, we can document it like `pyyaml` and `uritemplate`.

Since the former solution was ~1~ 3 lines, perhaps we can use it as fallback when `inflection` isn't installed?