### PR TITLE
Update release-notes.md

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -46,6 +46,7 @@ You can determine your currently installed version using `pip show`:
 * Revert "Ensure CursorPagination respects nulls in the ordering field". [#9381](https://github.com/encode/django-rest-framework/pull/9381)
 * Use warnings rather than logging a warning for DecimalField. [#9367](https://github.com/encode/django-rest-framework/pull/9367)
 * Remove unused code. [#9393](https://github.com/encode/django-rest-framework/pull/9393)
+* Django < 4.2 and Python < 3.8 no longer supported. [#9393](https://github.com/encode/django-rest-framework/pull/9393)
 
 ### 3.15.1
 


### PR DESCRIPTION
Just add a note in release notes of 3.15.2 about which versions of django and python are not supported any more