### PR TITLE
edit typo in renderers.md

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -525,7 +525,7 @@ Comma-separated values are a plain-text tabular data format, that can be easily 
 
 ## LaTeX
 
-[Rest Framework Latex] provides a renderer that outputs PDFs using Laulatex. It is maintained by [Pebble (S/F Software)][mypebble].
+[Rest Framework Latex] provides a renderer that outputs PDFs using Lualatex. It is maintained by [Pebble (S/F Software)][mypebble].
 
 
 [cite]: https://docs.djangoproject.com/en/stable/ref/template-response/#the-rendering-process


### PR DESCRIPTION
Simple fix of typo.

It's called lUAlatex and not lAUlatex.
