### PR TITLE
Add django-mongodb-backend support

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -16,6 +16,13 @@ def unicode_http_header(value):
     return value
 
 
+# django-mongodb-backend
+try:
+    from bson import ObjectId
+except ImportError:
+    ObjectId = None
+
+
 # django.contrib.postgres requires psycopg2
 try:
     from django.contrib.postgres import fields as postgres_fields

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1756,7 +1756,7 @@ class ObjectIdRestField(Field):
             raise ValidationError('Invalid ObjectId')
 
     def to_representation(self, value):
-        return str(value)
+        return value
 
 
 class JSONField(Field):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -35,6 +35,11 @@ try:
 except ImportError:
     pytz = None
 
+try:
+    from bson import ObjectId
+except ImportError:
+    ObjectId = None
+
 from rest_framework import ISO_8601
 from rest_framework.compat import ip_address_validators
 from rest_framework.exceptions import ErrorDetail, ValidationError
@@ -1743,6 +1748,15 @@ class HStoreField(DictField):
             "The `child` argument must be an instance of `CharField`, "
             "as the hstore extension stores values as strings."
         )
+
+
+class ObjectIdRestField(Field):
+    def to_internal_value(self, data):
+        if not ObjectId.is_valid(data):
+            raise ValidationError('Invalid ObjectId')
+
+    def to_representation(self, value):
+        return str(value)
 
 
 class JSONField(Field):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -27,7 +27,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework.compat import (
-    get_referenced_base_fields_from_q, postgres_fields
+    get_referenced_base_fields_from_q, postgres_fields, ObjectId
 )
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.fields import get_error_detail
@@ -938,6 +938,9 @@ class ModelSerializer(Serializer):
         serializer_field_mapping[postgres_fields.HStoreField] = HStoreField
         serializer_field_mapping[postgres_fields.ArrayField] = ListField
         serializer_field_mapping[postgres_fields.JSONField] = JSONField
+    if ObjectId:
+        from .fields import ObjectIdRestField
+        serializer_field_mapping[models.AutoField] = ObjectIdRestField
     serializer_related_field = PrimaryKeyRelatedField
     serializer_related_to_field = SlugRelatedField
     serializer_url_field = HyperlinkedIdentityField


### PR DESCRIPTION
Hello! I'm working on 3rd party library integration for [Django MongoDB Backend](https://github.com/mongodb/django-mongodb-backend) e.g. 

- https://github.com/carltongibson/django-filter/pull/1703

## Description

This draft PR adds an `ObjectIdRestField` to DRF for use with Django MongoDB Backend. With this PR, many DRF test suite errors change from `expected int, got ObjectId` to errors like:

```
___________________________________________________________________________ SearchFilterTests.test_search_field_with_custom_lookup ____________________________________________________________________________
tests/test_filters.py:225: in test_search_field_with_custom_lookup
    assert response.data == [
E   AssertionError: assert [{'id': '67be...text': 'abc'}] == [{'id': 1, 't...'title': 'z'}]
E     
E     At index 0 diff: {'id': '67be0f743ca9f525d672ebcc', 'title': 'z', 'text': 'abc'} != {'id': 1, 'title': 'z'
E     
E     ...Full output truncated (2 lines hidden), use '-vv' to show
```

Many of these errors can be fixed by removing hard coded pks similar to https://github.com/carltongibson/django-filter/pull/1703.

Planning to remove hard coded pks in a future commit after which I'll remove draft status. Any and all feedback appreciated!