### PR TITLE
Fix validation for `UniqueConstraint` with distinct condition fields

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -222,6 +222,28 @@ For example:
             extra_kwargs = {'client': {'required': False}}
             validators = []  # Remove a default "unique together" constraint.
 
+### UniqueConstraint with conditions
+
+When using Django's `UniqueConstraint` with conditions that reference other model fields, DRF will automatically use
+`UniqueTogetherValidator` instead of field-level `UniqueValidator`. This ensures proper validation behavior when the constraint
+effectively involves multiple fields.
+
+For example, a single-field constraint with a condition becomes a multi-field validation when the condition references other fields.
+
+    class MyModel(models.Model):
+        name = models.CharField(max_length=100)
+        status = models.CharField(max_length=20)
+
+        class Meta:
+            constraints = [
+                models.UniqueConstraint(
+                    fields=['name'],
+                    condition=models.Q(status='active'),
+                    name='unique_active_name'
+                )
+            ]
+
+
 ## Updating nested serializers
 
 When applying an update to an existing instance, uniqueness validators will

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1443,12 +1443,22 @@ class ModelSerializer(Serializer):
             for unique_together in parent_class._meta.unique_together:
                 yield unique_together, model._default_manager, [], None
             for constraint in parent_class._meta.constraints:
-                if isinstance(constraint, models.UniqueConstraint) and len(constraint.fields) > 1:
+                if isinstance(constraint, models.UniqueConstraint):
                     if constraint.condition is None:
                         condition_fields = []
                     else:
-                        condition_fields = list(get_referenced_base_fields_from_q(constraint.condition))
-                    yield (constraint.fields, model._default_manager, condition_fields, constraint.condition)
+                        condition_fields = list(
+                            get_referenced_base_fields_from_q(constraint.condition)
+                        )
+
+                    required_fields = {*constraint.fields, *condition_fields}
+                    if len(required_fields) > 1:
+                        yield (
+                            constraint.fields,
+                            model._default_manager,
+                            condition_fields,
+                            constraint.condition,
+                        )
 
     def get_uniqueness_extra_kwargs(self, field_names, declared_fields, extra_kwargs):
         """

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1451,6 +1451,8 @@ class ModelSerializer(Serializer):
                             get_referenced_base_fields_from_q(constraint.condition)
                         )
 
+                    # Combine constraint fields and condition fields. If the union
+                    # involves multiple fields, treat as unique-together validation
                     required_fields = {*constraint.fields, *condition_fields}
                     if len(required_fields) > 1:
                         yield (

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -86,6 +86,8 @@ def get_unique_validators(field_name, model_field):
             if condition is not None
             else set()
         )
+        # Only use UniqueValidator if the union of field and condition fields is 1
+        # (i.e. no additional fields referenced in conditions)
         if len(field_set | condition_fields) == 1:
             yield UniqueValidator(
                 queryset=queryset if condition is None else queryset.filter(condition),

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -8,7 +8,9 @@ from django.core import validators
 from django.db import models
 from django.utils.text import capfirst
 
-from rest_framework.compat import postgres_fields
+from rest_framework.compat import (
+    get_referenced_base_fields_from_q, postgres_fields
+)
 from rest_framework.validators import UniqueValidator
 
 NUMERIC_FIELD_TYPES = (
@@ -79,10 +81,16 @@ def get_unique_validators(field_name, model_field):
     unique_error_message = get_unique_error_message(model_field)
     queryset = model_field.model._default_manager
     for condition in conditions:
-        yield UniqueValidator(
-            queryset=queryset if condition is None else queryset.filter(condition),
-            message=unique_error_message
+        condition_fields = (
+            get_referenced_base_fields_from_q(condition)
+            if condition is not None
+            else set()
         )
+        if len(field_set | condition_fields) == 1:
+            yield UniqueValidator(
+                queryset=queryset if condition is None else queryset.filter(condition),
+                message=unique_error_message,
+            )
 
 
 def get_field_kwargs(field_name, model_field):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -834,11 +834,11 @@ class TestUniqueConstraintValidation(TestCase):
         validators = serializer.fields['global_id'].validators
         assert len(validators) == 1 + extra_validators_qty
         assert validators[0].queryset == UniqueConstraintModel.objects
+        ids_in_qs = {frozenset(v.queryset.values_list('id', flat=True)) for v in validators if hasattr(v, "queryset")}
+        assert ids_in_qs == {frozenset({1, 2, 3})}
 
         validators = serializer.fields['fancy_conditions'].validators
-        assert len(validators) == 2 + extra_validators_qty
-        ids_in_qs = {frozenset(v.queryset.values_list('id', flat=True)) for v in validators if hasattr(v, "queryset")}
-        assert ids_in_qs == {frozenset([1]), frozenset([3])}
+        assert len(validators) == extra_validators_qty
 
     def test_nullable_unique_constraint_fields_are_not_required(self):
         serializer = UniqueConstraintNullableSerializer(data={'title': 'Bob'})

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -278,7 +278,7 @@ class TestUniquenessTogetherValidation(TestCase):
     def test_is_unique_together_condition_based(self):
         """
         In a condition-based unique together validation, data is valid when
