### PR TITLE
Fix One field that is required=False, allow_null=True and not provided. to_representation should not explicitly set it to None

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -450,10 +450,10 @@ class Field:
         except (KeyError, AttributeError) as exc:
             if self.default is not empty:
                 return self.get_default()
-            if self.allow_null:
-                return None
             if not self.required:
                 raise SkipField()
+            if self.allow_null:
+                return None
             msg = (
                 'Got {exc_type} when attempting to get a value for field '
                 '`{field}` on serializer `{serializer}`.\nThe serializer '


### PR DESCRIPTION
## Example
```python
Consider the following serializer and instance:

class MySerializer(serializers.Serializer):
    name = serializers.CharField()
    type = serializers.CharField(required=False, allow_null=True)
    desc = serializers.CharField(required=False, allow_null=True)

instance = {'name': 'example'}
serializer = MySerializer(instance, partial=True)
data = serializer.data
# Current output: {'name': 'example', 'desc': None, 'type': None}
# Proposed output: {'name': 'example'}
```
## Changed
```python
def get_attribute(self, instance
        """
        Given the *outgoing* object instance, return the primitive value
        that should be used for this field.
        """
       ...
           
            # changed
            if not self.required: 
                raise SkipField()
            if self.allow_null:
                return None**
       ...
```
## Description
refs #9458

