### PR TITLE
Fix potential XSS vulnerability in break_long_headers template filter

### DIFF
--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -322,5 +322,5 @@ def break_long_headers(header):
     when possible (are comma separated)
     """
     if len(header) > 160 and ',' in header:
-        header = mark_safe('<br> ' + ', <br>'.join(header.split(',')))
+        header = mark_safe('<br> ' + ', <br>'.join(escape(header).split(',')))
     return header


### PR DESCRIPTION
## Description

The header input is now properly escaped before splitting and joining with `<br>` tags. This prevents potential XSS attacks if the header contains unsanitized user input.

This pull request addresses a potential XSS vulnerability in the `break_long_headers` template filter. By escaping the header input before processing, the risk of XSS attacks is mitigated. 