-        the constrained field differs when the condition applies`.
+        the constrained field differs when the condition applies.
         """
         ConditionUniquenessTogetherModel.objects.create(race_name='example', position=1)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -248,7 +248,7 @@ class TestUniquenessTogetherValidation(TestCase):
 
     def test_is_not_unique_together_condition_based(self):
         """
-        Failing unique together validation should result in non field errors when a condition-based
+        Failing unique together validation should result in non-field errors when a condition-based
         unique together constraint is violated.
         """
         ConditionUniquenessTogetherModel.objects.create(race_name='example', position=1)
@@ -275,10 +275,10 @@ class TestUniquenessTogetherValidation(TestCase):
             'position': 2
         }
 
-    def test_unique_together_condition_based(self):
+    def test_is_unique_together_condition_based(self):
         """
-        In a unique together validation, one field may be non-unique
-        so long as the set as a whole is unique.
+        In a condition-based unique together validation, data is valid when
+        the constrained field differs when the condition applies`.
         """
         ConditionUniquenessTogetherModel.objects.create(race_name='example', position=1)
 
@@ -288,6 +288,21 @@ class TestUniquenessTogetherValidation(TestCase):
         assert serializer.validated_data == {
             'race_name': 'other',
             'position': 1
+        }
+
+    def test_is_unique_together_when_condition_does_not_apply(self):
+        """
+        In a condition-based unique together validation, data is valid when
+        the condition does not apply, even if constrained fields match existing records.
+        """
+        ConditionUniquenessTogetherModel.objects.create(race_name='example', position=1)
+
+        data = {'race_name': 'example', 'position': 2}
+        serializer = ConditionUniquenessTogetherSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == {
+            'race_name': 'example',
+            'position': 2
         }
 
     def test_updated_instance_excluded_from_unique_together(self):
@@ -308,10 +323,10 @@ class TestUniquenessTogetherValidation(TestCase):
         When performing an update, the existing instance does not count
         as a match against uniqueness.
         """
-        ConditionUniquenessTogetherModel.objects.create(race_name='example', position=1)
+        instance = ConditionUniquenessTogetherModel.objects.create(race_name='example', position=1)
 
         data = {'race_name': 'example', 'position': 0}
-        serializer = ConditionUniquenessTogetherSerializer(self.instance, data=data)
+        serializer = ConditionUniquenessTogetherSerializer(instance, data=data)
         assert serializer.is_valid()
         assert serializer.validated_data == {
             'race_name': 'example',


### PR DESCRIPTION
## Description

Resolves: [#9707](https://github.com/encode/django-rest-framework/issues/9707).

-  Apply unique together constraint validation to unique constraint with a single constraint field **if** there are other fields used in the constraint conditions