### PR TITLE
Documentation: Add Python 3.12 to the requirements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ continued development by **[signing up for a paid plan][funding]**.
 
 REST framework requires the following:
 
-* Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11)
+* Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12)
 * Django (3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.0)
 
 We **highly recommend** and only officially support the latest patch release of


### PR DESCRIPTION
Add a missing required Python 3.12 version to the main documentation page.