### PR TITLE
Add `unaccent` to `SearchFilter`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,9 @@ jobs:
     - name: Install dependencies
       run: python -m pip install --upgrade tox
 
+    - name: Create unaccent extension
+      run: PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
+
     - name: Run tox targets for ${{ matrix.python-version }}
       run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d . | cut -f 1 -d '-')
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,9 +70,6 @@ jobs:
     - name: Install dependencies
       run: python -m pip install --upgrade tox
 
-    - name: Create unaccent extension
-      run: PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
-
     - name: Run tox targets for ${{ matrix.python-version }}
       run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d . | cut -f 1 -d '-')
 

--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -230,6 +230,7 @@ The search behavior may be specified by prefixing field names in `search_fields`
 | `$`    | `iregex`      | Regex search.      |
 | `@`    | `search`      | Full-text search (Currently only supported Django's [PostgreSQL backend][postgres-search]). |
 | None   | `icontains`   | Contains search (Default).  |
+| `&`    | `unaccent`    | Accent-insensitive search. (Currently only supported Django's [PostgreSQL backend][postgres-lookups]). |
 
 For example:
 
@@ -370,3 +371,4 @@ The [djangorestframework-word-filter][django-rest-framework-word-search-filter] 
 [HStoreField]: https://docs.djangoproject.com/en/stable/ref/contrib/postgres/fields/#hstorefield
 [JSONField]: https://docs.djangoproject.com/en/stable/ref/models/fields/#django.db.models.JSONField
 [postgres-search]: https://docs.djangoproject.com/en/stable/ref/contrib/postgres/search/
+[postgres-lookups]: https://docs.djangoproject.com/en/stable/ref/contrib/postgres/lookups/#unaccent

--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -239,7 +239,7 @@ By default, the search parameter is named `'search'`, but this may be overridden
 
 #### Accent-insensitive search
 
-The `UnaccentedSearchFilter` subclass performs accent-insensitive matching, so that a search for `Jeremy` also matches `Jérémy`. It behaves exactly like `SearchFilter`, except every lookup is wrapped with the `unaccent` transform (e.g. the default lookup becomes `unaccent__icontains`, `^` becomes `unaccent__istartswith`, and so on).
+The `UnaccentedSearchFilter` subclass performs accent-insensitive matching, so that a search for `Jeremy` also matches `Jérémy`. It behaves like `SearchFilter`, except the lookups are wrapped with the `unaccent` transform: the default lookup becomes `unaccent__icontains`, `^` becomes `unaccent__istartswith`, `=` becomes `unaccent__iexact`, and `$` becomes `unaccent__iregex`. The `@` (full-text search) prefix is left unchanged, as the `unaccent` transform cannot be combined with a full-text search lookup.
 
     from rest_framework import filters
 

--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -230,13 +230,24 @@ The search behavior may be specified by prefixing field names in `search_fields`
 | `$`    | `iregex`      | Regex search.      |
 | `@`    | `search`      | Full-text search (Currently only supported Django's [PostgreSQL backend][postgres-search]). |
 | None   | `icontains`   | Contains search (Default).  |
-| `&`    | `unaccent`    | Accent-insensitive search. (Currently only supported Django's [PostgreSQL backend][postgres-lookups]). |
 
 For example:
 
     search_fields = ['=username', '=email']
 
 By default, the search parameter is named `'search'`, but this may be overridden with the `SEARCH_PARAM` setting in the `REST_FRAMEWORK` configuration.
+
+#### Accent-insensitive search
+
+The `UnaccentedSearchFilter` subclass performs accent-insensitive matching, so that a search for `Jeremy` also matches `Jérémy`. It behaves exactly like `SearchFilter`, except every lookup is wrapped with the `unaccent` transform (e.g. the default lookup becomes `unaccent__icontains`, `^` becomes `unaccent__istartswith`, and so on).
+
+    from rest_framework import filters
+
+    class MyView(generics.ListAPIView):
+        filter_backends = [filters.UnaccentedSearchFilter]
+        search_fields = ['name']
+
+This is currently only supported on Django's [PostgreSQL backend][postgres-lookups], and requires the `unaccent` extension to be installed and `django.contrib.postgres` to be present in `INSTALLED_APPS`.
 
 To dynamically change search fields based on request content, it's possible to subclass the `SearchFilter` and override the `get_search_fields()` function. For example, the following subclass will only search on `title` if the query parameter `title_only` is in the request:
 

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -58,6 +58,7 @@ class SearchFilter(BaseFilterBackend):
         '=': 'iexact',
         '@': 'search',
         '$': 'iregex',
+        '&': 'unaccent',
     }
     search_title = _('Search')
     search_description = _('A search term.')

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -58,8 +58,8 @@ class SearchFilter(BaseFilterBackend):
         '=': 'iexact',
         '@': 'search',
         '$': 'iregex',
-        '&': 'unaccent',
     }
+    default_lookup = 'icontains'
     search_title = _('Search')
     search_description = _('A search term.')
 
@@ -105,8 +105,8 @@ class SearchFilter(BaseFilterBackend):
                     if hasattr(field, "path_infos"):
                         # Update opts to follow the relation.
                         opts = field.path_infos[-1].to_opts
-            # Otherwise, use the field with icontains.
-            lookup = 'icontains'
+            # Otherwise, use the field with the default lookup.
+            lookup = self.default_lookup
         return LOOKUP_SEP.join([field_name, lookup])
 
     def must_call_distinct(self, queryset, search_fields):
@@ -189,6 +189,23 @@ class SearchFilter(BaseFilterBackend):
                 },
             },
         ]
