### PR TITLE
Last ordering filter has the last say

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -822,8 +822,8 @@ class CursorPagination(BasePagination):
 
         if ordering_filters:
             # If a filter exists on the view that implements `get_ordering`
-            # then we defer to that filter to determine the ordering.
-            filter_cls = ordering_filters[0]
+            # then we defer to the last such filter to determine the ordering.
+            filter_cls = ordering_filters[-1]
             filter_instance = filter_cls()
             ordering_from_filter = filter_instance.get_ordering(request, queryset, view)
             if ordering_from_filter:


### PR DESCRIPTION
## Description
In https://github.com/encode/django-rest-framework/blob/63063da0820e23ef0edbf92a3031103a6c2ce254/rest_framework/generics.py#L153 every filter backend is called in the order as listed in the view's `filter_backends`. And since every `order_by` qs call clears the previous order (https://docs.djangoproject.com/en/5.0/ref/models/querysets/#django.db.models.query.QuerySet.order_by), the last ordering filter should have the final say for cursor pagination.

Although a bug fix, this poses the risk of being a major change for dependent projects.

PS:
IMO, the docs should have a warning somewhere about this. It seems uncommon or unexpected from DRF's side to have multiple ordering backends and even more unexpected with cursor pagination where you have to be extra careful anyways. And there should be a warning that [CursorPagination](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination) only uses `ordering[0]` for the cursor although it would be possible to implement a cursor on multiple fields a la `Q(ordering0__gt=cursor0) | Q(ordering0__gte=cursor0, ordering1__gt=cursor1) | ...` (unfolded result QS).