### PR TITLE
Update browsable-api.md

### DIFF
--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -24,7 +24,7 @@ from django.urls import include, path
 
 urlpatterns = [
     # ...
-    re_path(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework"))
+    path("api-auth/", include("rest_framework.urls", namespace="rest_framework"))
 ]
 ```
 

--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -20,9 +20,11 @@ By default, the API will return the format specified by the headers, which in th
 To quickly add authentication to the browesable api, add a routes named `"login"` and `"logout"` under the namespace `"rest_framework"`. DRF provides default routes for this which you can add to your urlconf:
 
 ```python
+from django.urls import include, re_path
+
 urlpatterns = [
     # ...
-    url(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework"))
+    re_path(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework"))
 ]
 ```
 

--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -20,7 +20,7 @@ By default, the API will return the format specified by the headers, which in th
 To quickly add authentication to the browesable api, add a routes named `"login"` and `"logout"` under the namespace `"rest_framework"`. DRF provides default routes for this which you can add to your urlconf:
 
 ```python
-from django.urls import include, re_path
+from django.urls import include, path
 
 urlpatterns = [
     # ...


### PR DESCRIPTION
The documentation uses a deprecated method url(), use re_path() instead. Explicit imports (which were not specified).

*Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Documentation edited: deprecated method correction.
