### PR TITLE
Improve schema generation for DictField and HStoreField

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -501,7 +501,7 @@ class AutoSchema(ViewInspector):
             }
 
         # Also handles serializers.HStoreField,
-        if isinstance(field, DictField):
+        if isinstance(field, serializers.DictField):
             schema = {
                 "type": "object",
                 "additionalProperties": self.map_field(field.child),

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -500,12 +500,17 @@ class AutoSchema(ViewInspector):
                 'format': 'binary'
             }
 
+        # Also handles serializers.HStoreField,
+        if isinstance(field, serializers.DictField):
+            return {
+                "type": "object",
+                "additionalProperties": self.map_field(field.child),
+            }
+
         # Simplest cases, default to 'string' type:
         FIELD_CLASS_SCHEMA_TYPE = {
             serializers.BooleanField: 'boolean',
             serializers.JSONField: 'object',
-            serializers.DictField: 'object',
-            serializers.HStoreField: 'object',
         }
         return {'type': FIELD_CLASS_SCHEMA_TYPE.get(field.__class__, 'string')}
 

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -501,11 +501,14 @@ class AutoSchema(ViewInspector):
             }
 
         # Also handles serializers.HStoreField,
-        if isinstance(field, serializers.DictField):
-            return {
+        if isinstance(field, DictField):
+            schema = {
                 "type": "object",
                 "additionalProperties": self.map_field(field.child),
             }
+            if field.help_text:
+                schema["description"] = field.help_text
+            return schema
 
         # Simplest cases, default to 'string' type:
         FIELD_CLASS_SCHEMA_TYPE = {


### PR DESCRIPTION
## Description

In `rest_framework.schemas.openapi.AutoSchema`, make `serializers.DictField` and `serializers.HStoreField` generate objects with `additionalProperties` defined by their `.child`.
