### PR TITLE
Add documentation about how to transform factory request to DRF request

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -105,6 +105,20 @@ This means that setting attributes directly on the request object may not always
     request.user = user
     response = view(request)
 
+If you want to test a request involving the REST framework’s 'Request' object, you’ll need to manually transform it first:
+
+    class DummyView(APIView):
+        ...
+
+    factory = APIRequestFactory()
+    request = factory.get('/', {'demo': 'test'})
+    drf_request = DummyView().initialize_request(request)
+    assert drf_request.query_params == {'demo': ['test']}
+
+    request = factory.post('/', {'example': 'test'})
+    drf_request = DummyView().initialize_request(request)
+    assert drf_request.data.get('example') == 'test'
+
 ---
 
 ## Forcing CSRF validation


### PR DESCRIPTION
## Description

Hi there!

As there were many issues opened around this topic: _"`APIRequestFactory` **does not** return a `Request` object"_ I think it would be worth to have a place in the documentation where explains it. 

Following the Tom's comment in the last issue https://github.com/encode/django-rest-framework/issues/6488#issuecomment-2049940926:
> If someone's invested and there's clearly a good existing place in the docs to highlight this, then we could accept a docs PR here.

*Past issues related: https://github.com/encode/django-rest-framework/issues/4440 and https://github.com/encode/django-rest-framework/issues/3608

This is what my proposal looks like:

<img width="836" alt="image" src="https://github.com/encode/django-rest-framework/assets/16822952/cceb2fdb-b1f2-4f4c-a2b6-aeb38cbac636">

I've also added a test to follow the Carlton's comment https://github.com/encode/django-rest-framework/issues/6488#issuecomment-2048962774

Thank you!