### PR TITLE
Tweak README.md links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,6 @@ Full documentation for the project is available at [https://www.django-rest-fram
 
 For questions and support, use the [REST framework discussion group][group], or `#restframework` on libera.chat IRC.
 
-You may also want to [follow the author on Twitter][twitter].
-
 # Security
 
 Please see the [security policy][security-policy].
@@ -184,7 +182,6 @@ Please see the [security policy][security-policy].
 [codecov]: https://codecov.io/github/encode/django-rest-framework?branch=master
 [pypi-version]: https://img.shields.io/pypi/v/djangorestframework.svg
 [pypi]: https://pypi.org/project/djangorestframework/
-[twitter]: https://twitter.com/starletdreaming
 [group]: https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework
 
 [funding]: https://fund.django-rest-framework.org/topics/funding/


### PR DESCRIPTION
Drop unnecessary self-serving promo text. (🤮 / 😅)

Really not relevant to the project.
I haven't checked to see if there are other `encode` projects which still include the same - contributors are welcome to issue similar pull requests referencing this if there's other similar bits of clean-up to be done.

