### PR TITLE
Add note to tutorial about required request in serializer context when using `HyperlinkedModelSerializer`

### DIFF
--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -109,6 +109,7 @@ You must write:
 If your view is a subclass of `GenericAPIView`, you may use the `get_serializer_context()` as a convenience method.
 
 ---
+
 ## Making sure our URL patterns are named
 
 If we're going to have a hyperlinked API, we need to make sure we name our URL patterns.  Let's take a look at which URL patterns we need to name.


### PR DESCRIPTION
This PR updates the Tutorial 5 Relationships & Hyperlinked APIs documentation to include an important note:

**When using HyperlinkedModelSerializer inside manually instantiated serializers in views (e.g., SnippetDetail), you must pass context={'request': request} to ensure URL fields resolve correctly.**

Without this context, developers following the tutorial as written will encounter errors like:

> HyperlinkedIdentityField requires the request in the serializer context. Add context={'request': request} when instantiating the serializer.

Motivation:

This omission frequently confuses beginners and is a common source of errors. Including this note will:
- Reduce friction for new users
- Prevent unnecessary troubleshooting

Fix #9729 