### PR TITLE
Docs: Remove an unnecessary step from quickstart.md

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -15,7 +15,6 @@ Create a new Django project named `tutorial`, then start a new app called `quick
     source env/bin/activate  # On Windows use `env\Scripts\activate`
 
     # Install Django and Django REST framework into the virtual environment
-    pip install django
     pip install djangorestframework
 
     # Set up a new project with a single application


### PR DESCRIPTION
Since django is a dependency of djangorestframework, we don’t need to install it manually.