+
+
+class UnaccentedSearchFilter(SearchFilter):
+    """
+    A SearchFilter that performs accent-insensitive matching.
+
+    Requires PostgreSQL with the ``unaccent`` extension installed and
+    ``django.contrib.postgres`` in ``INSTALLED_APPS``. See
+    https://docs.djangoproject.com/en/stable/ref/contrib/postgres/lookups/#unaccent
+    """
+    lookup_prefixes = {
+        '^': 'unaccent__istartswith',
+        '=': 'unaccent__iexact',
+        '@': 'unaccent__search',
+        '$': 'unaccent__iregex',
+    }
+    default_lookup = 'unaccent__icontains'
 
 
 class OrderingFilter(BaseFilterBackend):

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -202,7 +202,9 @@ class UnaccentedSearchFilter(SearchFilter):
     lookup_prefixes = {
         '^': 'unaccent__istartswith',
         '=': 'unaccent__iexact',
-        '@': 'unaccent__search',
+        # '@' stays accent-sensitive: unaccent can't be applied to full-text
+        # search.
+        '@': 'search',
         '$': 'unaccent__iregex',
     }
     default_lookup = 'unaccent__icontains'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,23 @@ from django.core.management.color import no_style
 from django.db import connection
 
 
+@pytest.fixture(scope='session')
+def django_db_setup(django_db_setup, django_db_blocker):
+    """
+    Ensure the PostgreSQL extensions required by some tests exist in the
+    *test* database.
+
+    pytest-django's ``django_db_setup`` creates the test database; we then add
+    the ``unaccent`` extension that the accent-insensitive search tests rely on.
+    Creating it on the server's default database is not enough, as the test
+    database is created separately. No-op on non-PostgreSQL backends.
+    """
+    if connection.vendor == 'postgresql':
+        with django_db_blocker.unblock(), connection.cursor() as cursor:
+            cursor.execute('CREATE EXTENSION IF NOT EXISTS unaccent')
+    yield
+
+
 @pytest.fixture
 def reset_sequences():
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,21 +9,18 @@ from django.core.management.color import no_style
 from django.db import connection
 
 
