### PR TITLE
tests: Check urlpatterns after cleanups

### DIFF
--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -318,10 +318,6 @@ class TestAPIRequestFactory(TestCase):
         assert request.META['CONTENT_TYPE'] == 'application/json'
 
 
-def check_urlpatterns(cls):
-    assert urlpatterns is not cls.urlpatterns
-
-
 class TestUrlPatternTestCase(URLPatternsTestCase):
     urlpatterns = [
         path('', view),
@@ -333,10 +329,11 @@ class TestUrlPatternTestCase(URLPatternsTestCase):
         super().setUpClass()
         assert urlpatterns is cls.urlpatterns
 
-        cls.addClassCleanup(
-            check_urlpatterns,
-            cls
-        )
+    @classmethod
+    def doClassCleanups(cls):
+        assert urlpatterns is cls.urlpatterns
+        super().doClassCleanups()
+        assert urlpatterns is not cls.urlpatterns
 
     def test_urlpatterns(self):
         assert self.client.get('/').status_code == 200


### PR DESCRIPTION
According to docs:
https://docs.python.org/3/library/unittest.html#unittest.TestCase.addClassCleanup

> Add a function to be called after tearDownClass() to cleanup resources
  used during the test class. Functions will be called in reverse order to
  the order they are added (LIFO).

This was revealed with recent change in pytest (`8.2.0`):
> pytest-dev/pytest#11728: For unittest-based tests, exceptions during
  class cleanup (as raised by functions registered with
  TestCase.addClassCleanup) are now reported instead of silently failing.

`check_urlpatterns` is called before `cleanup_url_patterns` and fails (problem was hidden by `pytest < 8.2.0`).

`doClassCleanups` can be used instead to check after-cleanup state:

https://docs.python.org/3/library/unittest.html#unittest.TestCase.doClassCleanups

> This method is called unconditionally after tearDownClass(), or after
  setUpClass() if setUpClass() raises an exception.
> 
> It is responsible for calling all the cleanup functions added by
  addClassCleanup(). If you need cleanup functions to be called prior to
  tearDownClass() then you can call doClassCleanups() yourself.

Fixes: https://github.com/encode/django-rest-framework/issues/9399
