### PR TITLE
Version 3.15.1

### DIFF
--- a/docs/community/3.15-announcement.md
+++ b/docs/community/3.15-announcement.md
@@ -31,10 +31,6 @@ The current minimum versions of Django still is 3.0 and Python 3.6.
 
 `ModelSerializer` generates validators for [UniqueConstraint](https://docs.djangoproject.com/en/4.0/ref/models/constraints/#uniqueconstraint) (both UniqueValidator and UniqueTogetherValidator)
 
-## ValidationErrors improvements
-
-The `ValidationError` has been aligned with Django's, currently supporting the same style (signature) and nesting.
-
 ## SimpleRouter non-regex matching support
 
 By default the URLs created by `SimpleRouter` use regular expressions. This behavior can be modified by setting the `use_regex_path` argument to `False` when instantiating the router.
@@ -46,10 +42,6 @@ Dependency on pytz has been removed and deprecation warnings have been added, Dj
 ##  Align `SearchFilter` behaviour to `django.contrib.admin` search
 
 Searches now may contain _quoted phrases_ with spaces, each phrase is considered as a single search term, and it will raise a validation error if any null-character is provided in search. See the [Filtering API guide](../api-guide/filtering.md) for more information.
-
-## Default values propagation
-
-Model fields' default values are now propagated to serializer fields, for more information see the [Serializer fields API guide](../api-guide/fields.md#default).
 
 ## Other fixes and improvements
 

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -36,6 +36,13 @@ You can determine your currently installed version using `pip show`:
 
 ## 3.15.x series
 
+### 3.15.1
+
+Date: 15th March 2024
+
+* Fix `SearchFilter` handling of quoted and comma seperated strings, when `.get_search_terms` is being called into by a custom class. See [[#9338](https://github.com/encode/django-rest-framework/issues/9338)]
+* Revert number of 3.15.0 issues which included unintended side-effects. See [[#9331](https://github.com/encode/django-rest-framework/issues/9331)]
+
 ### 3.15.0
 
 Date: 15th March 2024

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -38,7 +38,7 @@ You can determine your currently installed version using `pip show`:
 
 ### 3.15.1
 
-Date: 15th March 2024
+Date: 22nd March 2024
 
 * Fix `SearchFilter` handling of quoted and comma seperated strings, when `.get_search_terms` is being called into by a custom class. See [[#9338](https://github.com/encode/django-rest-framework/issues/9338)]
 * Revert number of 3.15.0 issues which included unintended side-effects. See [[#9331](https://github.com/encode/django-rest-framework/issues/9331)]

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -40,7 +40,7 @@ You can determine your currently installed version using `pip show`:
 
 Date: 22nd March 2024
 
-* Fix `SearchFilter` handling of quoted and comma seperated strings, when `.get_search_terms` is being called into by a custom class. See [[#9338](https://github.com/encode/django-rest-framework/issues/9338)]
+* Fix `SearchFilter` handling of quoted and comma separated strings, when `.get_search_terms` is being called into by a custom class. See [[#9338](https://github.com/encode/django-rest-framework/issues/9338)]
 * Revert number of 3.15.0 issues which included unintended side-effects. See [[#9331](https://github.com/encode/django-rest-framework/issues/9331)]
 
 ### 3.15.0

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -10,7 +10,7 @@ ______ _____ _____ _____    __
 import django
 
 __title__ = 'Django REST framework'
-__version__ = '3.15.0'
+__version__ = '3.15.1'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 3-Clause'
 __copyright__ = 'Copyright 2011-2023 Encode OSS Ltd'


### PR DESCRIPTION
### 3.15.1

Date: 22nd March 2024

* Fix `SearchFilter` handling of quoted and comma seperated strings, when `.get_search_terms` is being called into by a custom class. See [[#9338](https://github.com/encode/django-rest-framework/issues/9338)]
* Revert number of 3.15.0 issues which included unintended side-effects. See [[#9331](https://github.com/encode/django-rest-framework/issues/9331)]

---

Closes #9331
