### PR TITLE
Adding pagination to viewsets

### DIFF
--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -26,6 +26,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework import generics, mixins, views
 from rest_framework.decorators import MethodMapper
 from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
 
 
 def _is_extra_action(attr):
@@ -214,7 +215,35 @@ class ViewSet(ViewSetMixin, views.APIView):
     """
     The base ViewSet class does not provide any actions by default.
     """
-    pass
+
+    pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
+
+    @property
+    def paginator(self):
+        """
+        The paginator instance associated with the view, or `None`.
+        """
+        if not hasattr(self, "_paginator"):
+            if self.pagination_class is None:
+                self._paginator = None
+            else:
+                self._paginator = self.pagination_class()
+        return self._paginator
+
+    def paginate_queryset(self, queryset):
+        """
+        Return a single page of results, or `None` if pagination is disabled.
+        """
+        if self.paginator is None:
+            return None
+        return self.paginator.paginate_queryset(queryset, self.request, view=self)
+
+    def get_paginated_response(self, data):
+        """
+        Return a paginated style `Response` object for the given output data.
+        """
+        assert self.paginator is not None
+        return self.paginator.get_paginated_response(data)
 
 
 class GenericViewSet(ViewSetMixin, generics.GenericAPIView):


### PR DESCRIPTION
At the moment, it is not possible to use response pagination with ViewSets, and it is necessary to inherit GenericAPIView. However, the concept of ViewSets is to create only what is necessary and inheriting another class, receiving other methods that may be unnecessary in this context, just to use an attribute does not match this and it also decreases performance, since some data may be cached.

Example of paginated return of action in the current ViewSet structure:
```py
from rest_framework import viewsets, generics
from rest_framework.decorators import action

class MyViewSet(viewsets.ViewSet, generics.GenericAPIView):
    queryset = MyModel.objects.all()
    serializer_class = MyModelSerializer

    @action(detail=False, methods=['get'], pagination_class=MyPaginationClass)
    def list_paginated_objects(self, request, *args, **kwargs):
        my_objects = self.paginate_queryset(self.queryset)

        return self.get_paginated_response(MyModelSerializer(my_objects, many=True).data)
```

With my suggestion, we can perform pagination in the ViewSet, without the need to inherit other classes and their methods.

Example of paginated return of action in the proposed ViewSet structure:
```py
from rest_framework import viewsets
from rest_framework.decorators import action

class MyViewSet(viewsets.ViewSet):
    queryset = MyModel.objects.all()
    serializer_class = MyModelSerializer

    @action(detail=False, methods=['get'], pagination_class=MyPaginationClass)
    def list_paginated_objects(self, request, *args, **kwargs):
        my_objects = self.paginate_queryset(self.queryset)

        return self.get_paginated_response(MyModelSerializer(my_objects, many=True).data)
```