### PR TITLE
Removed extra <> in validators example

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -48,7 +48,7 @@ If we open up the Django shell using `manage.py shell` we can now
     CustomerReportSerializer():
         id = IntegerField(label='ID', read_only=True)
         time_raised = DateTimeField(read_only=True)
-        reference = CharField(max_length=20, validators=[<UniqueValidator(queryset=CustomerReportRecord.objects.all())>])
+        reference = CharField(max_length=20, validators=[UniqueValidator(queryset=CustomerReportRecord.objects.all())])
         description = CharField(style={'type': 'textarea'})
 
 The interesting bit here is the `reference` field. We can see that the uniqueness constraint is being explicitly enforced by a validator on the serializer field.


### PR DESCRIPTION
## Description

Fixes #9585 

Removed the extra <> around UniqueValidator.