### PR TITLE
Fix mutable default arguments in OrderingFilter methods

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -249,7 +249,9 @@ class OrderingFilter(BaseFilterBackend):
             return (ordering,)
         return ordering
 
-    def get_default_valid_fields(self, queryset, view, context={}):
+    def get_default_valid_fields(self, queryset, view, context=None):
+        if context is None:
+            context = {}
         # If `ordering_fields` is not specified, then we determine a default
         # based on the serializer class, if one exists on the view.
         if hasattr(view, 'get_serializer_class'):
@@ -286,7 +288,9 @@ class OrderingFilter(BaseFilterBackend):
             )
         ]
 
-    def get_valid_fields(self, queryset, view, context={}):
+    def get_valid_fields(self, queryset, view, context=None):
+        if context is None:
+            context = {}
         valid_fields = getattr(view, 'ordering_fields', self.ordering_fields)
 
         if valid_fields is None:


### PR DESCRIPTION
- Fixed get_default_valid_fields() and get_valid_fields() methods in filters.py
- Changed context={} default parameter to context=None to prevent mutable default anti-pattern
- Added proper None checking with context = {} assignment inside methods

Why this fix is important:
- Mutable default arguments (context={}) create shared state across function calls
- Same dict object gets reused, potentially causing unexpected side effects
- This is a well-known Python anti-pattern that can lead to bugs

What was changed:
- Line 249: get_default_valid_fields(self, queryset, view, context=None)
- Line 285: get_valid_fields(self, queryset, view, context=None)
- Added 'if context is None: context = {}' in both methods

Testing results:
- All existing filter tests pass (pytest tests/test_filters.py)
- Custom verification script confirms fix works correctly
- Maintains backward compatibility
- No breaking changes to API

Addresses GitHub issue #9741

https://github.com/encode/django-rest-framework/issues/9741

*Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
