### PR TITLE
Fix test with Django 5 when pytz is available

### DIFF
--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -5,4 +5,4 @@ pytest-django>=4.5.2,<5.0
 importlib-metadata<5.0
 # temporary pin of attrs
 attrs==22.1.0
-pytz
+pytz  # Remove when dropping support for Django<5.0

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -5,3 +5,4 @@ pytest-django>=4.5.2,<5.0
 importlib-metadata<5.0
 # temporary pin of attrs
 attrs==22.1.0
+pytz

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -10,11 +10,7 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import pytest
-
-try:
-    import pytz
-except ImportError:
-    pytz = None
+import pytz
 
 import django
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -1642,16 +1638,15 @@ class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     }
     outputs = {}
 
-    if pytz:
-        class MockTimezone(pytz.BaseTzInfo):
-            @staticmethod
-            def localize(value, is_dst):
-                raise pytz.InvalidTimeError()
+    class MockTimezone(pytz.BaseTzInfo):
+        @staticmethod
+        def localize(value, is_dst):
+            raise pytz.InvalidTimeError()
 
-            def __str__(self):
-                return 'America/New_York'
+        def __str__(self):
+            return 'America/New_York'
 
-        field = serializers.DateTimeField(default_timezone=MockTimezone())
+    field = serializers.DateTimeField(default_timezone=MockTimezone())
 
 
 @patch('rest_framework.utils.timezone.datetime_ambiguous', return_value=True)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1625,7 +1625,6 @@ class TestCustomTimezoneForDateTimeField(TestCase):
         assert rendered_date == rendered_date_in_timezone
 
 
-@pytest.mark.skipif(condition=pytz is None, reason="pytz is not available.")
 @pytest.mark.skipif(
     condition=django.VERSION >= (5,),
     reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.",

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1625,8 +1625,10 @@ class TestCustomTimezoneForDateTimeField(TestCase):
         assert rendered_date == rendered_date_in_timezone
 
 
-@pytest.mark.skipif(pytz is None or django.VERSION >= (5,),
-                    reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.")
+@pytest.mark.skipif(
+    condition=django.VERSION >= (5,), 
+    reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.",
+)
 class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     """
     Invalid values for `DateTimeField` with datetime in DST shift (non-existing or ambiguous) and timezone with DST.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1626,7 +1626,7 @@ class TestCustomTimezoneForDateTimeField(TestCase):
 
 
 @pytest.mark.skipif(pytz is None or django.VERSION >= (5,),
-    reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.")
+                    reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.")
 class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     """
     Invalid values for `DateTimeField` with datetime in DST shift (non-existing or ambiguous) and timezone with DST.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1626,7 +1626,7 @@ class TestCustomTimezoneForDateTimeField(TestCase):
 
 
 @pytest.mark.skipif(
-    condition=django.VERSION >= (5,), 
+    condition=django.VERSION >= (5,),
     reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.",
 )
 class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,10 +9,9 @@ from enum import auto
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
+import django
 import pytest
 import pytz
-
-import django
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import IntegerChoices, TextChoices
 from django.http import QueryDict

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     pytz = None
 
+import django
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import IntegerChoices, TextChoices
 from django.http import QueryDict
@@ -1624,7 +1625,8 @@ class TestCustomTimezoneForDateTimeField(TestCase):
         assert rendered_date == rendered_date_in_timezone
 
 
-@pytest.mark.skipif(pytz is None, reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.")
+@pytest.mark.skipif(pytz is None or django.VERSION >= (5,),
+    reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.")
 class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
     """
     Invalid values for `DateTimeField` with datetime in DST shift (non-existing or ambiguous) and timezone with DST.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1625,6 +1625,7 @@ class TestCustomTimezoneForDateTimeField(TestCase):
         assert rendered_date == rendered_date_in_timezone
 
 
+@pytest.mark.skipif(condition=pytz is None, reason="pytz is not available.")
 @pytest.mark.skipif(
     condition=django.VERSION >= (5,),
     reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.",

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ setenv =
        PYTHONWARNINGS=once
 deps =
         django42: Django>=4.2,<5.0
-        django42: pytz
         django50: Django>=5.0,<5.1
         django51: Django>=5.1,<5.2
         django52: Django>=5.2,<6.0

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ setenv =
        PYTHONWARNINGS=once
 deps =
         django42: Django>=4.2,<5.0
+        django42: pytz
         django50: Django>=5.0,<5.1
         django51: Django>=5.1,<5.2
         django52: Django>=5.2,<6.0


### PR DESCRIPTION
When running tests against Django 5.2, I am getting the following test failure when pytz is available on the machine. When I remove it, the issue is gone.

```pytb
_______________________ TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField.test_invalid_inputs _______________________
test_fields.py:682: in test_invalid_inputs
    self.field.run_validation(input_value)
../../build/prototype/sparc/usr/lib/python3.13/vendor-packages/rest_framework/fields.py:538: in run_validation
    value = self.to_internal_value(data)
../../build/prototype/sparc/usr/lib/python3.13/vendor-packages/rest_framework/fields.py:1190: in to_internal_value
    return self.enforce_timezone(parsed)
../../build/prototype/sparc/usr/lib/python3.13/vendor-packages/rest_framework/fields.py:1168: in enforce_timezone
    raise e
../../build/prototype/sparc/usr/lib/python3.13/vendor-packages/rest_framework/fields.py:1162: in enforce_timezone
    if not valid_datetime(dt):
../../build/prototype/sparc/usr/lib/python3.13/vendor-packages/rest_framework/utils/timezone.py:23: in valid_datetime
    if isinstance(dt.tzinfo, tzinfo) and not datetime_ambiguous(dt):
../../build/prototype/sparc/usr/lib/python3.13/vendor-packages/rest_framework/utils/timezone.py:16: in datetime_ambiguous
    return datetime_exists(dt) and (
../../build/prototype/sparc/usr/lib/python3.13/vendor-packages/rest_framework/utils/timezone.py:9: in datetime_exists
    return dt.astimezone(timezone.utc) == dt
E   NotImplementedError: a tzinfo subclass must implement utcoffset()
```

As such, I propose to modify the skip check as follows - after this change, the test passes.