### PR TITLE
Fix docs typo in Serializers Validators

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -233,7 +233,7 @@ Serializer classes can also include reusable validators that are applied to the 
 
     class EventSerializer(serializers.Serializer):
         name = serializers.CharField()
-        room_number = serializers.IntegerField(choices=[101, 102, 103, 201])
+        room_number = serializers.ChoiceField(choices=[101, 102, 103, 201])
         date = serializers.DateField()
 
         class Meta:


### PR DESCRIPTION
## Description

## Pull Request Description

**Fix: Correct example for UniqueTogetherValidator in serializer documentation**

The example provided for using `UniqueTogetherValidator` in the serializer documentation currently uses an `IntegerField` for the `room_number` field. This is incorrect, as `UniqueTogetherValidator` is designed to work with relational fields, not integer fields.

This pull request replaces the `IntegerField` with a `ChoiceField` for the `room_number` field, which is a more appropriate field type for this scenario. This change ensures that the example accurately demonstrates how to use `UniqueTogetherValidator` with related fields.

**Changes Made:**

- In the example code snippet, the `room_number` field has been changed from:
  ```python
  room_number = serializers.IntegerField(choices=[101, 102, 103, 201])
  ```
  to:
  ```python
  room_number = serializers.ChoiceField(choices=[101, 102, 103, 201])
  ```

This minor correction will help users understand how to properly implement `UniqueTogetherValidator` in their serializers.

https://github.com/encode/django-rest-framework/blob/d3dd45b3f48856c3513ab1eb5354194fa9898f39/docs/api-guide/serializers.md?plain=1#L236