### PR TITLE
Removing live examples of tutorial code that are no longer hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Some reasons you might want to use REST framework:
 * Customizable all the way down - just use [regular function-based views][functionview-section] if you don't need the [more][generic-views] [powerful][viewsets] [features][routers].
 * [Extensive documentation][docs], and [great community support][group].
 
-There is a live example API for testing purposes, [available here][sandbox].
-
 **Below**: *Screenshot from the browsable API*
 
 ![Screenshot][image]
@@ -188,7 +186,6 @@ Please see the [security policy][security-policy].
 [pypi]: https://pypi.org/project/djangorestframework/
 [twitter]: https://twitter.com/starletdreaming
 [group]: https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework
-[sandbox]: https://restframework.herokuapp.com/
 
 [funding]: https://fund.django-rest-framework.org/topics/funding/
 [sponsors]: https://fund.django-rest-framework.org/topics/funding/#our-sponsors

--- a/docs/community/project-management.md
+++ b/docs/community/project-management.md
@@ -199,7 +199,6 @@ If `@tomchristie` ceases to participate in the project then `@j4mie` has respons
 The following issues still need to be addressed:
 
 * Ensure `@jamie` has back-up access to the `django-rest-framework.org` domain setup and admin.
-* Document ownership of the [live example][sandbox] API.
 * Document ownership of the [mailing list][mailing-list] and IRC channel.
 * Document ownership and management of the security mailing list.
 
@@ -208,5 +207,4 @@ The following issues still need to be addressed:
 [transifex-project]: https://www.transifex.com/projects/p/django-rest-framework/
 [transifex-client]: https://pypi.org/project/transifex-client/
 [translation-memory]: http://docs.transifex.com/guides/tm#let-tm-automatically-populate-translations
-[sandbox]: https://restframework.herokuapp.com/
 [mailing-list]: https://groups.google.com/forum/#!forum/django-rest-framework

--- a/docs/index.md
+++ b/docs/index.md
@@ -247,7 +247,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 [serializer-section]: api-guide/serializers#serializers
 [modelserializer-section]: api-guide/serializers#modelserializer
 [functionview-section]: api-guide/views#function-based-views
-[sandbox]: https://restframework.herokuapp.com/
 [sponsors]: https://fund.django-rest-framework.org/topics/funding/#our-sponsors
 
 [quickstart]: tutorial/quickstart.md

--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -8,7 +8,7 @@ The tutorial is fairly in-depth, so you should probably get a cookie and a cup o
 
 ---
 
-**Note**: The code for this tutorial is available in the [encode/rest-framework-tutorial][repo] repository on GitHub.  The completed implementation is also online as a sandbox version for testing, [available here][sandbox].
+**Note**: The code for this tutorial is available in the [encode/rest-framework-tutorial][repo] repository on GitHub. Feel free to clone the repository and see the code in action.
 
 ---
 
@@ -307,7 +307,7 @@ Quit out of the shell...
     Validating models...
 
     0 errors found
-    Django version 4.0, using settings 'tutorial.settings'
+    Django version 5.0, using settings 'tutorial.settings'
     Starting Development server at http://127.0.0.1:8000/
     Quit the server with CONTROL-C.
 
@@ -371,7 +371,6 @@ We'll see how we can start to improve things in [part 2 of the tutorial][tut-2].
 
 [quickstart]: quickstart.md
 [repo]: https://github.com/encode/rest-framework-tutorial
-[sandbox]: https://restframework.herokuapp.com/
 [venv]: https://docs.python.org/3/library/venv.html
 [tut-2]: 2-requests-and-responses.md
 [httpie]: https://github.com/httpie/httpie#installation


### PR DESCRIPTION
## Description

**1. The tutorial code in the official documentation is no longer hosted in the sandbox, so I've removed that reference from the official documentation.**

#8887 
#9357 

(before the change)
<img width="831" alt="image" src="https://github.com/encode/django-rest-framework/assets/88619089/bcfeccab-dca1-4b06-9d91-7aae42722439">

(after the change)
<img width="835" alt="image" src="https://github.com/encode/django-rest-framework/assets/88619089/f973cc16-ceba-4c51-a5e6-dbdcdf9d504e">


**2. minor change, DRF now supports Django 5.0. I've updated the parts of the documentation where Django 4.0 is used to 5.0.**

(before the change)
<img width="820" alt="image" src="https://github.com/encode/django-rest-framework/assets/88619089/cde3ad34-237a-4bf2-b8d3-f66f5bed833d">

(after the change)
<img width="821" alt="image" src="https://github.com/encode/django-rest-framework/assets/88619089/babc7603-9ee4-48d9-a975-67cfb80a5968">

**3. minor concern... The source code for the tutorial is currently using DRF 3.11. I think it would be nice to use a tool like dependabot to ensure that the code in the tutorial follows the latest version of DRF (even if there is very little difference in behavior between DRF 3.11 and 3.15).**

<img width="378" alt="image" src="https://github.com/encode/django-rest-framework/assets/88619089/17ac7cbd-51af-4600-92a6-08fd1aff9b56">
