### PR TITLE
fix anonymous access for DjangoModelPermissionsOrAnonReadOnly

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -255,6 +255,12 @@ class DjangoModelPermissionsOrAnonReadOnly(DjangoModelPermissions):
     """
     authenticated_users_only = False
 
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return bool(super().has_permission(request, view))
+
+        return bool(request.method in SAFE_METHODS)
+
 
 class DjangoObjectPermissions(DjangoModelPermissions):
     """


### PR DESCRIPTION
This pull request fixes anonymous read-only access for the `DjangoModelPermissionsOrAnonReadOnly` class in `permissions.py` as mentioned in issue #9299.

If the user is authenticated, it will run the the `has_permission` method defined in `DjangoModelPermissions` since it's the parent class. If the user is not authenticated, then the user will have permission *only* if the method is safe. (GET, HEAD, or OPTIONS)