### PR TITLE
abstract away allowed actions and methods, and use a set for faster membership checks

### DIFF
--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -11,7 +11,7 @@ from rest_framework.settings import api_settings
 
 from .generators import BaseSchemaGenerator
 from .inspectors import ViewInspector
-from .utils import get_pk_description, is_list_view
+from .utils import get_pk_description, is_list_view, ALLOW_FILTER_ACTIONS, ALLOW_FILTER_METHODS
 
 
 def common_path(paths):
@@ -522,9 +522,9 @@ class AutoSchema(ViewInspector):
             return False
 
         if hasattr(self.view, 'action'):
-            return self.view.action in ["list", "retrieve", "update", "partial_update", "destroy"]
+            return self.view.action in ALLOW_FILTER_ACTIONS
 
-        return method.lower() in ["get", "put", "patch", "delete"]
+        return method.lower() in ALLOW_FILTER_METHODS
 
     def get_filter_fields(self, path, method):
         if not self._allows_filters(path, method):

--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -11,7 +11,10 @@ from rest_framework.settings import api_settings
 
 from .generators import BaseSchemaGenerator
 from .inspectors import ViewInspector
-from .utils import get_pk_description, is_list_view, ALLOW_FILTER_ACTIONS, ALLOW_FILTER_METHODS
+from .utils import (
+    ALLOW_FILTER_ACTIONS, ALLOW_FILTER_METHODS, get_pk_description,
+    is_list_view
+)
 
 
 def common_path(paths):

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -18,7 +18,10 @@ from rest_framework.settings import api_settings
 
 from .generators import BaseSchemaGenerator
 from .inspectors import ViewInspector
-from .utils import get_pk_description, is_list_view, ALLOW_FILTER_ACTIONS, ALLOW_FILTER_METHODS
+from .utils import (
+    ALLOW_FILTER_ACTIONS, ALLOW_FILTER_METHODS, get_pk_description,
+    is_list_view
+)
 
 
 class SchemaGenerator(BaseSchemaGenerator):

--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -18,7 +18,7 @@ from rest_framework.settings import api_settings
 
 from .generators import BaseSchemaGenerator
 from .inspectors import ViewInspector
-from .utils import get_pk_description, is_list_view
+from .utils import get_pk_description, is_list_view, ALLOW_FILTER_ACTIONS, ALLOW_FILTER_METHODS
 
 
 class SchemaGenerator(BaseSchemaGenerator):
@@ -320,8 +320,8 @@ class AutoSchema(ViewInspector):
         if getattr(self.view, 'filter_backends', None) is None:
             return False
         if hasattr(self.view, 'action'):
-            return self.view.action in ["list", "retrieve", "update", "partial_update", "destroy"]
-        return method.lower() in ["get", "put", "patch", "delete"]
+            return self.view.action in ALLOW_FILTER_ACTIONS
+        return method.lower() in ALLOW_FILTER_METHODS
 
     def get_pagination_parameters(self, path, method):
         view = self.view

--- a/rest_framework/schemas/utils.py
+++ b/rest_framework/schemas/utils.py
@@ -40,5 +40,6 @@ def get_pk_description(model, model_field):
         name=model._meta.verbose_name,
     )
 
+
 ALLOW_FILTER_ACTIONS = {"list", "retrieve", "update", "partial_update", "destroy"}
 ALLOW_FILTER_METHODS = {"get", "put", "patch", "delete"}

--- a/rest_framework/schemas/utils.py
+++ b/rest_framework/schemas/utils.py
@@ -39,3 +39,6 @@ def get_pk_description(model, model_field):
         value_type=value_type,
         name=model._meta.verbose_name,
     )
+
+ALLOW_FILTER_ACTIONS = {"list", "retrieve", "update", "partial_update", "destroy"}
+ALLOW_FILTER_METHODS = {"get", "put", "patch", "delete"}


### PR DESCRIPTION
Prevent writing the same set of allowed actions/methods twice, and use a set to do membership checks in *O(1)* over *O(n)*.