### PR TITLE
Handle substitution errors with no parameters to ValidationError

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -162,7 +162,6 @@ class ValidationError(APIException):
         # For validation failures, we may collect many errors together,
         # so the details should always be coerced to a list if not already.
         if isinstance(detail, str):
-            #import pdb; pdb.set_trace()
             detail = [detail % params]
         elif isinstance(detail, ValidationError):
             detail = detail.detail
@@ -172,7 +171,6 @@ class ValidationError(APIException):
                 if isinstance(detail_item, ValidationError):
                     final_detail += detail_item.detail
                 else:
-                    #import pdb; pdb.set_trace()
                     final_detail += [detail_item % params if isinstance(detail_item, str) else detail_item]
             detail = final_detail
         elif not isinstance(detail, dict) and not isinstance(detail, list):

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -177,9 +177,7 @@ class ValidationError(APIException):
         """Handle error messages with templates and placeholders."""
         try:
             return detail % params
-        except KeyError:
-            return detail
-        except ValueError:
+        except (KeyError, ValueError, TypeError, IndexError, AttributeError):
             return detail
 
 

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -15,6 +15,11 @@ from rest_framework import status
 from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 
+class SafeReplacerDict(dict):
+    def __missing__(self, key):
+        return key
+
+
 def _get_error_details(data, default_code=None):
     """
     Descend into a nested data structure, forcing any
@@ -144,7 +149,7 @@ class ValidationError(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
     default_detail = _('Invalid input.')
     default_code = 'invalid'
-    default_params = {}
+    default_params = SafeReplacerDict()
 
     def __init__(self, detail=None, code=None, params=None):
         if detail is None:
@@ -157,6 +162,7 @@ class ValidationError(APIException):
         # For validation failures, we may collect many errors together,
         # so the details should always be coerced to a list if not already.
         if isinstance(detail, str):
+            #import pdb; pdb.set_trace()
             detail = [detail % params]
         elif isinstance(detail, ValidationError):
             detail = detail.detail
@@ -166,6 +172,7 @@ class ValidationError(APIException):
                 if isinstance(detail_item, ValidationError):
                     final_detail += detail_item.detail
                 else:
+                    #import pdb; pdb.set_trace()
                     final_detail += [detail_item % params if isinstance(detail_item, str) else detail_item]
             detail = final_detail
         elif not isinstance(detail, dict) and not isinstance(detail, list):

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -15,11 +15,6 @@ from rest_framework import status
 from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 
-class SafeReplacerDict(dict):
-    def __missing__(self, key):
-        return key
-
-
 def _get_error_details(data, default_code=None):
     """
     Descend into a nested data structure, forcing any

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -164,6 +164,7 @@ class TestValidationErrorWithDjangoStyle(TestCase):
             params={'value3': '44'}
         )
         assert isinstance(error.detail, list)
+        import pdb; pdb.set_trace()
         assert len(error.detail) == 3
         assert str(error.detail[0]) == 'Invalid value: 42'
         assert str(error.detail[1]) == 'Invalid value: 43'
@@ -197,7 +198,7 @@ class TestValidationErrorWithDjangoStyle(TestCase):
         assert str(error.detail[2]) == 'Invalid value: 44'
         assert str(error.detail[3]) == 'Invalid value: 45'
 
-    def test_validation_error_without_params(self):
+    def test_validation_error_without_params_string_templating(self):
         """Ensure that substitutable errors can be emitted without params."""
 
         # mimic the logic in fields.Field.run_validators by saving the exception
@@ -206,7 +207,24 @@ class TestValidationErrorWithDjangoStyle(TestCase):
         # the string has a substitutable substring ...
         errors = []
         try:
-            raise ValidationError('%(user)s')
+            raise ValidationError(detail='%(user)s')
+        except ValidationError as exc:
+            errors.extend(exc.detail)
+
+        # ensure it raises the correct exception type as an input to a new ValidationError
+        with pytest.raises(ValidationError):
+            raise ValidationError(errors)
+
+    def test_validation_error_without_params_date_formatters(self):
+        """Ensure that substitutable errors can be emitted without params."""
+
+        # mimic the logic in fields.Field.run_validators by saving the exception
+        # detail into a list which will then be the detail for a new ValidationError.
+        # this should not throw a KeyError or a TypeError even though
+        # the string has a substitutable substring ...
+        errors = []
+        try:
+            raise ValidationError(detail='Expects format %Y-%m-%d %H:%M:%S')
         except ValidationError as exc:
             errors.extend(exc.detail)
 

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -164,7 +164,6 @@ class TestValidationErrorWithDjangoStyle(TestCase):
             params={'value3': '44'}
         )
         assert isinstance(error.detail, list)
-        import pdb; pdb.set_trace()
         assert len(error.detail) == 3
         assert str(error.detail[0]) == 'Invalid value: 42'
         assert str(error.detail[1]) == 'Invalid value: 43'

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -214,6 +214,22 @@ class TestValidationErrorWithDjangoStyle(TestCase):
         with pytest.raises(ValidationError):
             raise ValidationError(errors)
 
