### PR TITLE
Modify permission operands to use custom messages

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -106,6 +106,17 @@ class APIException(Exception):
     default_code = 'error'
 
     def __init__(self, detail=None, code=None):
+        if (
+            isinstance(detail, tuple)
+            and isinstance(code, tuple)
+            and len(detail) == len(code)
+        ):
+            self.detail = [
+                _get_error_details(d or self.default_detail, c or self.default_code)
+                for d, c in zip(detail, code)
+            ]
+            return
+
         if detail is None:
             detail = self.default_detail
         if code is None:

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -2,6 +2,7 @@
 Provides a set of pluggable permission policies.
 """
 from django.http import Http404
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import exceptions
 
@@ -91,6 +92,13 @@ class OR:
     def __init__(self, op1, op2):
         self.op1 = op1
         self.op2 = op2
+        self.message1 = getattr(op1, 'message', None)
+        self.message2 = getattr(op2, 'message', None)
+        self.message = self.message1 or self.message2
+        if self.message1 and self.message2:
+            self.message = '"{0}" {1} "{2}"'.format(
+                self.message1, _('OR'), self.message2,
+            )
 
     def has_permission(self, request, view):
         return (

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -119,6 +119,7 @@ class OR:
 class NOT:
     def __init__(self, op1):
         self.op1 = op1
+        self.message = getattr(self.op1, 'message_inverted', None)
 
     def has_permission(self, request, view):
         return not self.op1.has_permission(request, view)

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -62,18 +62,29 @@ class AND:
     def __init__(self, op1, op2):
         self.op1 = op1
         self.op2 = op2
+        self.message = None
 
     def has_permission(self, request, view):
-        return (
-            self.op1.has_permission(request, view) and
-            self.op2.has_permission(request, view)
-        )
+        if not self.op1.has_permission(request, view):
+            self.message = getattr(self.op1, 'message', None)
+            return False
+
+        if not self.op2.has_permission(request, view):
+            self.message = getattr(self.op2, 'message', None)
+            return False
+
+        return True
 
     def has_object_permission(self, request, view, obj):
-        return (
-            self.op1.has_object_permission(request, view, obj) and
-            self.op2.has_object_permission(request, view, obj)
-        )
+        if not self.op1.has_object_permission(request, view, obj):
+            self.message = getattr(self.op1, 'message', None)
+            return False
+
+        if not self.op2.has_object_permission(request, view, obj):
+            self.message = getattr(self.op2, 'message', None)
+            return False
+
+        return True
 
 
 class OR:

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -556,7 +556,7 @@ class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
 
 
 class DeniedObjectViewWithDetailOR1(PermissionInstanceView):
-    permission_classes = (BasicObjectPerm | BasicObjectPermWithDetail,)
+    permission_classes = (BasicObjectPerm | BasicObjectPermWithDetail)
 
 
 class DeniedObjectViewWithDetailOR2(PermissionInstanceView):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -552,7 +552,7 @@ class DeniedObjectViewWithDetailAND2(PermissionInstanceView):
 
 
 class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
-    permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail,)
+    permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail)
 
 
 class DeniedObjectViewWithDetailOR1(PermissionInstanceView):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -18,6 +18,9 @@ from tests.models import BasicModel
 
 factory = APIRequestFactory()
 
+CUSTOM_MESSAGE_1 = 'Custom: You cannot access this resource'
+CUSTOM_MESSAGE_2 = 'Custom: You do not have permission to view this resource'
+
 
 class BasicSerializer(serializers.ModelSerializer):
     class Meta:
@@ -454,8 +457,15 @@ class BasicPerm(permissions.BasePermission):
 
 
 class BasicPermWithDetail(permissions.BasePermission):
-    message = 'Custom: You cannot access this resource'
+    message = CUSTOM_MESSAGE_1
     code = 'permission_denied_custom'
+
+    def has_permission(self, request, view):
+        return False
+
+
+class AnotherBasicPermWithDetail(permissions.BasePermission):
+    message = CUSTOM_MESSAGE_2
 
     def has_permission(self, request, view):
         return False
@@ -467,8 +477,15 @@ class BasicObjectPerm(permissions.BasePermission):
 
 
 class BasicObjectPermWithDetail(permissions.BasePermission):
-    message = 'Custom: You cannot access this resource'
+    message = CUSTOM_MESSAGE_1
     code = 'permission_denied_custom'
+
+    def has_object_permission(self, request, view, obj):
+        return False
+
+
+class AnotherBasicObjectPermWithDetail(permissions.BasePermission):
+    message = CUSTOM_MESSAGE_2
 
     def has_object_permission(self, request, view, obj):
         return False
@@ -487,6 +504,18 @@ class DeniedViewWithDetail(PermissionInstanceView):
     permission_classes = (BasicPermWithDetail,)
 
 
+class DeniedViewWithDetailAND1(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail & permissions.AllowAny,)
+
+
+class DeniedViewWithDetailAND2(PermissionInstanceView):
+    permission_classes = (permissions.AllowAny & AnotherBasicPermWithDetail,)
+
+
+class DeniedViewWithDetailAND3(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail & AnotherBasicPermWithDetail,)
+
+
 class DeniedObjectView(PermissionInstanceView):
     permission_classes = (BasicObjectPerm,)
 
@@ -495,13 +524,33 @@ class DeniedObjectViewWithDetail(PermissionInstanceView):
     permission_classes = (BasicObjectPermWithDetail,)
 
 
+class DeniedObjectViewWithDetailAND1(PermissionInstanceView):
+    permission_classes = (BasicObjectPermWithDetail & permissions.AllowAny,)
+
+
+class DeniedObjectViewWithDetailAND2(PermissionInstanceView):
+    permission_classes = (permissions.AllowAny & AnotherBasicObjectPermWithDetail,)
+
+
+class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
+    permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail,)
+
+
 denied_view = DeniedView.as_view()
 
 denied_view_with_detail = DeniedViewWithDetail.as_view()
 
+denied_view_with_detail_and_1 = DeniedViewWithDetailAND1.as_view()
+denied_view_with_detail_and_2 = DeniedViewWithDetailAND2.as_view()
+denied_view_with_detail_and_3 = DeniedViewWithDetailAND3.as_view()
+
 denied_object_view = DeniedObjectView.as_view()
 
 denied_object_view_with_detail = DeniedObjectViewWithDetail.as_view()
+
+denied_object_view_with_detail_and_1 = DeniedObjectViewWithDetailAND1.as_view()
+denied_object_view_with_detail_and_2 = DeniedObjectViewWithDetailAND2.as_view()
+denied_object_view_with_detail_and_3 = DeniedObjectViewWithDetailAND3.as_view()
 
 
 class CustomPermissionsTests(TestCase):
@@ -510,36 +559,71 @@ class CustomPermissionsTests(TestCase):
         User.objects.create_user('username', 'username@example.com', 'password')
         credentials = basic_auth_header('username', 'password')
         self.request = factory.get('/1', format='json', HTTP_AUTHORIZATION=credentials)
-        self.custom_message = 'Custom: You cannot access this resource'
         self.custom_code = 'permission_denied_custom'
 
     def test_permission_denied(self):
         response = denied_view(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertNotEqual(detail, self.custom_message)
+        self.assertNotEqual(detail, CUSTOM_MESSAGE_1)
         self.assertNotEqual(detail.code, self.custom_code)
 
     def test_permission_denied_with_custom_detail(self):
         response = denied_view_with_detail(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(detail, self.custom_message)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
         self.assertEqual(detail.code, self.custom_code)
+
+    def test_permission_denied_with_custom_detail_and_1(self):
+        response = denied_view_with_detail_and_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_with_custom_detail_and_2(self):
+        response = denied_view_with_detail_and_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_2)
+
+    def test_permission_denied_with_custom_detail_and_3(self):
+        response = denied_view_with_detail_and_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
 
     def test_permission_denied_for_object(self):
         response = denied_object_view(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertNotEqual(detail, self.custom_message)
+        self.assertNotEqual(detail, CUSTOM_MESSAGE_1)
         self.assertNotEqual(detail.code, self.custom_code)
 
     def test_permission_denied_for_object_with_custom_detail(self):
         response = denied_object_view_with_detail(self.request, pk=1)
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(detail, self.custom_message)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
         self.assertEqual(detail.code, self.custom_code)
+
+    def test_permission_denied_for_object_with_custom_detail_and_1(self):
+        response = denied_object_view_with_detail_and_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_for_object_with_custom_detail_and_2(self):
+        response = denied_object_view_with_detail_and_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_2)
+
+    def test_permission_denied_for_object_with_custom_detail_and_3(self):
+        response = denied_object_view_with_detail_and_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_2)
 
 
 class PermissionsCompositionTests(TestCase):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -516,6 +516,18 @@ class DeniedViewWithDetailAND3(PermissionInstanceView):
     permission_classes = (BasicPermWithDetail & AnotherBasicPermWithDetail,)
 
 
+class DeniedViewWithDetailOR1(PermissionInstanceView):
+    permission_classes = (BasicPerm | BasicPermWithDetail,)
+
+
+class DeniedViewWithDetailOR2(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail | BasicPerm,)
+
+
+class DeniedViewWithDetailOR3(PermissionInstanceView):
+    permission_classes = (BasicPermWithDetail | AnotherBasicPermWithDetail,)
+
+
 class DeniedObjectView(PermissionInstanceView):
     permission_classes = (BasicObjectPerm,)
 
@@ -536,6 +548,18 @@ class DeniedObjectViewWithDetailAND3(PermissionInstanceView):
     permission_classes = (AnotherBasicObjectPermWithDetail & BasicObjectPermWithDetail,)
 
 
+class DeniedObjectViewWithDetailOR1(PermissionInstanceView):
+    permission_classes = (BasicObjectPerm | BasicObjectPermWithDetail,)
+
+
+class DeniedObjectViewWithDetailOR2(PermissionInstanceView):
+    permission_classes = (BasicObjectPermWithDetail | BasicObjectPerm,)
+
+
+class DeniedObjectViewWithDetailOR3(PermissionInstanceView):
+    permission_classes = (BasicObjectPermWithDetail | AnotherBasicObjectPermWithDetail,)
+
+
 denied_view = DeniedView.as_view()
 
 denied_view_with_detail = DeniedViewWithDetail.as_view()
@@ -544,6 +568,10 @@ denied_view_with_detail_and_1 = DeniedViewWithDetailAND1.as_view()
 denied_view_with_detail_and_2 = DeniedViewWithDetailAND2.as_view()
 denied_view_with_detail_and_3 = DeniedViewWithDetailAND3.as_view()
 
+denied_view_with_detail_or_1 = DeniedViewWithDetailOR1.as_view()
+denied_view_with_detail_or_2 = DeniedViewWithDetailOR2.as_view()
+denied_view_with_detail_or_3 = DeniedViewWithDetailOR3.as_view()
+
 denied_object_view = DeniedObjectView.as_view()
 
 denied_object_view_with_detail = DeniedObjectViewWithDetail.as_view()
@@ -551,6 +579,10 @@ denied_object_view_with_detail = DeniedObjectViewWithDetail.as_view()
 denied_object_view_with_detail_and_1 = DeniedObjectViewWithDetailAND1.as_view()
 denied_object_view_with_detail_and_2 = DeniedObjectViewWithDetailAND2.as_view()
 denied_object_view_with_detail_and_3 = DeniedObjectViewWithDetailAND3.as_view()
+
+denied_object_view_with_detail_or_1 = DeniedObjectViewWithDetailOR1.as_view()
+denied_object_view_with_detail_or_2 = DeniedObjectViewWithDetailOR2.as_view()
+denied_object_view_with_detail_or_3 = DeniedObjectViewWithDetailOR3.as_view()
 
 
 class CustomPermissionsTests(TestCase):
@@ -593,6 +625,25 @@ class CustomPermissionsTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(detail, CUSTOM_MESSAGE_1)
 
+    def test_permission_denied_with_custom_detail_or_1(self):
+        response = denied_view_with_detail_or_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_with_custom_detail_or_2(self):
+        response = denied_view_with_detail_or_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_with_custom_detail_or_3(self):
+        response = denied_view_with_detail_or_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        expected_message = '"{0}" OR "{1}"'.format(CUSTOM_MESSAGE_1, CUSTOM_MESSAGE_2)
+        self.assertEqual(detail, expected_message)
+
     def test_permission_denied_for_object(self):
         response = denied_object_view(self.request, pk=1)
         detail = response.data.get('detail')
@@ -624,6 +675,25 @@ class CustomPermissionsTests(TestCase):
         detail = response.data.get('detail')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(detail, CUSTOM_MESSAGE_2)
+
+    def test_permission_denied_for_object_with_custom_detail_or_1(self):
+        response = denied_object_view_with_detail_or_1(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_for_object_with_custom_detail_or_2(self):
+        response = denied_object_view_with_detail_or_2(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, CUSTOM_MESSAGE_1)
+
+    def test_permission_denied_for_object_with_custom_detail_or_3(self):
+        response = denied_object_view_with_detail_or_3(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        expected_message = '"{0}" OR "{1}"'.format(CUSTOM_MESSAGE_1, CUSTOM_MESSAGE_2)
+        self.assertEqual(detail, expected_message)
 
 
 class PermissionsCompositionTests(TestCase):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -20,6 +20,7 @@ factory = APIRequestFactory()
 
 CUSTOM_MESSAGE_1 = 'Custom: You cannot access this resource'
 CUSTOM_MESSAGE_2 = 'Custom: You do not have permission to view this resource'
+INVERTED_MESSAGE = 'Inverted: Your account already active'
 
 
 class BasicSerializer(serializers.ModelSerializer):
@@ -458,6 +459,7 @@ class BasicPerm(permissions.BasePermission):
 
 class BasicPermWithDetail(permissions.BasePermission):
     message = CUSTOM_MESSAGE_1
+    message_inverted = INVERTED_MESSAGE
     code = 'permission_denied_custom'
 
     def has_permission(self, request, view):
@@ -478,6 +480,7 @@ class BasicObjectPerm(permissions.BasePermission):
 
 class BasicObjectPermWithDetail(permissions.BasePermission):
     message = CUSTOM_MESSAGE_1
+    message_inverted = INVERTED_MESSAGE
     code = 'permission_denied_custom'
 
     def has_object_permission(self, request, view, obj):
@@ -528,6 +531,10 @@ class DeniedViewWithDetailOR3(PermissionInstanceView):
     permission_classes = (BasicPermWithDetail | AnotherBasicPermWithDetail,)
 
 
+class DeniedViewWithDetailNOT(PermissionInstanceView):
+    permission_classes = (~BasicPermWithDetail,)
+
+
 class DeniedObjectView(PermissionInstanceView):
     permission_classes = (BasicObjectPerm,)
 
@@ -560,6 +567,10 @@ class DeniedObjectViewWithDetailOR3(PermissionInstanceView):
     permission_classes = (BasicObjectPermWithDetail | AnotherBasicObjectPermWithDetail,)
 
 
+class DeniedObjectViewWithDetailNOT(PermissionInstanceView):
+    permission_classes = (~BasicObjectPermWithDetail,)
+
+
 denied_view = DeniedView.as_view()
 
 denied_view_with_detail = DeniedViewWithDetail.as_view()
@@ -572,6 +583,8 @@ denied_view_with_detail_or_1 = DeniedViewWithDetailOR1.as_view()
 denied_view_with_detail_or_2 = DeniedViewWithDetailOR2.as_view()
 denied_view_with_detail_or_3 = DeniedViewWithDetailOR3.as_view()
 
+denied_view_with_detail_not = DeniedObjectViewWithDetailNOT.as_view()
+
 denied_object_view = DeniedObjectView.as_view()
 
 denied_object_view_with_detail = DeniedObjectViewWithDetail.as_view()
@@ -583,6 +596,8 @@ denied_object_view_with_detail_and_3 = DeniedObjectViewWithDetailAND3.as_view()
 denied_object_view_with_detail_or_1 = DeniedObjectViewWithDetailOR1.as_view()
 denied_object_view_with_detail_or_2 = DeniedObjectViewWithDetailOR2.as_view()
 denied_object_view_with_detail_or_3 = DeniedObjectViewWithDetailOR3.as_view()
+
+denied_object_view_with_detail_not = DeniedObjectViewWithDetailNOT.as_view()
 
 
 class CustomPermissionsTests(TestCase):
@@ -644,6 +659,12 @@ class CustomPermissionsTests(TestCase):
         expected_message = '"{0}" OR "{1}"'.format(CUSTOM_MESSAGE_1, CUSTOM_MESSAGE_2)
         self.assertEqual(detail, expected_message)
 
+    def test_permission_denied_with_custom_detail_not(self):
+        response = denied_view_with_detail_not(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, INVERTED_MESSAGE)
+
     def test_permission_denied_for_object(self):
         response = denied_object_view(self.request, pk=1)
         detail = response.data.get('detail')
@@ -694,6 +715,12 @@ class CustomPermissionsTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         expected_message = '"{0}" OR "{1}"'.format(CUSTOM_MESSAGE_1, CUSTOM_MESSAGE_2)
         self.assertEqual(detail, expected_message)
+
+    def test_permission_denied_for_object_with_custom_detail_not(self):
+        response = denied_object_view_with_detail_not(self.request, pk=1)
+        detail = response.data.get('detail')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(detail, INVERTED_MESSAGE)
 
 
 class PermissionsCompositionTests(TestCase):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -548,7 +548,7 @@ class DeniedObjectViewWithDetailAND1(PermissionInstanceView):
 
 
 class DeniedObjectViewWithDetailAND2(PermissionInstanceView):
-    permission_classes = (permissions.AllowAny & AnotherBasicObjectPermWithDetail,)
+    permission_classes = (permissions.AllowAny & AnotherBasicObjectPermWithDetail)
 
 
 class DeniedObjectViewWithDetailAND3(PermissionInstanceView):


### PR DESCRIPTION
Refs #6427

This is continuation of  #6499 #6502

This PR fixes error where permissions were missing `.message` property after applying `&` or `|`.

I'll mark this as a draft, and add the same handling for `.code` property. And maybe see if we can somehow refactor/optimize/make_better.

And I will add documentation. Probably, the only point worth mentioning is the new `message_inverted` property, because other change is just a bugfix, and everyone already expects that .message and .code will not be lost when using combined permission.
