### PR TITLE
Remove transefix mentions from documentation

### DIFF
--- a/docs/community/project-management.md
+++ b/docs/community/project-management.md
@@ -51,11 +51,6 @@ The following template should be used for the description of the issue, and serv
     Release manager is @***.
     Pull request is #***.
 
-    During development cycle:
-
-    - [ ] Upload the new content to be translated to [transifex](https://www.django-rest-framework.org/topics/project-management/#translations).
-
-
     Checklist:
 
     - [ ] Create pull request for [release notes](https://github.com/encode/django-rest-framework/blob/master/docs/topics/release-notes.md) based on the [*.*.* milestone](https://github.com/encode/django-rest-framework/milestones/***).
@@ -64,7 +59,6 @@ The following template should be used for the description of the issue, and serv
         - [ ] `setup.py` Python & Django version trove classifiers
         - [ ] `README` Python & Django versions
         - [ ] `docs` Python & Django versions
-    - [ ] Update the translations from [transifex](https://www.django-rest-framework.org/topics/project-management/#translations).
     - [ ] Ensure the pull request increments the version to `*.*.*` in [`restframework/__init__.py`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/__init__.py).
     - [ ] Ensure documentation validates
         - Build and serve docs `mkdocs serve`
@@ -82,55 +76,6 @@ The following template should be used for the description of the issue, and serv
     To modify this process for future releases make a pull request to the [project management](https://www.django-rest-framework.org/topics/project-management/) documentation.
 
 When pushing the release to PyPI ensure that your environment has been installed from our development `requirement.txt`, so that documentation and PyPI installs are consistently being built against a pinned set of packages.
-
----
-
-## Translations
-
-The maintenance team are responsible for managing the translation packs include in REST framework. Translating the source strings into multiple languages is managed through the [transifex service][transifex-project].
-
-### Managing Transifex
-
-The [official Transifex client][transifex-client] is used to upload and download translations to Transifex. The client is installed using pip:
-
-    pip install transifex-client
-
-To use it you'll need a login to Transifex which has a password, and you'll need to have administrative access to the Transifex project. You'll need to create a `~/.transifexrc` file which contains your credentials.
-
-    [https://www.transifex.com]
-    username = ***
-    token = ***
-    password = ***
-    hostname = https://www.transifex.com
-
-### Upload new source files
-
-When any user visible strings are changed, they should be uploaded to Transifex so that the translators can start to translate them. To do this, just run:
-
-    # 1. Update the source django.po file, which is the US English version.
-    cd rest_framework
-    django-admin makemessages -l en_US
-    # 2. Push the source django.po file to Transifex.
-    cd ..
-    tx push -s
-
-When pushing source files, Transifex will update the source strings of a resource to match those from the new source file.
-
-Here's how differences between the old and new source files will be handled:
-
-* New strings will be added.
-* Modified strings will be added as well.
-* Strings which do not exist in the new source file will be removed from the database, along with their translations. If that source strings gets re-added later then [Transifex Translation Memory][translation-memory] will automatically include the translation string.
-
-### Download translations
-
-When a translator has finished translating their work needs to be downloaded from Transifex into the REST framework repository. To do this, run:
-
-    # 3. Pull the translated django.po files from Transifex.
-    tx pull -a --minimum-perc 10
-    cd rest_framework
-    # 4. Compile the binary .mo files for all supported languages.
-    django-admin compilemessages
 
 ---
 
@@ -158,7 +103,4 @@ The following issues still need to be addressed:
 
 [bus-factor]: https://en.wikipedia.org/wiki/Bus_factor
 [un-triaged]: https://github.com/encode/django-rest-framework/issues?q=is%3Aopen+no%3Alabel
-[transifex-project]: https://www.transifex.com/projects/p/django-rest-framework/
-[transifex-client]: https://pypi.org/project/transifex-client/
-[translation-memory]: http://docs.transifex.com/guides/tm#let-tm-automatically-populate-translations
 [mailing-list]: https://groups.google.com/forum/#!forum/django-rest-framework

--- a/docs/topics/internationalization.md
+++ b/docs/topics/internationalization.md
@@ -60,11 +60,12 @@ If you only wish to support a subset of the available languages, use Django's st
 
 ## Adding new translations
 
-REST framework translations are managed online using [Transifex][transifex-project]. You can use the Transifex service to add new translation languages. The maintenance team will then ensure that these translation strings are included in the REST framework package.
+REST framework translations are managed on GitHub. You can contribute new translation languages or update existing ones
+by following the guidelines in the [Contributing to REST Framework][] section and submitting a pull request.
 
 Sometimes you may need to add translation strings to your project locally. You may need to do this if:
 
-* You want to use REST Framework in a language which has not been translated yet on Transifex.
+* You want to use REST Framework in a language which is not supported by the project.
 * Your project includes custom error messages, which are not part of REST framework's default translation strings.
 
 #### Translating a new language locally
@@ -103,9 +104,9 @@ You can find more information on how the language preference is determined in th
 For API clients the most appropriate of these will typically be to use the `Accept-Language` header; Sessions and cookies will not be available unless using session authentication, and generally better practice to prefer an `Accept-Language` header for API clients rather than using language URL prefixes.
 
 [cite]: https://youtu.be/Wa0VfS2q94Y
+[Contributing to REST Framework]: ../community/contributing.md#development
 [django-translation]: https://docs.djangoproject.com/en/stable/topics/i18n/translation
 [custom-exception-handler]: ../api-guide/exceptions.md#custom-exception-handling
-[transifex-project]: https://explore.transifex.com/django-rest-framework-1/django-rest-framework/
 [django-po-source]: https://raw.githubusercontent.com/encode/django-rest-framework/master/rest_framework/locale/en_US/LC_MESSAGES/django.po
 [django-language-preference]: https://docs.djangoproject.com/en/stable/topics/i18n/translation/#how-django-discovers-language-preference
 [django-locale-paths]: https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-LOCALE_PATHS


### PR DESCRIPTION
## Description

In #9535, it was decided to handle translations in the Github repository, so we removed the reference to transefix from the documentation.
Wondering: should we update contributing.md? Or is this change in the documentation sufficient?
