### PR TITLE
use warnings rather than logging a warning for DecimalField warnings

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -4,9 +4,9 @@ import datetime
 import decimal
 import functools
 import inspect
-import logging
 import re
 import uuid
+import warnings
 from collections.abc import Mapping
 from enum import Enum
 
@@ -43,8 +43,6 @@ from rest_framework.utils import html, humanize_datetime, json, representation
 from rest_framework.utils.formatting import lazy_format
 from rest_framework.utils.timezone import valid_datetime
 from rest_framework.validators import ProhibitSurrogateCharactersValidator
-
-logger = logging.getLogger("rest_framework.fields")
 
 
 class empty:
@@ -989,9 +987,9 @@ class DecimalField(Field):
         self.min_value = min_value
 
         if self.max_value is not None and not isinstance(self.max_value, decimal.Decimal):
-            logger.warning("max_value in DecimalField should be Decimal type.")
+            warnings.warn("max_value should be a Decimal instance.")
         if self.min_value is not None and not isinstance(self.min_value, decimal.Decimal):
-            logger.warning("min_value in DecimalField should be Decimal type.")
+            warnings.warn("min_value should be a Decimal instance.")
 
         if self.max_digits is not None and self.decimal_places is not None:
             self.max_whole_digits = self.max_digits - self.decimal_places


### PR DESCRIPTION
## Description

addressing https://github.com/encode/django-rest-framework/pull/8972#issuecomment-2039940577