### PR TITLE
Raise NotAcceptable if suffix or query format is not acceptable

### DIFF
--- a/rest_framework/negotiation.py
+++ b/rest_framework/negotiation.py
@@ -2,7 +2,6 @@
 Content negotiation deals with selecting an appropriate renderer given the
 incoming request.  Typically this will be based on the request's Accept header.
 """
-from django.http import Http404
 
 from rest_framework import exceptions
 from rest_framework.settings import api_settings
@@ -85,7 +84,10 @@ class DefaultContentNegotiation(BaseContentNegotiation):
         renderers = [renderer for renderer in renderers
                      if renderer.format == format]
         if not renderers:
-            raise Http404
+            raise exceptions.NotAcceptable(
+                detail="Could not satisfy the request format suffix or query.",
+                available_renderers=renderers
+            )
         return renderers
 
     def get_accept_list(self, request):


### PR DESCRIPTION
refs #9591 

Modified the error handling in `negotiation.py` to raise `exceptions.NotAcceptable` when a renderer is not found.