### PR TITLE
Fixed #5363 -- HTML5 datetime-local valid format HTMLFormRenderer

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -338,7 +338,10 @@ class HTMLFormRenderer(BaseRenderer):
         field = field.as_form_field()
 
         if style.get('input_type') == 'datetime-local' and isinstance(field.value, str):
-            field.value = field.value.rstrip('Z')
+            # The format of an input type="datetime-local" is "yyyy-MM-ddThh:mm"
+            # followed by optional ":ss" or ":ss.SSS", so remove [milli|micro]seconds
+            # to avoid browser error.
+            field.value = "".join(field.value.rstrip('Z').split(".")[:1])
 
         if 'template' in style:
             template_name = style['template']

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,5 +1,6 @@
 import re
 from collections.abc import MutableMapping
+from datetime import datetime
 
 import pytest
 from django.core.cache import cache
@@ -486,6 +487,23 @@ class TestHiddenFieldHTMLFormRenderer(TestCase):
         field = serializer['published']
         rendered = renderer.render_field(field, {})
         assert rendered == ''
+
+
+class TestDateTimeFieldHTMLFormRender(TestCase):
+    def test_datetime_field_rendering(self):
+        class TestSerializer(serializers.Serializer):
+            appointment = serializers.DateTimeField()
+
+        appointment = datetime(2024, 12, 24, 00, 55, 30, 345678)
+        serializer = TestSerializer(data={"appointment": appointment})
+        serializer.is_valid()
+        renderer = HTMLFormRenderer()
+        field = serializer['appointment']
+        rendered = renderer.render_field(field, {})
+        self.assertInHTML(
+            '<input name="appointment" class="form-control" type="datetime-local" value="2024-12-24T00:55:30">',
+            rendered
+        )
 
 
 class TestHTMLFormRenderer(TestCase):


### PR DESCRIPTION
## Description

Hi!

This PR deletes the [milli|micro]seconds part of a `DateTimeField` input at `HTMLFormRenderer` to avoid break in browsers:

<img width="1792" alt="image" src="https://github.com/encode/django-rest-framework/assets/16822952/ca16e35e-b916-48a9-b6e0-77f70e0ec72c">

refs #5363 
