### PR TITLE
Fix wrong link PR(#9435) on release-notes 3.15.2

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -42,7 +42,7 @@ You can determine your currently installed version using `pip show`:
 
 **Date**: 14th June 2024
 
-* Fix potential XSS vulnerability in browsable API. [#9435](https://github.com/encode/django-rest-framework/pull/9157)
+* Fix potential XSS vulnerability in browsable API. [#9435](https://github.com/encode/django-rest-framework/pull/9435)
 * Revert "Ensure CursorPagination respects nulls in the ordering field". [#9381](https://github.com/encode/django-rest-framework/pull/9381)
 * Use warnings rather than logging a warning for DecimalField. [#9367](https://github.com/encode/django-rest-framework/pull/9367)
 * Remove unused code. [#9393](https://github.com/encode/django-rest-framework/pull/9393)


### PR DESCRIPTION
## Description

Fix wrong PR link for #9435 on release-notes v3.15.2

![image](https://github.com/encode/django-rest-framework/assets/78490028/0bad2ef2-14d5-4056-9192-5d8ea9ad3c57)
