### PR TITLE
Limit creation of new issues and clarify bug report process

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug report
+    url: https://github.com/encode/django-rest-framework/compare
+    about: To report a bug, please open a pull request with a failing test reproducing the problem.
+  - name: New features
+    url: https://www.django-rest-framework.org/community/contributing/
+    about: |
+      At this point in its lifespan, we consider Django REST framework to be feature-complete. 
+      We focus on pull requests that track the continued development of Django versions, and 
+      generally do not accept new features or code formatting changes.

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -30,6 +30,7 @@ The [Django code of conduct][code-of-conduct] gives a fuller set of guidelines f
 
 * Django REST framework is considered feature-complete. Please do not file requests to change behavior, unless it is required for security reasons or to maintain compatibility with upcoming Django or Python versions.
 * Feature requests will typically be closed with a recommendation that they be implemented outside the core REST framework library (e.g. as third-party libraries).  This approach allows us to keep down the maintenance overhead of REST framework, so that the focus can be on continued stability and great documentation.
+* To report a bug, open a pull request with a failing test. Apart from the above categories, we mainly focus on fixing regression bugs: things that used to work but recently stopped working. Anything else will be treated as a feature request.
 
 # Development
 


### PR DESCRIPTION
## Description

As follow up from https://github.com/encode/django-rest-framework/pull/9660, limit new issue creation and clarify process for reporting bugs.

This is [how it looks](https://github.com/browniebroke/read-only-gh-issues-demo/issues/new/choose): 

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/8a0d5837-6524-40a5-83ac-962d0a8c5061" />
