### PR TITLE
Drop deprecated `AutoSchema._get_reference` method

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -23,9 +23,5 @@ HTTP_HEADER_ENCODING = 'iso-8859-1'
 ISO_8601 = 'iso-8601'
 
 
-class RemovedInDRF316Warning(DeprecationWarning):
-    pass
-
-
 class RemovedInDRF317Warning(PendingDeprecationWarning):
     pass

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -11,9 +11,7 @@ from django.core.validators import (
 from django.db import models
 from django.utils.encoding import force_str
 
-from rest_framework import (
-    RemovedInDRF316Warning, exceptions, renderers, serializers
-)
+from rest_framework import exceptions, renderers, serializers
 from rest_framework.compat import inflection, uritemplate
 from rest_framework.fields import _UnvalidatedField, empty
 from rest_framework.settings import api_settings
@@ -721,11 +719,3 @@ class AutoSchema(ViewInspector):
             path = path[1:]
 
         return [path.split('/')[0].replace('_', '-')]
-
-    def _get_reference(self, serializer):
-        warnings.warn(
-            "Method `_get_reference()` has been renamed to `get_reference()`. "
-            "The old name will be removed in DRF v3.16.",
-            RemovedInDRF316Warning, stacklevel=2
-        )
-        return self.get_reference(serializer)


### PR DESCRIPTION
## Description

In preparation for the upcoming 3.16 release, drop `AutoSchema._get_reference` method which is marked as `RemovedInDRF316Warning`. 

The warning class is now unused, so dropping that as well (shouldn't be needed with DRF 3.16).

- #9516