### PR TITLE
Add MODEL_SERIALIZER_FIELD_MAPPING settings

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -143,6 +143,17 @@ Default: `ordering`
 
 ---
 
+## Serializer settings
+
+#### MODEL_SERIALIZER_FIELD_MAPPING
+
+Extra field mapping used to extend or override mapping of django db fields to serializer fields which is used by 
+ModelSerializer to set up fields for serializer.
+
+Default: `{}`
+
+---
+
 ## Versioning settings
 
 #### DEFAULT_VERSION

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -894,48 +894,8 @@ class ModelSerializer(Serializer):
     * A set of default validators are automatically populated.
     * Default `.create()` and `.update()` implementations are provided.
 
-    The process of automatically determining a set of serializer fields
-    based on the model fields is reasonably complex, but you almost certainly
-    don't need to dig into the implementation.
-
-    If the `ModelSerializer` class *doesn't* generate the set of fields that
-    you need you should either declare the extra/differing fields explicitly on
-    the serializer class, or simply use a `Serializer` class.
     """
-    serializer_field_mapping = {
-        models.AutoField: IntegerField,
-        models.BigIntegerField: IntegerField,
-        models.BooleanField: BooleanField,
-        models.CharField: CharField,
-        models.CommaSeparatedIntegerField: CharField,
-        models.DateField: DateField,
-        models.DateTimeField: DateTimeField,
-        models.DecimalField: DecimalField,
-        models.DurationField: DurationField,
-        models.EmailField: EmailField,
-        models.Field: ModelField,
-        models.FileField: FileField,
-        models.FloatField: FloatField,
-        models.ImageField: ImageField,
-        models.IntegerField: IntegerField,
-        models.NullBooleanField: BooleanField,
-        models.PositiveIntegerField: IntegerField,
-        models.PositiveSmallIntegerField: IntegerField,
-        models.SlugField: SlugField,
-        models.SmallIntegerField: IntegerField,
-        models.TextField: CharField,
-        models.TimeField: TimeField,
-        models.URLField: URLField,
-        models.UUIDField: UUIDField,
-        models.GenericIPAddressField: IPAddressField,
-        models.FilePathField: FilePathField,
-    }
-    if hasattr(models, 'JSONField'):
-        serializer_field_mapping[models.JSONField] = JSONField
-    if postgres_fields:
-        serializer_field_mapping[postgres_fields.HStoreField] = HStoreField
-        serializer_field_mapping[postgres_fields.ArrayField] = ListField
-        serializer_field_mapping[postgres_fields.JSONField] = JSONField
+
     serializer_related_field = PrimaryKeyRelatedField
     serializer_related_to_field = SlugRelatedField
     serializer_url_field = HyperlinkedIdentityField
@@ -949,6 +909,61 @@ class ModelSerializer(Serializer):
     # views, to correctly handle the 'Location' response header for
     # "HTTP 201 Created" responses.
     url_field_name = None
+
+    @property
+    def serializer_field_mapping(self):
+        """Get mapping of django model field to serializer field.
+
+        The process of automatically determining a set of serializer fields
+        based on the model fields is reasonably complex, but you almost certainly
+        don't need to dig into the implementation.
+
+        If the `ModelSerializer` class *doesn't* generate the set of fields that
+        you need you should either extend serializer_field_mapping with
+        the extra/differing fields explicitly, or simply use a `Serializer`
+        class.
+
+        """
+        serializer_field_mapping = {
+            models.AutoField: IntegerField,
+            models.BigIntegerField: IntegerField,
+            models.BooleanField: BooleanField,
+            models.CharField: CharField,
+            models.CommaSeparatedIntegerField: CharField,
+            models.DateField: DateField,
+            models.DateTimeField: DateTimeField,
+            models.DecimalField: DecimalField,
+            models.DurationField: DurationField,
+            models.EmailField: EmailField,
+            models.Field: ModelField,
+            models.FileField: FileField,
+            models.FloatField: FloatField,
+            models.ImageField: ImageField,
+            models.IntegerField: IntegerField,
+            models.NullBooleanField: BooleanField,
+            models.PositiveIntegerField: IntegerField,
+            models.PositiveSmallIntegerField: IntegerField,
+            models.SlugField: SlugField,
+            models.SmallIntegerField: IntegerField,
+            models.TextField: CharField,
+            models.TimeField: TimeField,
+            models.URLField: URLField,
+            models.UUIDField: UUIDField,
+            models.GenericIPAddressField: IPAddressField,
+            models.FilePathField: FilePathField,
+        }
+        if hasattr(models, 'JSONField'):
+            serializer_field_mapping[models.JSONField] = JSONField
+        if postgres_fields:
+            serializer_field_mapping[postgres_fields.HStoreField] = HStoreField
+            serializer_field_mapping[postgres_fields.ArrayField] = ListField
+            serializer_field_mapping[postgres_fields.JSONField] = JSONField
+        for (
+            model_field,
+            serializer_field,
+        ) in api_settings.MODEL_SERIALIZER_FIELD_MAPPING.items():
+            serializer_field_mapping[model_field] = serializer_field
+        return serializer_field_mapping
 
     # Default `create` and `update` behavior...
     def create(self, validated_data):

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -126,6 +126,9 @@ DEFAULTS = {
         'retrieve': 'read',
         'destroy': 'delete'
     },
+
+    # Serializers
+    'MODEL_SERIALIZER_FIELD_MAPPING': {}
 }
 
 
@@ -147,7 +150,8 @@ IMPORT_STRINGS = [
     'UNAUTHENTICATED_USER',
     'UNAUTHENTICATED_TOKEN',
     'VIEW_NAME_FUNCTION',
-    'VIEW_DESCRIPTION_FUNCTION'
+    'VIEW_DESCRIPTION_FUNCTION',
+    'MODEL_SERIALIZER_FIELD_MAPPING',
 ]
 
 
@@ -168,6 +172,16 @@ def perform_import(val, setting_name):
         return import_from_string(val, setting_name)
     elif isinstance(val, (list, tuple)):
         return [import_from_string(item, setting_name) for item in val]
+    elif isinstance(val, (dict)):
+        return {
+            import_from_string(
+                key,
+                setting_name,
+            ): import_from_string(
+                value,
+                setting_name,
+            ) for key, value in val.items()
+        }
     return val
 
 


### PR DESCRIPTION
Add way to extend field mapping for ModelSerializer without redefining.

As of now the only way to do it is to make such hack

```python
class ModelSerializer:
  @property
    def serializer_field_mapping(
        self,
    ) -> dict[type[Field], type[serializers.Field]]:
        """Extend serializer mapping with custom fields."""
        serializer_field_mapping = super().serializer_field_mapping
        serializer_field_mapping[FileField] = CustomField
        serializer_field_mapping[ImageField] = CustomField
        return serializer_field_mapping
```

But for this users need to do this for every serializer or create a base one. This setting will simplify this and make it easier to extend mapping for custom or unsupported fields.