+    def test_validation_error_without_params_digit(self):
+        """Ensure that substitutable errors can be emitted with a digit placeholder."""
+
+        # mimic the logic in fields.Field.run_validators by saving the exception
+        # detail into a list which will then be the detail for a new ValidationError.
+        # this should not throw a TypeError on the date format placeholders ...
+        errors = []
+        try:
+            raise ValidationError(detail='%d')
+        except ValidationError as exc:
+            errors.extend(exc.detail)
+
+        # ensure it raises the correct exception type as an input to a new ValidationError
+        with pytest.raises(ValidationError):
+            raise ValidationError(errors)
+
     def test_validation_error_without_params_date_formatters(self):
         """Ensure that substitutable errors can be emitted with invalid template placeholders."""
 
@@ -223,6 +239,46 @@ class TestValidationErrorWithDjangoStyle(TestCase):
         errors = []
         try:
             raise ValidationError(detail='Expects format %Y-%m-%d %H:%M:%S')
+        except ValidationError as exc:
+            errors.extend(exc.detail)
+
+        # ensure it raises the correct exception type as an input to a new ValidationError
+        with pytest.raises(ValidationError):
+            raise ValidationError(errors)
+
+    def test_validation_error_with_param_that_has_attribute_error(self):
+        """Ensure that substitutable errors can be emitted with a bad string repr."""
+
+        class FooBar:
+            def __str__(self):
+                raise AttributeError("i was poorly coded")
+
+        # mimic the logic in fields.Field.run_validators by saving the exception
+        # detail into a list which will then be the detail for a new ValidationError.
+        # this should not throw a ValueError on the date format placeholders ...
+        errors = []
+        try:
+            raise ValidationError(detail='%s', params=FooBar())
+        except ValidationError as exc:
+            errors.extend(exc.detail)
+
+        # ensure it raises the correct exception type as an input to a new ValidationError
+        with pytest.raises(ValidationError):
+            raise ValidationError(errors)
+
+    def test_validation_error_with_param_that_has_index_error(self):
+        """Ensure that substitutable errors can be emitted with a bad string repr."""
+
+        class FooBar:
+            def __str__(self):
+                raise IndexError("i was poorly coded")
+
+        # mimic the logic in fields.Field.run_validators by saving the exception
+        # detail into a list which will then be the detail for a new ValidationError.
+        # this should not throw a ValueError on the date format placeholders ...
+        errors = []
+        try:
+            raise ValidationError(detail='%s', params=FooBar())
         except ValidationError as exc:
             errors.extend(exc.detail)
 

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -219,8 +219,7 @@ class TestValidationErrorWithDjangoStyle(TestCase):
 
         # mimic the logic in fields.Field.run_validators by saving the exception
         # detail into a list which will then be the detail for a new ValidationError.
-        # this should not throw a KeyError or a TypeError even though
-        # the string has a substitutable substring ...
+        # this should not throw a ValueError on the date format placeholders ...
         errors = []
         try:
             raise ValidationError(detail='Expects format %Y-%m-%d %H:%M:%S')

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import TestCase
 
 from rest_framework import serializers, status
@@ -195,3 +196,20 @@ class TestValidationErrorWithDjangoStyle(TestCase):
         assert str(error.detail[1]) == 'Invalid value: 43'
         assert str(error.detail[2]) == 'Invalid value: 44'
         assert str(error.detail[3]) == 'Invalid value: 45'
+
+    def test_validation_error_without_params(self):
+        """Ensure that substitutable errors can be emitted without params."""
+
+        # mimic the logic in fields.Field.run_validators by saving the exception
+        # detail into a list which will then be the detail for a new ValidationError.
+        # this should not throw a KeyError or a TypeError even though
+        # the string has a substitutable substring ...
+        errors = []
+        try:
+            raise ValidationError('%(user)s')
+        except ValidationError as exc:
+            errors.extend(exc.detail)
+
+        # ensure it raises the correct exception type as an input to a new ValidationError
+        with pytest.raises(ValidationError):
+            raise ValidationError(errors)

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -215,7 +215,7 @@ class TestValidationErrorWithDjangoStyle(TestCase):
             raise ValidationError(errors)
 
     def test_validation_error_without_params_date_formatters(self):
-        """Ensure that substitutable errors can be emitted without params."""
+        """Ensure that substitutable errors can be emitted with invalid template placeholders."""
 
         # mimic the logic in fields.Field.run_validators by saving the exception
         # detail into a list which will then be the detail for a new ValidationError.


### PR DESCRIPTION
`%` substituation requires all keys to be matched during substitution, so if a ValidationError happens to include a `%(foo)s` style variable not met by the parameters, it will throw a KeyError. In Field.run_validators there is also an accumulation of errors that are wrapped by a final ValidationError which can then throw TypeError if any of the sub-errors contain replaceable substrings.

This is more complicated than it first seemed. https://github.com/encode/django-rest-framework/issues/9295 has a dateformat string throwing a ValueError, which won't ever work with `foo % bar` so this patch needs more testing and edge case handling.

This patch implements a new function to handle the string substitution and related errors in a unified way that returns the original string if something fails.

should fix https://github.com/encode/django-rest-framework/issues/9295

