### PR TITLE
speed up matching of filter fields by using a set

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -67,6 +67,11 @@ using the `APIView` class-based views.
 
 Or, if you're using the `@api_view` decorator with function based views.
 
+    from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+    from rest_framework.decorators import api_view, authentication_classes, permission_classes
+    from rest_framework.permissions import IsAuthenticated
+    from rest_framework.response import Response
+
     @api_view(['GET'])
     @authentication_classes([SessionAuthentication, BasicAuthentication])
     @permission_classes([IsAuthenticated])

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -311,7 +311,7 @@ class OrderingFilter(BaseFilterBackend):
         return valid_fields
 
     def remove_invalid_fields(self, queryset, fields, view, request):
-        valid_fields = [item[0] for item in self.get_valid_fields(queryset, view, {'request': request})]
+        valid_fields = {item[0] for item in self.get_valid_fields(queryset, view, {'request': request})}
 
         def term_valid(term):
             if term.startswith("-"):


### PR DESCRIPTION
A set uses *O(1)* average lookup time, so we first get all sorting fields (takes *O(n)*), but then we can do the matching in *O(n)*, whereas now it is worst-case *O(n^2)*.