### PR TITLE
Update renderers documentation example

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -283,7 +283,7 @@ By default this will include the following keys: `view`, `request`, `response`, 
 
 The following is an example plaintext renderer that will return a response with the `data` parameter as the content of the response.
 
-    from django.utils.encoding import smart_text
+    from django.utils.encoding import smart_str
     from rest_framework import renderers
 
 
@@ -292,7 +292,7 @@ The following is an example plaintext renderer that will return a response with 
         format = 'txt'
 
         def render(self, data, accepted_media_type=None, renderer_context=None):
-            return smart_text(data, encoding=self.charset)
+            return smart_str(data, encoding=self.charset)
 
 ## Setting the character set
 


### PR DESCRIPTION
## Description
Hi,

Renderers documentation example still uses `smart_text` https://www.django-rest-framework.org/api-guide/renderers/#example and it was deprecated in Django 3.0 https://docs.djangoproject.com/en/4.0/releases/3.0/#features-deprecated-in-3-0. So I replaced by `smart_str`

Thank you!