### PR TITLE
Update `strftime` formats link in the documentation

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -460,4 +460,4 @@ Default: `None`
 [cite]: https://www.python.org/dev/peps/pep-0020/
 [rfc4627]: https://www.ietf.org/rfc/rfc4627.txt
 [heroku-minified-json]: https://github.com/interagent/http-api-design#keep-json-minified-in-all-responses
-[strftime]: https://docs.python.org/3/library/time.html#time.strftime
+[strftime]: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes


### PR DESCRIPTION


## Description

The original added link is incorrect. The correct link which provides datetime format codes is: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes 
