### PR TITLE
feat:The request in the dispatch function has been type annotated

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -496,7 +496,7 @@ class APIView(View):
         self.args = args
         self.kwargs = kwargs
         request = self.initialize_request(request, *args, **kwargs)
-        self.request = request
+        self.request: Request = request
         self.headers = self.default_response_headers  # deprecate?
 
         try:


### PR DESCRIPTION
## Description

This pull request adds an explicit type annotation to `self.request` within the `dispatch` method.  
By assigning `self.request: Request = request`, it helps IDEs like PyCharm correctly infer the type of `self.request`, improving type checking and code navigation.

There are no functional changes, only a minor internal improvement for developer experience.

No related issue.
