### PR TITLE
Fixed regression that tests using format still work

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -150,6 +150,8 @@ class APIRequestFactory(DjangoRequestFactory):
         """
         Encode the data returning a two tuple of (bytes, content_type)
         """
+        if data is None:
+            return (b'', content_type)
 
         assert format is None or content_type is None, (
             'You may not set both `format` and `content_type`.'
@@ -160,9 +162,6 @@ class APIRequestFactory(DjangoRequestFactory):
                 data = self._encode_json(data, content_type)
             except AttributeError:
                 pass
-
-            if data is None:
-                data = ''
 
             # Content type specified explicitly, treat data as a raw bytestring
             ret = force_bytes(data, settings.DEFAULT_CHARSET)
@@ -181,6 +180,7 @@ class APIRequestFactory(DjangoRequestFactory):
 
             # Use format and render the data into a bytestring
             renderer = self.renderer_classes[format]()
+            ret = renderer.render(data)
 
             # Determine the content-type header from the renderer
             content_type = renderer.media_type
@@ -189,14 +189,9 @@ class APIRequestFactory(DjangoRequestFactory):
                     content_type, renderer.charset
                 )
 
-            if data is None:
-                ret = ''
-            else:
-                ret = renderer.render(data)
-
-            # Coerce text to bytes if required.
-            if isinstance(ret, str) and renderer.charset:
-                ret = ret.encode(renderer.charset)
+                # Coerce text to bytes if required.
+                if isinstance(ret, str):
+                    ret = ret.encode(renderer.charset)
 
         return ret, content_type
 

--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -195,7 +195,7 @@ class APIRequestFactory(DjangoRequestFactory):
                 ret = renderer.render(data)
 
             # Coerce text to bytes if required.
-            if isinstance(ret, str):
+            if isinstance(ret, str) and renderer.charset:
                 ret = ret.encode(renderer.charset)
 
         return ret, content_type

--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -189,9 +189,9 @@ class APIRequestFactory(DjangoRequestFactory):
                     content_type, renderer.charset
                 )
 
-                # Coerce text to bytes if required.
-                if isinstance(ret, str):
-                    ret = ret.encode(renderer.charset)
+            # Coerce text to bytes if required.
+            if isinstance(ret, str):
+                ret = ret.encode(renderer.charset)
 
         return ret, content_type
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -10,7 +10,9 @@ from django.urls import path
 
 from rest_framework import fields, parsers, renderers, serializers, status
 from rest_framework.authtoken.models import Token
-from rest_framework.decorators import api_view, parser_classes, renderer_classes
+from rest_framework.decorators import (
+    api_view, parser_classes, renderer_classes
+)
 from rest_framework.response import Response
 from rest_framework.test import (
     APIClient, APIRequestFactory, URLPatternsTestCase, force_authenticate
@@ -55,10 +57,12 @@ class BasicSerializer(serializers.Serializer):
 def post_json_view(request):
     return Response(request.data)
 
+
 @api_view(['DELETE'])
 @renderer_classes((renderers.JSONRenderer, ))
 def delete_json_view(request):
     return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 @api_view(['POST'])
 def post_view(request):


### PR DESCRIPTION
## Description

This is a fix for a regression introduced in PR #6511 which we discovered in our tests run on Django REST framework JSON:API against DRF master.

The error only occurred on tests which return no content (e.g. delete), use a renderer without charset (e.g. JSONRenderer) and using format to determine the renderer.
