### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13-dev'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       run: python -m pip install --upgrade codecov tox
 
     - name: Run tox targets for ${{ matrix.python-version }}
-      run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
+      run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d . | cut -f 1 -d '-')
 
     - name: Run extra tox targets
       if: ${{ matrix.python-version == '3.9' }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ continued development by **[signing up for a paid plan][funding]**.
 REST framework requires the following:
 
 * Django (4.2, 5.0, 5.1)
-* Python (3.8, 3.9, 3.10, 3.11, 3.12)
+* Python (3.8, 3.9, 3.10, 3.11, 3.12, 3.13)
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -79,8 +79,9 @@ class ViewInspector:
         view = self.view
 
         method_name = getattr(view, 'action', method.lower())
-        method_docstring = getattr(view, method_name, None).__doc__
-        if method_docstring:
+        method_func = getattr(view, method_name, None)
+        method_docstring = method_func.__doc__
+        if method_func and method_docstring:
             # An explicit docstring on the method or action.
             return self._get_description_section(view, method.lower(), formatting.dedent(smart_str(method_docstring)))
         else:

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
        {py310}-{django42,django50,django51,djangomain}
        {py311}-{django42,django50,django51,djangomain}
        {py312}-{django42,django50,django51,djangomain}
+       {py313}-{django51,djangomain}
        base
        dist
        docs


### PR DESCRIPTION
## Description

- [x] Add Python 3.13-dev to the CI
- [x] Declare support in the docs and in package metadata
- [x] Fix issue(s)

## Issues found

### 1. Fix view description inspection

Python 3.13 introduced docstrings for the `None` singletong: https://github.com/python/cpython/pull/117813

In Python 3.12, this is an empty string:

```
 ➜ python3.12
Python 3.12.6 (main, Sep 10 2024, 19:06:17) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> d = None
>>> d.__doc__
>>>
```

In Python 3.13, it's no longer empty:

```
 ➜ python3.13
Python 3.13.0rc2+ (heads/3.13:660baa1, Sep 10 2024, 18:57:50) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> d = None
>>> d.__doc__
'The type of the None singleton.'
>>>
```

The fix: added a check in the inspector that get the view description out the view function docstring to catch this edge case.