-@pytest.fixture(scope='session')
-def django_db_setup(django_db_setup, django_db_blocker):
+@pytest.fixture
+def unaccent_extension(db):
     """
-    Ensure the PostgreSQL extensions required by some tests exist in the
-    *test* database.
+    Enable the PostgreSQL ``unaccent`` extension for a single test.
 
-    pytest-django's ``django_db_setup`` creates the test database; we then add
-    the ``unaccent`` extension that the accent-insensitive search tests rely on.
-    Creating it on the server's default database is not enough, as the test
-    database is created separately. No-op on non-PostgreSQL backends.
+    Opt in with ``@pytest.mark.usefixtures("unaccent_extension")`` so only
+    tests that need it have it. No-op on non-PostgreSQL backends.
     """
-    if connection.vendor == 'postgresql':
-        with django_db_blocker.unblock(), connection.cursor() as cursor:
-            cursor.execute('CREATE EXTENSION IF NOT EXISTS unaccent')
-    yield
+    if connection.vendor != 'postgresql':
+        return
+    with connection.cursor() as cursor:
+        cursor.execute('CREATE EXTENSION IF NOT EXISTS unaccent')
 
 
 @pytest.fixture

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -247,6 +247,26 @@ class SearchFilterTests(TestCase):
                 {'id': 2, 'title': 'zz', 'text': 'bcd'},
             ]
 
+    @pytest.mark.requires_postgres
+    def test_search_field_with_unaccent(self):
+        SearchFilterModel.objects.create(title='Jeremy', text='jeremy')
+        SearchFilterModel.objects.create(title='Jérémy', text='jérémy')
+        SearchFilterModel.objects.create(title='Jérémie', text='jérémie')
+        SearchFilterModel.objects.create(title='Jeremie', text='jeremie')
+
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('&title',)
+
+        view = SearchListView.as_view()
+
+        request = factory.get('/', {'search': 'Jerem'})
+        response = view(request)
+        assert len(response.data) == 4
+        assert {item['title'] for item in response.data} == {'Jeremy', 'Jérémy', 'Jérémie', 'Jeremie'}
+
     def test_search_field_with_multiple_words(self):
         class SearchListView(generics.ListAPIView):
             queryset = SearchFilterModel.objects.all()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -248,7 +248,7 @@ class SearchFilterTests(TestCase):
             ]
 
     @pytest.mark.requires_postgres
-    def test_search_field_with_unaccent(self):
+    def test_unaccented_search_default_lookup(self):
         SearchFilterModel.objects.create(title='Jeremy', text='jeremy')
         SearchFilterModel.objects.create(title='Jérémy', text='jérémy')
         SearchFilterModel.objects.create(title='Jérémie', text='jérémie')
@@ -257,8 +257,8 @@ class SearchFilterTests(TestCase):
         class SearchListView(generics.ListAPIView):
             queryset = SearchFilterModel.objects.all()
             serializer_class = SearchFilterSerializer
-            filter_backends = (filters.SearchFilter,)
-            search_fields = ('&title',)
+            filter_backends = (filters.UnaccentedSearchFilter,)
+            search_fields = ('title',)
 
         view = SearchListView.as_view()
 
@@ -266,6 +266,27 @@ class SearchFilterTests(TestCase):
         response = view(request)
         assert len(response.data) == 4
         assert {item['title'] for item in response.data} == {'Jeremy', 'Jérémy', 'Jérémie', 'Jeremie'}
+
+    @pytest.mark.requires_postgres
+    def test_unaccented_search_with_prefix_lookup(self):
+        SearchFilterModel.objects.create(title='Jeremy', text='jeremy')
+        SearchFilterModel.objects.create(title='Jérémy', text='jérémy')
+        SearchFilterModel.objects.create(title='Jérémie', text='jérémie')
+        SearchFilterModel.objects.create(title='Jeremie', text='jeremie')
+
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.UnaccentedSearchFilter,)
+            # '=' maps to 'unaccent__iexact' on UnaccentedSearchFilter
+            search_fields = ('=title',)
+
+        view = SearchListView.as_view()
+
+        request = factory.get('/', {'search': 'Jeremy'})
+        response = view(request)
+        assert len(response.data) == 2
+        assert {item['title'] for item in response.data} == {'Jeremy', 'Jérémy'}
 
     def test_search_field_with_multiple_words(self):
         class SearchListView(generics.ListAPIView):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -248,45 +248,31 @@ class SearchFilterTests(TestCase):
             ]
 
     @pytest.mark.requires_postgres
