### PR TITLE
Remove invalid pytest option in `setup.cfg`, improve readability of test result

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 license_files = LICENSE.md
 
 [tool:pytest]
-addopts=--tb=short --strict-markers -ra
-testspath = tests
+addopts = -v --tb=short --strict-markers -ra
+testpaths = tests
 filterwarnings = ignore:CoreAPI compatibility is deprecated*:rest_framework.RemovedInDRF317Warning
 
 [flake8]


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

If you run `./runtests.py` in the current package, you'll get a warning like this. (unknown config option: testspath)
<img width="1440" alt="스크린샷 2024-04-02 오후 3 35 04" src="https://github.com/encode/django-rest-framework/assets/88619089/5090829c-a8ed-4d5d-95f7-6272e0ab9c7a">

A patch was made in [this commit](https://github.com/encode/django-rest-framework/commit/67b5093ca526d219b8f25abf427161e154c23c6e) to remove the warning, but it appears to have been reverted back [here](https://github.com/encode/django-rest-framework/commit/a16dbfd11018fa01ceaf6dee7df34ab0430282cf#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52).

I've also added the `-v` option to verbosely display the results of running `./runtests`.
(If this is an unnecessary change, I'll revert it).

(before `-v` option)
<img width="1440" alt="스크린샷 2024-04-02 오후 3 34 38" src="https://github.com/encode/django-rest-framework/assets/88619089/6778bddc-493b-49fd-a55e-aab0cc926902">

(after added `-v` option)
<img width="1440" alt="스크린샷 2024-04-02 오후 3 36 05" src="https://github.com/encode/django-rest-framework/assets/88619089/5e15aaef-77c9-4e0b-9fc7-17f6038ac3aa">

This change does not affect the results of the `-q` option.
(with `-q` option)
<img width="1440" alt="image" src="https://github.com/encode/django-rest-framework/assets/88619089/f4b472c4-6821-4dcb-abda-bf798d812304">

### References

[as you can see](https://docs.pytest.org/en/7.0.x/reference/customize.html#setup-cfg), `testspath` is not valid pytest option and should use `testpaths`

<img width="893" alt="image" src="https://github.com/encode/django-rest-framework/assets/88619089/377890ac-b0f8-46fa-abf6-e96b1e1be604">
