### PR TITLE
Add missing ignore_outcome=true for the Python 3.13 - Django main combination

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,3 +52,6 @@ ignore_outcome = true
 
 [testenv:py312-djangomain]
 ignore_outcome = true
+
+[testenv:py313-djangomain]
+ignore_outcome = true


### PR DESCRIPTION
## Description

We have that for all runs against Django main but was missed when we added Python 3.13.