### PR TITLE
docs: replace 'namespace' with 'name'

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -129,7 +129,7 @@ Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
     # Additionally, we include login URLs for the browsable API.
     urlpatterns = [
         path('', include(router.urls)),
-        path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+        path('api-auth/', include('rest_framework.urls', name='rest_framework'))
     ]
 
 Because we're using viewsets instead of views, we can automatically generate the URL conf for our API, by simply registering the viewsets with a router class.


### PR DESCRIPTION
- in [quickstart](https://www.django-rest-framework.org/tutorial/quickstart/), path(namespace='rest_framework') is wrong, path takes no argument called 'namespace', correct one is name="rest_framework"