### PR TITLE
Drop coreapi support for DRF 3.17

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,6 +1,4 @@
 # Optional packages which may be used with REST framework.
-coreapi==2.3.1
-coreschema==0.0.4
 django-filter
 django-guardian>=2.4.0,<2.5
 inflection==0.5.1


### PR DESCRIPTION
## Description

refs #8453

As discussed in #8453, we are deprecating the coreapi for drf 3.17. 

I read the discussion in detail, and I'm wondering if it was decided to “leave all schema generation logic in the library that generates the schema (drf-spectacular), and drf will not be involved in schema generation” (drf-spectacular will be part of drf?) The comments in the linked discussion say that...

> Yes. The idea would be to leave (just) the extension points in place, as they are.

