### PR TITLE
Add django-pyoidc as a third party authentication library

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -454,6 +454,12 @@ There are currently two forks of this project.
 
 More information can be found in the [Documentation](https://django-rest-durin.readthedocs.io/en/latest/index.html).
 
+## django-pyoidc
+
+[dango-pyoidc][django_pyoidc] adds support for OpenID Connect (OIDC) authentication. This allows you to delegate user management to an Identity Provider, which can be used to implement Single-Sign-On (SSO). It provides support for most uses-cases, such as customizing how token info are mapped to user models, using OIDC audiences for access control, etc.
+
+More information can be found in the [Documentation](https://django-pyoidc.readthedocs.io/latest/index.html).
+
 [cite]: https://jacobian.org/writing/rest-worst-practices/
 [http401]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
 [http403]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
@@ -491,3 +497,4 @@ More information can be found in the [Documentation](https://django-rest-durin.r
 [django-rest-authemail]: https://github.com/celiao/django-rest-authemail
 [django-rest-durin]: https://github.com/eshaan7/django-rest-durin
 [login-required-middleware]: https://docs.djangoproject.com/en/stable/ref/middleware/#django.contrib.auth.middleware.LoginRequiredMiddleware
+[django-pyoidc] : https://github.com/makinacorpus/django_pyoidc

--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -62,6 +62,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [drf-oidc-auth][drf-oidc-auth] - Implements OpenID Connect token authentication for DRF.
 * [drfpasswordless][drfpasswordless] - Adds (Medium, Square Cash inspired) passwordless logins and signups via email and mobile numbers.
 * [django-rest-authemail][django-rest-authemail] - Provides a RESTful API for user signup and authentication using email addresses.
+* [dango-pyoidc][django-pyoidc] adds support for OpenID Connect (OIDC) authentication.
 
 ### Permissions
 
@@ -256,3 +257,4 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [drf-api-action]: https://github.com/Ori-Roza/drf-api-action
 [drf-redesign]: https://github.com/youzarsiph/drf-redesign
 [drf-material]: https://github.com/youzarsiph/drf-material
+[django-pyoidc] : https://github.com/makinacorpus/django_pyoidc


### PR DESCRIPTION
Hello there ! 👋

After a few years of work we just released a library that implements OpenID Connect (OIDC) authentication for Django and django-rest-framework. There are others libraries that implements OIDC for django/drf, but we were not satisfied with their implementation (read more [here](https://django-pyoidc.readthedocs.io/latest/explanation.html)).

Would you mind adding a link to this library in drf documentation ?