### PR TITLE
Cleanup dependencies and conditions for unsupported Python versions

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -1,5 +1,4 @@
 import contextlib
-import sys
 from collections.abc import Mapping, MutableMapping
 
 from django.utils.encoding import force_str
@@ -29,21 +28,20 @@ class ReturnDict(dict):
         # but preserve the raw data.
         return (dict, (dict(self),))
 
-    if sys.version_info >= (3, 9):
-        # These are basically copied from OrderedDict, with `serializer` added.
-        def __or__(self, other):
-            if not isinstance(other, dict):
-                return NotImplemented
-            new = self.__class__(self, serializer=self.serializer)
-            new.update(other)
-            return new
+    # These are basically copied from OrderedDict, with `serializer` added.
+    def __or__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        new = self.__class__(self, serializer=self.serializer)
+        new.update(other)
+        return new
 
-        def __ror__(self, other):
-            if not isinstance(other, dict):
-                return NotImplemented
-            new = self.__class__(other, serializer=self.serializer)
-            new.update(self)
-            return new
+    def __ror__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        new = self.__class__(other, serializer=self.serializer)
+        new.update(self)
+        return new
 
 
 class ReturnList(list):

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     author_email='tom@tomchristie.com',  # SEE NOTE BELOW (*)
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=["django>=4.2", 'backports.zoneinfo;python_version<"3.9"'],
+    install_requires=["django>=4.2"],
     python_requires=">=3.9",
     zip_safe=False,
     classifiers=[

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -8,6 +8,7 @@ import warnings
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
 from enum import auto
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -29,11 +30,6 @@ from rest_framework.fields import (
     is_simple_callable
 )
 from tests.models import UUIDForeignKeyTarget
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-else:
-    from backports.zoneinfo import ZoneInfo
 
 utc = datetime.timezone.utc
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,6 @@ import datetime
 import math
 import os
 import re
-import sys
 import uuid
 import warnings
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
@@ -637,10 +636,6 @@ class Test5087Regression:
 
 
 class TestTyping(TestCase):
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_field_is_subscriptable(self):
         assert serializers.Field is serializers.Field["foo"]
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 from django.db import models
 from django.http import Http404
@@ -703,23 +701,11 @@ class TestSerializer(TestCase):
 
 
 class TestTyping(TestCase):
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_genericview_is_subscriptable(self):
         assert generics.GenericAPIView is generics.GenericAPIView["foo"]
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_listview_is_subscriptable(self):
         assert generics.ListAPIView is generics.ListAPIView["foo"]
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_instanceview_is_subscriptable(self):
         assert generics.RetrieveAPIView is generics.RetrieveAPIView["foo"]

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -9,7 +9,6 @@ import datetime
 import decimal
 import json  # noqa
 import re
-import sys
 import tempfile
 
 import pytest
@@ -397,10 +396,6 @@ class TestDurationFieldMapping(TestCase):
                 fields = '__all__'
 
         expected = dedent("""
-            TestSerializer():
-                id = IntegerField(label='ID', read_only=True)
-                duration_field = DurationField(max_value=datetime.timedelta(3), min_value=datetime.timedelta(1))
-        """) if sys.version_info < (3, 7) else dedent("""
             TestSerializer():
                 id = IntegerField(label='ID', read_only=True)
                 duration_field = DurationField(max_value=datetime.timedelta(days=3), min_value=datetime.timedelta(days=1))

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3,7 +3,6 @@ Tests for content parsing, and form-overloaded content parsing.
 """
 import copy
 import os.path
-import sys
 import tempfile
 
 import pytest
@@ -375,9 +374,5 @@ class TestDeepcopy(TestCase):
 
 
 class TestTyping(TestCase):
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_request_is_subscriptable(self):
         assert Request is Request["foo"]

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,6 +1,3 @@
-import sys
-
-import pytest
 from django.test import TestCase, override_settings
 from django.urls import include, path, re_path
 
@@ -289,9 +286,5 @@ class Issue807Tests(TestCase):
 
 
 class TestTyping(TestCase):
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_response_is_subscriptable(self):
         assert Response is Response["foo"]

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,7 +1,6 @@
 import inspect
 import pickle
 import re
-import sys
 from collections import ChainMap
 from collections.abc import Mapping
 
@@ -205,10 +204,6 @@ class TestSerializer:
                 exceptions.ErrorDetail(string='Raised error', code='invalid')
             ]}
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_serializer_is_subscriptable(self):
         assert serializers.Serializer is serializers.Serializer["foo"]
 
@@ -743,10 +738,6 @@ class TestDeclaredFieldInheritance:
 
 
 class Test8301Regression:
-    @pytest.mark.skipif(
-        sys.version_info < (3, 9),
-        reason="dictionary union operator requires Python 3.9 or higher",
-    )
     def test_ReturnDict_merging(self):
         # Serializer.data returns ReturnDict, this is essentially a test for that.
 

--- a/tests/test_serializer_lists.py
+++ b/tests/test_serializer_lists.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 from django.http import QueryDict
 from django.utils.datastructures import MultiValueDict
@@ -60,10 +58,6 @@ class TestListSerializer:
         assert serializer.is_valid()
         assert serializer.validated_data == expected_output
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="subscriptable classes requires Python 3.7 or higher",
-    )
     def test_list_serializer_is_subscriptable(self):
         assert serializers.ListSerializer is serializers.ListSerializer["foo"]
 


### PR DESCRIPTION
*Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Remove optional dependency `backports.zoneinfo` and conditions for unsupported Python versions that were recently dropped. We support Python 3.9 and above so anything for Python <3.9 can go.