### PR TITLE
Apply black formatting to caching markdown

### DIFF
--- a/docs/api-guide/caching.md
+++ b/docs/api-guide/caching.md
@@ -75,11 +75,9 @@ from rest_framework.response import Response
 
 @cache_page(60 * 15)
 @vary_on_cookie
-@api_view(['GET'])
+@api_view(["GET"])
 def get_user_list(request):
-    content = {
-        'user_feed': request.user.get_user_feed()
-    }
+    content = {"user_feed": request.user.get_user_feed()}
     return Response(content)
 ```
 


### PR DESCRIPTION
## Description

It _looks_ like blacken-docs is failing on this file. Running black locally fails with a failed to reformat. This is because it expects python code, and  when it hits the ">", there's invalid python.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).
