### PR TITLE
Use final version of Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
-        - '3.13-dev'
+        - '3.13'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Final version of Python 3.13 has been released and is now also available on GitHub actions. Follow up of pull request #9527.