### PR TITLE
Update 1-serialization.md

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -321,7 +321,7 @@ You can install httpie using pip:
 
 Finally, we can get a list of all of the snippets:
 
-    http http://127.0.0.1:8000/snippets/ --unsorted
+    http GET http://127.0.0.1:8000/snippets/ --unsorted
 
     HTTP/1.1 200 OK
     ...
@@ -354,7 +354,7 @@ Finally, we can get a list of all of the snippets:
 
 Or we can get a particular snippet by referencing its id:
 
-    http http://127.0.0.1:8000/snippets/2/ --unsorted
+    http GET http://127.0.0.1:8000/snippets/2/ --unsorted
 
     HTTP/1.1 200 OK
     ...


### PR DESCRIPTION
Making explicit the http GET method of the httpie calls. For some reason it is sending a POST instead of a GET request as it should be described here: https://httpie.io/docs/cli/optional-get-and-post

Note:
I was following the docs and testing it within the Git Bash windows console app for making the requests and debugging the DRF project in Pycharm.

*Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
