### PR TITLE
Switch to codecov GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       run: python -m pip install --upgrade pip setuptools virtualenv wheel
 
     - name: Install dependencies
-      run: python -m pip install --upgrade codecov tox
+      run: python -m pip install --upgrade tox
 
     - name: Run tox targets for ${{ matrix.python-version }}
       run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d . | cut -f 1 -d '-')
@@ -45,8 +45,9 @@ jobs:
         tox -e base,dist,docs
 
     - name: Upload coverage
-      run: |
-        codecov -e TOXENV,DJANGO
+      uses: codecov/codecov-action@v5
+      with:
+        env_vars: TOXENV,DJANGO
 
   test-docs:
     name: Test documentation links


### PR DESCRIPTION
## Description

While coverage seems to be reported with the current method, the package [we rely on is deprecated](https://github.com/codecov/codecov-python). Trying this method to see if it works out of the box or if need more work.

Fix #7908
