### PR TITLE
Add `__hash__` method for `permissions.OperandHolder` class

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -54,6 +54,9 @@ class OperandHolder(OperationHolderMixin):
             self.op2_class == other.op2_class
         )
 
+    def __hash__(self):
+        return hash((self.operator_class, self.op1_class, self.op2_class))
+
 
 class AND:
     def __init__(self, op1, op2):


### PR DESCRIPTION
`OperandHolder` is not hashable, so need to add `__hash__` method

## Description

`OperandHolder` is not hashable after #8710, need to add `__hash__` method to it to provide convenient syntax to filter unique permissions using `set` or `dict.fromkeys`

## Ways to represent

```python
1. from rest_framework import permissions
2. set([permissions.IsAuthenticated & permissions.IsAdminUser])
```
![image](https://github.com/encode/django-rest-framework/assets/53380238/d07f5f16-7a2c-40f4-88cd-b5e6be757fa0)

## Fixes
* Remove `__eq__` method from `OperandHolder`
or
* Provide `__hash__` method to `OperandHolder`

Second way is provided in this PR 