### PR TITLE
Added protections to AttributeErrors raised within properties

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -217,7 +217,8 @@ class Request:
     @property
     def data(self):
         if not _hasattr(self, '_full_data'):
-            self._load_data_and_files()
+            with wrap_attributeerrors():
+                self._load_data_and_files()
         return self._full_data
 
     @property
@@ -420,13 +421,14 @@ class Request:
             _request = self.__getattribute__("_request")
             return getattr(_request, attr)
         except AttributeError:
-            return self.__getattribute__(attr)
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
 
     @property
     def POST(self):
         # Ensure that request.POST uses our request parsing.
         if not _hasattr(self, '_data'):
-            self._load_data_and_files()
+            with wrap_attributeerrors():
+                self._load_data_and_files()
         if is_form_media_type(self.content_type):
             return self._data
         return QueryDict('', encoding=self._request._encoding)
@@ -437,7 +439,8 @@ class Request:
         # Different from the other two cases, which are not valid property
         # names on the WSGIRequest class.
         if not _hasattr(self, '_files'):
-            self._load_data_and_files()
+            with wrap_attributeerrors():
+                self._load_data_and_files()
         return self._files
 
     def force_plaintext_errors(self, value):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -126,6 +126,25 @@ class TestContentParsing(TestCase):
         request.parsers = (PlainTextParser(), )
         assert request.data == content
 
+    def test_calling_data_fails_when_attribute_error_is_raised(self):
+        """
+        Ensure attribute errors raised when parsing are properly re-raised.
+        """
+        expected_message = "Internal error"
+
+        class BrokenParser:
+            media_type = "application/json"
+
+            def parse(self, *args, **kwargs):
+                raise AttributeError(expected_message)
+
+        http_request = factory.post('/', data={}, format="json")
+        request = Request(http_request)
+        request.parsers = (BrokenParser,)
+
+        with self.assertRaisesMessage(WrappedAttributeError, expected_message):
+            request.data
+
 
 class MockView(APIView):
     authentication_classes = (SessionAuthentication,)


### PR DESCRIPTION
## Description of Changes

Updates the `Request` class's `data`, `FILES`, and `POST` properties to utilize the `wrap_attributeerrors` context manager to ensure any properties that run `_load_data_and_files` in the `Request` class properly handle any `AttributeError`s raised internally.

Updates the `__getattr__` function to explicitly raise an `AttributeError` rather than calling `__getattribute__` again, as calling `__getattribute__` can have unexpected side effects (see #9433).

Adds a unit test to cover the case where a Parser raises an attribute error when the `Request.data` property is accessed.

## Benefits
`AttributeError`s raised in properties such as from parsing will now produce sane error messages and will no longer result in errors being suppressed.

## Possible drawbacks

None that I am currently aware of.

## Applicable issues
- fixes #9433

## Additional information
There appears to already be a precedent for this type of handling in request.py with the `wrap_attributeerrors` context manager that is currently only used for authentication. This extends that behavior to other properties via a common `safe_property` decorator that can be used instead of the builtin `property` decorator.

I had originally utilized a `safe_property` decorator to automatically add safe attribute handling to all properties, but that a significant performance penalty when accessing the properties as pointed out by @reddytocode. It has been dropped.