### PR TITLE
Add MaxFileSizeValidator and MinFileSizeValidator for file size constraints

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -170,6 +170,74 @@ If you want the date field to be entirely hidden from the user, then use `Hidden
 
 ---
 
+## MaxFileSizeValidator and MinFileSizeValidator
+
+These validators can be used to enforce file size constraints on uploaded files. They are especially useful for `FileField` and `ImageField` in serializers.
+
+### MaxFileSizeValidator
+
+Ensures that the uploaded file does not exceed a maximum size (in bytes).
+
+**Parameters:**
+
+* `max_size` (*required*) — The maximum file size in bytes.
+* `message` — Custom error message. May use `{max_size}` in the string.
+* `code` — Custom error code. Default is `'max_file_size'`.
+
+### MinFileSizeValidator
+
+Ensures that the uploaded file meets a minimum size (in bytes).
+
+**Parameters:**
+
+* `min_size` (*required*) — The minimum file size in bytes.
+* `message` — Custom error message. May use `{min_size}` in the string.
+* `code` — Custom error code. Default is `'min_file_size'`.
+
+### Usage Examples
+
+#### Basic usage with FileField
+
+    from rest_framework import serializers
+    from rest_framework.validators import MaxFileSizeValidator, MinFileSizeValidator
+
+    class FileUploadSerializer(serializers.Serializer):
+        file = serializers.FileField(validators=[
+            MaxFileSizeValidator(1024 * 1024),  # 1MB max
+            MinFileSizeValidator(1024),         # 1KB min
+        ])
+
+#### Usage with ImageField
+
+    class ImageUploadSerializer(serializers.Serializer):
+        image = serializers.ImageField(validators=[
+            MaxFileSizeValidator(5 * 1024 * 1024),  # 5MB max
+            MinFileSizeValidator(1024),             # 1KB min
+        ])
+
+#### Custom error messages and codes
+
+    class CustomFileSerializer(serializers.Serializer):
+        file = serializers.FileField(validators=[
+            MaxFileSizeValidator(
+                max_size=1024 * 1024,
+                message="File size cannot exceed {max_size} bytes",
+                code='file_too_large'
+            ),
+            MinFileSizeValidator(
+                min_size=1024,
+                message="File must be at least {min_size} bytes",
+                code='file_too_small'
+            ),
+        ])
+
+### Error Codes
+
+* `max_file_size` — Default error code for MaxFileSizeValidator
+* `min_file_size` — Default error code for MinFileSizeValidator
+
+---
+
 # Advanced field defaults
 
 Validators that are applied across multiple fields in the serializer can sometimes require a field input that should not be provided by the API client, but that *is* available as input to the validator.

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,7 +8,6 @@ from django import VERSION as django_version
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import DataError, models
 from django.test import TestCase
-from PIL import Image
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -1186,6 +1185,11 @@ class TestFileSizeValidatorIntegration(TestCase):
         assert 'min_file_size' in serializer.errors['file'][0].code
 
     def test_imagefield_max_size(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("PIL not available")
+
         class ImageSerializer(serializers.Serializer):
             image = serializers.ImageField(validators=[MaxFileSizeValidator(1024)])
 
@@ -1207,6 +1211,11 @@ class TestFileSizeValidatorIntegration(TestCase):
         assert 'max_file_size' in serializer.errors['image'][0].code
 
     def test_imagefield_min_size(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("PIL not available")
+
         class ImageSerializer(serializers.Serializer):
             image = serializers.ImageField(validators=[MinFileSizeValidator(100)])
 


### PR DESCRIPTION
# Add file size validators for FileField and ImageField

Adds two new validators to enforce file size constraints on uploaded files:

## Background

In many of our DRF and Django projects, we work extensively with FileField and ImageField and need to validate file sizes. I've been creating these validators locally, and other developers have been implementing similar solutions. I thought it would be beneficial to create a standardized class that can be added to DRF and used across our projects.

## New Validators

- **MaxFileSizeValidator**: Ensures files don't exceed a maximum size (in bytes)
- **MinFileSizeValidator**: Ensures files meet a minimum size (in bytes)

## Features

- Customizable error messages and codes
- Deconstructible for migrations
- Works with FileField and ImageField
- Gracefully handles objects without .size attribute

## Usage

```python
from rest_framework.validators import MaxFileSizeValidator, MinFileSizeValidator

class FileUploadSerializer(serializers.Serializer):
    file = serializers.FileField(validators=[
        MaxFileSizeValidator(1024 * 1024),  # 1MB max
        MinFileSizeValidator(1024),         # 1KB min
    ])
```

## Implementation

- Added to `rest_framework/validators.py`
- 77 new tests covering unit and integration scenarios
- Documentation added to `docs/api-guide/validators.md`
- All existing tests pass (1577 total)

## Error Codes

- `max_file_size` - Default for MaxFileSizeValidator
- `min_file_size` - Default for MinFileSizeValidator