### PR TITLE
Update quickstart.md

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -15,7 +15,7 @@ Create a new Django project named `tutorial`, then start a new app called `quick
     source env/bin/activate  # On Windows use `env\Scripts\activate`
 
     # Install Django and Django REST framework into the virtual environment
-    pip install djangorestframework
+    pip install django djangorestframework
 
     # Set up a new project with a single application
     django-admin startproject tutorial .  # Note the trailing '.' character


### PR DESCRIPTION
Add the `django` package to the `pip install` command.
## Description

In the [Quickstart](https://www.django-rest-framework.org/tutorial/quickstart/) webpage, the first code snippet under the [Project setup](https://www.django-rest-framework.org/tutorial/quickstart/#project-setup) section contains a small discrepancy.

As per the comment/description `# Install Django and Django REST framework into the virtual environment`, the following command `pip install djangorestframework` does not include the `django` package.

This pull request fixes the discrepancy by changing the command `pip install djangorestframework` to `pip install django djangorestframework`.
