### PR TITLE
fix(response): remove http content-type header on 204 status code

### DIFF
--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -9,6 +9,7 @@ from http.client import responses
 from django.template.response import SimpleTemplateResponse
 
 from rest_framework.serializers import Serializer
+from rest_framework.status import HTTP_204_NO_CONTENT
 
 
 class Response(SimpleTemplateResponse):
@@ -79,7 +80,7 @@ class Response(SimpleTemplateResponse):
             )
             return ret.encode(charset)
 
-        if not ret:
+        if not ret or self.status_code == HTTP_204_NO_CONTENT:
             del self['Content-Type']
 
         return ret


### PR DESCRIPTION
Hi, 
The BUG is when you return a Response with status code of 204_NO_CONTENT it should not include the Content-Type header.
I've wrote a patch and drop the header in that case.

Regards, Ainyava