### PR TITLE
Version 3.15.2.

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -36,6 +36,15 @@ You can determine your currently installed version using `pip show`:
 
 ## 3.15.x series
 
+### 3.15.2
+
+**Date**: 14th June 2024
+
+* Fix potential XSS vulnerability in browsable API. [#9435](https://github.com/encode/django-rest-framework/pull/9157)
+* Revert "Ensure CursorPagination respects nulls in the ordering field". [#9381](https://github.com/encode/django-rest-framework/pull/9381)
+* Use warnings rather than logging a warning for DecimalField. [#9367](https://github.com/encode/django-rest-framework/pull/9367)
+* Remove unused code. [#9393](https://github.com/encode/django-rest-framework/pull/9393)
+
 ### 3.15.1
 
 Date: 22nd March 2024

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -10,7 +10,7 @@ ______ _____ _____ _____    __
 import django
 
 __title__ = 'Django REST framework'
-__version__ = '3.15.1'
+__version__ = '3.15.2'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 3-Clause'
 __copyright__ = 'Copyright 2011-2023 Encode OSS Ltd'


### PR DESCRIPTION
### 3.15.2

**Date**: 14th June 2024

* Fix potential XSS vulnerability in browsable API. [#9435](https://github.com/encode/django-rest-framework/pull/9157)
* Revert "Ensure CursorPagination respects nulls in the ordering field". [#9381](https://github.com/encode/django-rest-framework/pull/9381)
* Use warnings rather than logging a warning for DecimalField. [#9367](https://github.com/encode/django-rest-framework/pull/9367)
* Remove unused code. [#9393](https://github.com/encode/django-rest-framework/pull/9393)

---

I think these are the relevant code changes since 3.15.1. See [the history](https://github.com/encode/django-rest-framework/commits/master/) for changes, which mostly consists of docs fixs.
