### PR TITLE
Add Apitally to third party packages documentation

### DIFF
--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -158,6 +158,7 @@ To submit new content, [create a pull request][drf-create-pr].
 * [django-requestlogs] - Providing middleware and other helpers for audit logging for REST framework.
 * [drf-standardized-errors][drf-standardized-errors] - DRF exception handler to standardize error responses for all API endpoints.
 * [drf-api-action][drf-api-action] - uses the power of DRF also as a library functions
+* [apitally] - A simple API monitoring, analytics, and request logging tool using middleware. For DRF-specific setup guide, [click here](https://docs.apitally.io/frameworks/django-rest-framework).
 
 ### Customization
 
@@ -260,4 +261,5 @@ To submit new content, [create a pull request][drf-create-pr].
 [drf-redesign]: https://github.com/youzarsiph/drf-redesign
 [drf-material]: https://github.com/youzarsiph/drf-material
 [django-pyoidc]: https://github.com/makinacorpus/django_pyoidc
+[apitally]: https://github.com/apitally/apitally-py
 [drf-shapeless-serializers]: https://github.com/khaledsukkar2/drf-shapeless-serializers


### PR DESCRIPTION
Add [Apitally](https://github.com/apitally/apitally-py) to the Third Party Packages page in the docs, under Misc.

Apitally is a simple, lightweight API monitoring and analytics tool for DRF that helps developers track API usage, performance, and errors with minimal setup. It also includes request logging and alerting features.

See setup guide here:
https://docs.apitally.io/frameworks/django-rest-framework