### PR TITLE
PoC: use moved module django.contrib.admindocs.regex if available

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -7,7 +7,12 @@ import re
 from importlib import import_module
 
 from django.conf import settings
-from django.contrib.admindocs.views import simplify_regex
+
+try:
+    from django.contrib.admindocs.regex import simplify_regex
+except ImportError:
+    from django.contrib.admindocs.views import simplify_regex
+
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.urls import URLPattern, URLResolver

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
        {py38,py39}-{django42}
-       {py310}-{django42,django50,django51,djangomain}
-       {py311}-{django42,django50,django51,djangomain}
-       {py312}-{django42,django50,django51,djangomain}
-       {py313}-{django51,djangomain}
+       {py310}-{django42,django50,django51,djangomain,djangofork}
+       {py311}-{django42,django50,django51,djangomain,djangofork}
+       {py312}-{django42,django50,django51,djangomain,djangofork}
+       {py313}-{django51,djangomain,djangofork}
        base
        dist
        docs
@@ -20,6 +20,7 @@ deps =
         django50: Django>=5.0,<5.1
         django51: Django>=5.1,<5.2
         djangomain: https://github.com/django/django/archive/main.tar.gz
+        djangofork: https://github.com/browniebroke/django/archive/split-admindocs-regexes-utils.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt
         setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
        {py38,py39}-{django42}
-       {py310}-{django42,django50,django51,djangomain,djangofork}
-       {py311}-{django42,django50,django51,djangomain,djangofork}
+       {py310}-{django42,django50,django51,djangomain}
+       {py311}-{django42,django50,django51,djangomain}
        {py312}-{django42,django50,django51,djangomain,djangofork}
        {py313}-{django51,djangomain,djangofork}
        base
@@ -52,4 +52,13 @@ ignore_outcome = true
 ignore_outcome = true
 
 [testenv:py312-djangomain]
+ignore_outcome = true
+
+[testenv:py313-djangomain]
+ignore_outcome = true
+
+[testenv:py312-djangofork]
+ignore_outcome = true
+
+[testenv:py313-djangofork]
 ignore_outcome = true


### PR DESCRIPTION
## Description

An experiement to run against https://github.com/django/django/pull/19116

As mentioned https://github.com/encode/django-rest-framework/issues/9626 - trying to fix it in Django
