### PR TITLE
Add message_key to UniqueConstraintValidator for Structured Error Handling

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -99,10 +99,11 @@ class UniqueTogetherValidator:
     missing_message = _('This field is required.')
     requires_context = True
 
-    def __init__(self, queryset, fields, message=None):
+    def __init__(self, queryset, fields, message=None, message_key=None):
         self.queryset = queryset
         self.fields = fields
         self.message = message or self.message
+        self.message_key = message_key
 
     def enforce_required_fields(self, attrs, serializer):
         """
@@ -176,7 +177,8 @@ class UniqueTogetherValidator:
         if checked_values and None not in checked_values and qs_exists(queryset):
             field_names = ', '.join(self.fields)
             message = self.message.format(field_names=field_names)
-            raise ValidationError(message, code='unique')
+            error_message = {self.message_key: message} if self.message_key else message
+            raise ValidationError(error_message, code='unique')
 
     def __repr__(self):
         return '<%s(queryset=%s, fields=%s)>' % (

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -222,6 +222,31 @@ class TestUniquenessTogetherValidation(TestCase):
             ]
         }
 
+    def test_is_not_unique_together_with_message_key(self):
+        """
+        Failing unique together validation should result in message_key errors.
+        """
+        class ErrorMessageKeySerializer(serializers.ModelSerializer):
+            class Meta:
+                model = UniquenessTogetherModel
+                fields = '__all__'
+                validators = [
+                    UniqueTogetherValidator(
+                        queryset=UniquenessTogetherModel.objects.all(),
+                        fields=['race_name', 'position'],
+                        message_key='name'
+                    )
+                ]
+
+        data = {'race_name': 'example', 'position': 2}
+        serializer = ErrorMessageKeySerializer(data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            'name': [
+                'The fields race_name, position must make a unique set.'
+            ]
+        }
+
     def test_is_unique_together(self):
         """
         In a unique together validation, one field may be non-unique


### PR DESCRIPTION
### Problem:  
The UniqueTogetherValidator previously raised validation errors using the non_related_fields key, leading to inconsistencies in error structures. As a result:  
- Errors were difficult to associate with specific fields in frontend applications.  
- Validation messages were not properly structured, making it challenging to integrate with form-handling logic.  
- When `non_related_fields` were involved, the error response did not clearly indicate the affected field.  

### Solution:  
- Introduced a `message_key` parameter to the `UniqueTogetherValidator`.  
- If provided, the validation error will be returned as a dictionary with `message_key` as the key.  
- If `message_key` is not provided, the error will default to `{non_related_field: "The fields race_name, position must make a unique set."}` for clarity.  

### Example  

#### **Before (Without `message_key`)**  
```python
class ErrorMessageKeySerializer(serializers.ModelSerializer):
    class Meta:
        model = UniquenessTogetherModel
        fields = '__all__'
        validators = [
            UniqueTogetherValidator(
                queryset=UniquenessTogetherModel.objects.all(),
                fields=['race_name', 'position']
            )
        ]
```
**Response:**  
```json
{
  "non_related_field": ["The fields race_name, position must make a unique set."]
}
```

#### **After (With `message_key="name"`)**  
```python
class ErrorMessageKeySerializer(serializers.ModelSerializer):
    class Meta:
        model = UniquenessTogetherModel
        fields = '__all__'
        validators = [
            UniqueTogetherValidator(
                queryset=UniquenessTogetherModel.objects.all(),
                fields=['race_name', 'position'],
                message_key='race_name'
            )
        ]
```
**Response:**  
```json
{
  "race_name": ["The fields race_name, position must make a unique set."]
}
```
