### PR TITLE
fix: Fix invalid ngettext usage

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -226,8 +226,6 @@ class UnsupportedMediaType(APIException):
 class Throttled(APIException):
     status_code = status.HTTP_429_TOO_MANY_REQUESTS
     default_detail = _('Request was throttled.')
-    extra_detail_singular = _('Expected available in {wait} second.')
-    extra_detail_plural = _('Expected available in {wait} seconds.')
     default_code = 'throttled'
 
     def __init__(self, wait=None, detail=None, code=None):
@@ -235,13 +233,16 @@ class Throttled(APIException):
             detail = force_str(self.default_detail)
         if wait is not None:
             wait = math.ceil(wait)
-            detail = ' '.join((
-                detail,
-                force_str(ngettext(self.extra_detail_singular.format(wait=wait),
-                                   self.extra_detail_plural.format(wait=wait),
-                                   wait))))
+            detail = " ".join((detail, force_str(self.extra_detail(wait))))
         self.wait = wait
         super().__init__(detail, code)
+
+    def extra_detail(self, wait):
+        return ngettext(
+            'Expected available in {wait} second.',
+            'Expected available in {wait} seconds.',
+            wait,
+        ).format(wait=wait)
 
 
 def server_error(request, *args, **kwargs):

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -237,7 +237,8 @@ class Throttled(APIException):
         self.wait = wait
         super().__init__(detail, code)
 
-    def extra_detail(self, wait):
+    @staticmethod
+    def extra_detail(wait):
         return ngettext(
             'Expected available in {wait} second.',
             'Expected available in {wait} seconds.',


### PR DESCRIPTION
## Description

Format should be called after `ngettext`, not before.

See example: https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#pluralization

Formatting changes is because i don't know how to properly format it with your previous style, and there's no included autoformat/or formatting linter. I just formatted it automatically with ruff-lsp. Feel free to revert fomatting changes to your style or explain me what to do.