### PR TITLE
Update GitHub Actions to use Ubuntu 22.04 for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -50,7 +50,7 @@ jobs:
 
   test-docs:
     name: Test documentation links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
## Description

According to this(https://github.com/actions/runner-images/issues/11101), the Ubuntu 20.04 runner environment will be deprecated on 2025-04-15. Now that the ubuntu 24.04 runner environment is officially released, update the images used in CI.

<img width="1371" alt="image" src="https://github.com/user-attachments/assets/28e63799-8ca3-418f-87d7-f09caefcdf87" />
