### PR TITLE
Revert Unique Together Checking Regression

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -160,19 +160,10 @@ class UniqueTogetherValidator:
         queryset = self.exclude_current_instance(attrs, queryset, serializer.instance)
 
         # Ignore validation if any field is None
-        if serializer.instance is None:
-            checked_values = [
-                value for field, value in attrs.items() if field in self.fields
-            ]
-        else:
-            # Ignore validation if all field values are unchanged
-            checked_values = [
-                value
-                for field, value in attrs.items()
-                if field in self.fields and value != getattr(serializer.instance, field)
-            ]
-
-        if checked_values and None not in checked_values and qs_exists(queryset):
+        checked_values = [
+            value for field, value in attrs.items() if field in self.fields
+        ]
+        if None not in checked_values and qs_exists(queryset):
             field_names = ', '.join(self.fields)
             message = self.message.format(field_names=field_names)
             raise ValidationError(message, code='unique')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from django import VERSION as django_version
@@ -452,22 +452,6 @@ class TestUniquenessTogetherValidation(TestCase):
         data = {'date': None, 'race_name': 'Paris Marathon', 'position': 1}
         serializer = NullUniquenessTogetherSerializer(data=data)
         assert not serializer.is_valid()
-
-    def test_ignore_validation_for_unchanged_fields(self):
-        """
-        If all fields in the unique together constraint are unchanged,
-        then the instance should skip uniqueness validation.
-        """
-        instance = UniquenessTogetherModel.objects.create(
-            race_name="Paris Marathon", position=1
-        )
-        data = {"race_name": "Paris Marathon", "position": 1}
-        serializer = UniquenessTogetherSerializer(data=data, instance=instance)
-        with patch(
-            "rest_framework.validators.qs_exists"
-        ) as mock:
-            assert serializer.is_valid()
-            assert not mock.called
 
     def test_filter_queryset_do_not_skip_existing_attribute(self):
         """


### PR DESCRIPTION
## Description

Revert the changes in https://github.com/encode/django-rest-framework/pull/9154 that are leading to a regression where existing data in `initial_data` is ignored, where a uniqueness constraint might be incorrectly validated against, as described in https://github.com/encode/django-rest-framework/issues/9358.

