### PR TITLE
Add test covering update view without `queryset` attribute

### DIFF
--- a/tests/test_prefetch_related.py
+++ b/tests/test_prefetch_related.py
@@ -56,3 +56,17 @@ class TestPrefetchRelatedUpdates(TestCase):
             'email': 'tom@example.com'
         }
         assert response.data == expected
+
+    def test_can_update_without_queryset_on_class_view(self):
+        class UserUpdateWithoutQuerySet(generics.UpdateAPIView):
+            serializer_class = UserSerializer
+
+            def get_object(self):
+                return User.objects.get(pk=self.kwargs['pk'])
+
+        request = factory.patch('/', {'username': 'new'})
+        response = UserUpdateWithoutQuerySet.as_view()(request, pk=self.user.pk)
+        assert response.data['id'] == self.user.id
+        assert response.data['username'] == 'new'
+        self.user.refresh_from_db()
+        assert self.user.username == 'new'


### PR DESCRIPTION
## Description

Add test covering an expected behaviour from pre 3.15, where update views don't have to define a `queryset` attribute or `get_queryset` method. The behaviour regressed in 3.15 and the change was reverted in 3.15.1. However, it's a behaviour users care about which isn't covered by the test suite.

- Original PR: #8043
- Regression report: #9306
- Reverted in #9327
- Test extracted from: #9314