-    def test_unaccented_search_default_lookup(self):
-        SearchFilterModel.objects.create(title='Jeremy', text='jeremy')
-        SearchFilterModel.objects.create(title='Jérémy', text='jérémy')
-        SearchFilterModel.objects.create(title='Jérémie', text='jérémie')
-        SearchFilterModel.objects.create(title='Jeremie', text='jeremie')
+    @pytest.mark.usefixtures("unaccent_extension")
+    def test_unaccented_search_lookups(self):
+        for title in ('Jérémy', 'Jeremy', 'Jérémie', 'Amélie'):
+            SearchFilterModel.objects.create(title=title, text=title.lower())
 
-        class SearchListView(generics.ListAPIView):
-            queryset = SearchFilterModel.objects.all()
-            serializer_class = SearchFilterSerializer
-            filter_backends = (filters.UnaccentedSearchFilter,)
-            search_fields = ('title',)
+        # (search field, term, expected titles) for each prefix. All but '@'
+        # are accent-insensitive, so an unaccented term matches accented titles.
+        cases = [
+            ('title', 'rem', {'Jérémy', 'Jeremy', 'Jérémie'}),       # unaccent__icontains
+            ('^title', 'jer', {'Jérémy', 'Jeremy', 'Jérémie'}),      # unaccent__istartswith
+            ('=title', 'jeremy', {'Jérémy', 'Jeremy'}),              # unaccent__iexact
+            ('$title', 'jerem.+', {'Jérémy', 'Jeremy', 'Jérémie'}),  # unaccent__iregex
+            ('@title', 'Jeremy', {'Jeremy'}),                        # search (accent-sensitive)
+        ]
 
-        view = SearchListView.as_view()
+        for search_field, term, expected in cases:
+            with self.subTest(search_field=search_field):
+                class SearchListView(generics.ListAPIView):
+                    queryset = SearchFilterModel.objects.all()
+                    serializer_class = SearchFilterSerializer
+                    filter_backends = (filters.UnaccentedSearchFilter,)
+                    search_fields = (search_field,)
 
-        request = factory.get('/', {'search': 'Jerem'})
-        response = view(request)
-        assert len(response.data) == 4
-        assert {item['title'] for item in response.data} == {'Jeremy', 'Jérémy', 'Jérémie', 'Jeremie'}
-
-    @pytest.mark.requires_postgres
-    def test_unaccented_search_with_prefix_lookup(self):
-        SearchFilterModel.objects.create(title='Jeremy', text='jeremy')
-        SearchFilterModel.objects.create(title='Jérémy', text='jérémy')
-        SearchFilterModel.objects.create(title='Jérémie', text='jérémie')
-        SearchFilterModel.objects.create(title='Jeremie', text='jeremie')
-
-        class SearchListView(generics.ListAPIView):
-            queryset = SearchFilterModel.objects.all()
-            serializer_class = SearchFilterSerializer
-            filter_backends = (filters.UnaccentedSearchFilter,)
-            # '=' maps to 'unaccent__iexact' on UnaccentedSearchFilter
-            search_fields = ('=title',)
-
-        view = SearchListView.as_view()
-
-        request = factory.get('/', {'search': 'Jeremy'})
-        response = view(request)
-        assert len(response.data) == 2
-        assert {item['title'] for item in response.data} == {'Jeremy', 'Jérémy'}
+                response = SearchListView.as_view()(factory.get('/', {'search': term}))
+                assert {item['title'] for item in response.data} == expected
 
     def test_search_field_with_multiple_words(self):
         class SearchListView(generics.ListAPIView):


### PR DESCRIPTION
## Description

Based on discussion https://github.com/encode/django-rest-framework/discussions/7759 I've created this PR to continue the work made in https://github.com/encode/django-rest-framework/pull/8775 and https://github.com/encode/django-rest-framework/pull/7733

_There are no tests with PostgreSQL but I'm creating this to test with the CI_