### PR TITLE
Support for the Strictest CSP with Nonce for Scripts

### DIFF
--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -244,19 +244,19 @@
       {% endif %}
 
       {% block script %}
-        <script type="application/json" id="drf_csrf">
+        <script type="application/json" id="drf_csrf" nonce="{{ request.csp_nonce }}">
           {
             "csrfHeaderName": "{{ csrf_header_name|default:'X-CSRFToken' }}",
             "csrfToken": "{{ csrf_token }}"
           }
         </script>
-        <script src="{% static "rest_framework/js/jquery-3.7.1.min.js" %}"></script>
-        <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
-        <script src="{% static "rest_framework/js/csrf.js" %}"></script>
-        <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
-        <script src="{% static "rest_framework/js/prettify-min.js" %}"></script>
-        <script src="{% static "rest_framework/js/default.js" %}"></script>
-        <script src="{% static "rest_framework/js/load-ajax-form.js" %}"></script>
+        <script src="{% static "rest_framework/js/jquery-3.7.1.min.js" %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static "rest_framework/js/ajax-form.js" %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static "rest_framework/js/csrf.js" %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static "rest_framework/js/bootstrap.min.js" %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static "rest_framework/js/prettify-min.js" %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static "rest_framework/js/default.js" %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static "rest_framework/js/load-ajax-form.js" %}" nonce="{{ request.csp_nonce }}"></script>
       {% endblock %}
     </body>
   {% endblock %}

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -287,19 +287,19 @@
     {% endif %}
 
     {% block script %}
-      <script type="application/json" id="drf_csrf">
+      <script type="application/json" id="drf_csrf" nonce="{{ request.csp_nonce }}">
         {
           "csrfHeaderName": "{{ csrf_header_name|default:'X-CSRFToken' }}",
           "csrfToken": "{% if request %}{{ csrf_token }}{% endif %}"
         }
       </script>
-      <script src="{% static "rest_framework/js/jquery-3.7.1.min.js" %}"></script>
-      <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
-      <script src="{% static "rest_framework/js/csrf.js" %}"></script>
-      <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
-      <script src="{% static "rest_framework/js/prettify-min.js" %}"></script>
-      <script src="{% static "rest_framework/js/default.js" %}"></script>
-      <script src="{% static "rest_framework/js/load-ajax-form.js" %}"></script>
+      <script src="{% static "rest_framework/js/jquery-3.7.1.min.js" %}" nonce="{{ request.csp_nonce }}"></script>
+      <script src="{% static "rest_framework/js/ajax-form.js" %}" nonce="{{ request.csp_nonce }}"></script>
+      <script src="{% static "rest_framework/js/csrf.js" %}" nonce="{{ request.csp_nonce }}"></script>
+      <script src="{% static "rest_framework/js/bootstrap.min.js" %}" nonce="{{ request.csp_nonce }}"></script>
+      <script src="{% static "rest_framework/js/prettify-min.js" %}" nonce="{{ request.csp_nonce }}"></script>
+      <script src="{% static "rest_framework/js/default.js" %}" nonce="{{ request.csp_nonce }}"></script>
+      <script src="{% static "rest_framework/js/load-ajax-form.js" %}" nonce="{{ request.csp_nonce }}"></script>
     {% endblock %}
 
   </body>

--- a/rest_framework/templates/rest_framework/docs/error.html
+++ b/rest_framework/templates/rest_framework/docs/error.html
@@ -66,6 +66,6 @@ at <code>rest_framework/docs/error.html</code>.</p>
 
 
 
-        <script src="{% static 'rest_framework/js/jquery-3.7.1.min.js' %}"></script>
+        <script src="{% static 'rest_framework/js/jquery-3.7.1.min.js' %}" nonce="{{ request.csp_nonce }}"></script>
     </body>
 </html>

--- a/rest_framework/templates/rest_framework/docs/index.html
+++ b/rest_framework/templates/rest_framework/docs/index.html
@@ -17,8 +17,8 @@
         <link href="{% static 'rest_framework/docs/img/favicon.ico' %}" rel="shortcut icon">
 
         {% if code_style %}<style>{{ code_style }}</style>{% endif %}
-        <script src="{% static 'rest_framework/js/coreapi-0.1.1.js' %}"></script>
-        <script src="{% url 'api-docs:schema-js' %}"></script>
+        <script src="{% static 'rest_framework/js/coreapi-0.1.1.js' %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% url 'api-docs:schema-js' %}" nonce="{{ request.csp_nonce }}"></script>
 
     </head>
 
@@ -38,11 +38,11 @@
         {% include "rest_framework/docs/auth/basic.html" %}
         {% include "rest_framework/docs/auth/session.html" %}
 
-        <script src="{% static 'rest_framework/js/jquery-3.7.1.min.js' %}"></script>
-        <script src="{% static 'rest_framework/js/bootstrap.min.js' %}"></script>
-        <script src="{% static 'rest_framework/docs/js/jquery.json-view.min.js' %}"></script>
-        <script src="{% static 'rest_framework/docs/js/api.js' %}"></script>
-        <script>
+        <script src="{% static 'rest_framework/js/jquery-3.7.1.min.js' %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static 'rest_framework/js/bootstrap.min.js' %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static 'rest_framework/docs/js/jquery.json-view.min.js' %}" nonce="{{ request.csp_nonce }}"></script>
+        <script src="{% static 'rest_framework/docs/js/api.js' %}" nonce="{{ request.csp_nonce }}"></script>
+        <script nonce="{{ request.csp_nonce }}">
             {% if user.is_authenticated %}
                 window.auth = {
                     'type': 'session',

--- a/rest_framework/templates/rest_framework/docs/langs/javascript-intro.html
+++ b/rest_framework/templates/rest_framework/docs/langs/javascript-intro.html
@@ -1,5 +1,5 @@
 {% load rest_framework %}
 {% load static %}
 <pre class="highlight javascript hide" data-language="javascript"><code>{% code html %}<!-- Load the JavaScript client library -->
-<script src="{% static 'rest_framework/js/coreapi-0.1.1.js' %}"></script>
-<script src="{% url 'api-docs:schema-js' %}"></script>{% endcode %}</code></pre>
+<script src="{% static 'rest_framework/js/coreapi-0.1.1.js' %}" nonce="{{ request.csp_nonce }}"></script>
+<script src="{% url 'api-docs:schema-js' %}" nonce="{{ request.csp_nonce }}"></script>{% endcode %}</code></pre>


### PR DESCRIPTION
When you use the strictest Content Security Policy (CSP) configuration, Django REST Framework scripts may be blocked.

To prevent this blocking, each script that is loaded must include a nonce. Adding self, domain, or other sources to the policy is insufficient because [strict-dynamic](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic) disallows them.

Example of a CSP violation report:
```
[Report Only] Refused to load the script '<URL>' because it violates the following Content Security Policy directive: "script-src ... 'strict-dynamic' 'unsafe-eval' 'nonce-J7Q4+1H1yqr9X+9tkiqBNw=='". Note that 'strict-dynamic' is present, so host-based allowlisting is disabled. Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.
```

Rel: #7960, #8783