### PR TITLE
Return None values as None in ListSerializer.to_representation

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -711,7 +711,7 @@ class ListSerializer(BaseSerializer):
         iterable = data.all() if isinstance(data, models.manager.BaseManager) else data
 
         return [
-            self.child.to_representation(item) for item in iterable
+            self.child.to_representation(item) if item is not None else None for item in iterable
         ]
 
     def validate(self, attrs):


### PR DESCRIPTION
## Description

I recently encountered some unexpected behavior when using ListSerializer when there are `None` values in the list.

Here's a snippet that describes the issue and provides a way to reproduce it:

```python
from rest_framework import serializers


class Bar(serializers.Serializer):
    a = serializers.ListSerializer(
        child=serializers.IntegerField(allow_null=True)
    )

class Foo(serializers.Serializer):
    a = serializers.IntegerField(allow_null=True)
    b = Bar()


foo = Foo(data={'a': 1, 'b': {'a': [None]}})

print(foo.is_valid(raise_exception=True)) # this passes
print(foo.data)  # this triggers the error
```
traceback: 
```python
File ~/workspace/django-rest-framework/rest_framework/serializers.py:714, in <listcomp>(.0)
    709 # Dealing with nested relationships, data can be a Manager,
    710 # so, first get a queryset from the Manager if needed
    711 iterable = data.all() if isinstance(data, models.manager.BaseManager) else data
    713 return [
--> 714     self.child.to_representation(item) for item in iterable
    715 ]

File ~/workspace/django-rest-framework/rest_framework/fields.py:923, in IntegerField.to_representation(self, value)
    922 def to_representation(self, value):
--> 923     return int(value)

TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

Another thing to note is that `ListField` already handles it properly (in #4118  ), in fact I'm just copying what's been done to `ListField` to `ListSerializer`. 

So I think there are two issues that kinda throws me off:
1. If a serializer instance passes the validation, it should not then throw an error when getting the `.data` attribute.
2. The behavior should be the same as `ListField`
