### PR TITLE
Drop Python 3.8 as EOL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Some reasons you might want to use REST framework:
 
 # Requirements
 
-* Python 3.8+
+* Python 3.9+
 * Django 4.2, 5.0, 5.1
 
 We **highly recommend** and only officially support the latest patch release of

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from io import open
 from setuptools import find_packages, setup
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 8)
+REQUIRED_PYTHON = (3, 9)
 
 # This check and everything above must remain compatible with Python 2.7.
 if CURRENT_PYTHON < REQUIRED_PYTHON:
@@ -83,7 +83,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     install_requires=["django>=4.2", 'backports.zoneinfo;python_version<"3.9"'],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -97,7 +97,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-       {py38,py39}-{django42}
+       {py39}-{django42}
        {py310}-{django42,django50,django51,djangomain}
        {py311}-{django42,django50,django51,djangomain}
        {py312}-{django42,django50,django51,djangomain}


### PR DESCRIPTION
After DRF 3.16 release is done, it might be right time to drop python 3.8 support... until then