### PR TITLE
Prepare 3.16.1 release

### DIFF
--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -40,7 +40,7 @@ You can determine your currently installed version using `pip show`:
 
 ### 3.16.1
 
-**Date**: TBC
+**Date**: 7th July 2025
 
 This release is considered a bugfix release.
 

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -38,6 +38,68 @@ You can determine your currently installed version using `pip show`:
 
 ## 3.16.x series
 
+### 3.16.1
+
+**Date**: TBC
+
+This release is considered a bugfix release.
+
+#### Minor changes
+
+* Cleanup optional `backports.zoneinfo` dependency and conditions on unsupported Python 3.8 and lower in [#9681](https://github.com/encode/django-rest-framework/pull/9681). Python versions prior to 3.9 were already unsupported so this shouldn't be a breaking change.
+
+#### Bug fixes
+
+* Fix `UniqueTogetherValidator` to handle fields w/ `source` attr in [#9688](https://github.com/encode/django-rest-framework/pull/9688)
+* Drop HTML line breaks on long headers in browsable API in [#9438](https://github.com/encode/django-rest-framework/pull/9438)
+* Fix regression in `unique_together` validation with `SerializerMethodField` in [#9712](https://github.com/encode/django-rest-framework/pull/9712)
+
+#### Translations
+
+* Add Kazakh locale support in [#9713](https://github.com/encode/django-rest-framework/pull/9713)
+* Update translations for Korean translations in [#9571](https://github.com/encode/django-rest-framework/pull/9571)
+* Update German translations in [#9676](https://github.com/encode/django-rest-framework/pull/9676)
+* Update Chinese translations in [#9675](https://github.com/encode/django-rest-framework/pull/9675)
+* Update Arabic translations-sal in [#9595](https://github.com/encode/django-rest-framework/pull/9595)
+* Update Persian translations in [#9576](https://github.com/encode/django-rest-framework/pull/9576)
+* Update Spanish translations in [#9701](https://github.com/encode/django-rest-framework/pull/9701)
+* Update Turkish Translations in [#9749](https://github.com/encode/django-rest-framework/pull/9749)
+* Fix some typos in Brazilian Portuguese translations in [#9673](https://github.com/encode/django-rest-framework/pull/9673)
+
+#### Documentation
+
+* Removed reference to GitHub Issues and Discussions in [#9660](https://github.com/encode/django-rest-framework/pull/9660)
+* Add `drf-restwind` and update outdated images in `browsable-api.md` in [#9680](https://github.com/encode/django-rest-framework/pull/9680)
+* Updated funding page to represent current scope in [#9686](https://github.com/encode/django-rest-framework/pull/9686)
+* Fix broken Heroku JSON Schema link in [#9693](https://github.com/encode/django-rest-framework/pull/9693)
+* Update Django documentation links to use stable version in [#9698](https://github.com/encode/django-rest-framework/pull/9698)
+* Expand docs on unique constraints cause 'required=True' in [#9725](https://github.com/encode/django-rest-framework/pull/9725)
+* Revert extension back from `djangorestframework-guardian2` to `djangorestframework-guardian` in [#9734](https://github.com/encode/django-rest-framework/pull/9734)
+* Add note to tutorial about required `request` in serializer context when using `HyperlinkedModelSerializer` in [#9732](https://github.com/encode/django-rest-framework/pull/9732)
+
+#### Internal changes
+
+* Update GitHub Actions to use Ubuntu 24.04 for testing in [#9677](https://github.com/encode/django-rest-framework/pull/9677)
+* Update test matrix to use Django 5.2 stable version in [#9679](https://github.com/encode/django-rest-framework/pull/9679)
+* Add `pyupgrade` to `pre-commit` hooks in [#9682](https://github.com/encode/django-rest-framework/pull/9682)
+* Fix test with Django 5 when `pytz` is available in [#9715](https://github.com/encode/django-rest-framework/pull/9715)
+
+#### New Contributors
+* [`@araggohnxd`](https://github.com/araggohnxd) made their first contribution in [#9673](https://github.com/encode/django-rest-framework/pull/9673)
+* [`@mbeijen`](https://github.com/mbeijen) made their first contribution in [#9660](https://github.com/encode/django-rest-framework/pull/9660)
+* [`@stefan6419846`](https://github.com/stefan6419846) made their first contribution in [#9676](https://github.com/encode/django-rest-framework/pull/9676)
+* [`@ren000thomas`](https://github.com/ren000thomas) made their first contribution in [#9675](https://github.com/encode/django-rest-framework/pull/9675)
+* [`@ulgens`](https://github.com/ulgens) made their first contribution in [#9682](https://github.com/encode/django-rest-framework/pull/9682)
+* [`@bukh-sal`](https://github.com/bukh-sal) made their first contribution in [#9595](https://github.com/encode/django-rest-framework/pull/9595)
+* [`@rezatn0934`](https://github.com/rezatn0934) made their first contribution in [#9576](https://github.com/encode/django-rest-framework/pull/9576)
+* [`@Rohit10jr`](https://github.com/Rohit10jr) made their first contribution in [#9693](https://github.com/encode/django-rest-framework/pull/9693)
+* [`@kushibayev`](https://github.com/kushibayev) made their first contribution in [#9713](https://github.com/encode/django-rest-framework/pull/9713)
+* [`@alihassancods`](https://github.com/alihassancods) made their first contribution in [#9732](https://github.com/encode/django-rest-framework/pull/9732)
+* [`@kulikjak`](https://github.com/kulikjak) made their first contribution in [#9715](https://github.com/encode/django-rest-framework/pull/9715)
+* [`@Natgho`](https://github.com/Natgho) made their first contribution in [#9749](https://github.com/encode/django-rest-framework/pull/9749)
+
+**Full Changelog**: https://github.com/encode/django-rest-framework/compare/3.16.0...3.16.1
+
 ### 3.16.0
 
 **Date**: 28th March 2025

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -85,6 +85,7 @@ This release fixes a few bugs, clean-up some old code paths for unsupported Pyth
 * Fix test with Django 5 when `pytz` is available in [#9715](https://github.com/encode/django-rest-framework/pull/9715)
 
 #### New Contributors
+
 * [`@araggohnxd`](https://github.com/araggohnxd) made their first contribution in [#9673](https://github.com/encode/django-rest-framework/pull/9673)
 * [`@mbeijen`](https://github.com/mbeijen) made their first contribution in [#9660](https://github.com/encode/django-rest-framework/pull/9660)
 * [`@stefan6419846`](https://github.com/stefan6419846) made their first contribution in [#9676](https://github.com/encode/django-rest-framework/pull/9676)

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -106,14 +106,14 @@ This release is considered a bugfix release.
 
 This release is considered a significant release to improve upstream support with Django and Python. Some of these may change the behaviour of existing features and pre-existing behaviour. Specifically, some fixes were added to around the support of `UniqueConstraint` with nullable fields which will improve built-in serializer validation.
 
-## Features
+#### Features
 
 * Add official support for Django 5.1 and its new `LoginRequiredMiddleware` in [#9514](https://github.com/encode/django-rest-framework/pull/9514) and [#9657](https://github.com/encode/django-rest-framework/pull/9657)
 * Add official Django 5.2a1 support in [#9634](https://github.com/encode/django-rest-framework/pull/9634)
 * Add support for Python 3.13 in [#9527](https://github.com/encode/django-rest-framework/pull/9527) and [#9556](https://github.com/encode/django-rest-framework/pull/9556)
 * Support Django 2.1+ test client JSON data automatically serialized in [#6511](https://github.com/encode/django-rest-framework/pull/6511) and fix a regression in [#9615](https://github.com/encode/django-rest-framework/pull/9615)
 
-## Bug fixes
+#### Bug fixes
 
 * Fix unique together validator to respect condition's fields from `UniqueConstraint` in [#9360](https://github.com/encode/django-rest-framework/pull/9360)
 * Fix raising on nullable fields part of `UniqueConstraint` in [#9531](https://github.com/encode/django-rest-framework/pull/9531)
@@ -124,19 +124,19 @@ This release is considered a significant release to improve upstream support wit
 * Fix noisy warning and accept integers as min/max values of `DecimalField` in [#9515](https://github.com/encode/django-rest-framework/pull/9515)
 * Fix usages of `open()` in `setup.py` in [#9661](https://github.com/encode/django-rest-framework/pull/9661)
 
-## Translations
+#### Translations
 
 * Add some missing Chinese translations in [#9505](https://github.com/encode/django-rest-framework/pull/9505)
 * Fix spelling mistakes in Farsi language were corrected in [#9521](https://github.com/encode/django-rest-framework/pull/9521)
 * Fixing and adding missing Brazilian Portuguese translations in [#9535](https://github.com/encode/django-rest-framework/pull/9535)
 
-## Removals
+#### Removals
 
 * Remove support for Python 3.8 in [#9670](https://github.com/encode/django-rest-framework/pull/9670)
 * Remove long deprecated code from request wrapper in [#9441](https://github.com/encode/django-rest-framework/pull/9441)
 * Remove deprecated `AutoSchema._get_reference` method in [#9525](https://github.com/encode/django-rest-framework/pull/9525)
 
-## Documentation and internal changes
+#### Documentation and internal changes
 
 * Provide tests for hashing of `OperandHolder` in [#9437](https://github.com/encode/django-rest-framework/pull/9437)
 * Update documentation: Add `adrf` third party package in [#9198](https://github.com/encode/django-rest-framework/pull/9198)
@@ -156,7 +156,7 @@ This release is considered a significant release to improve upstream support wit
 * Fix a number of typos in the test suite in the docs in [#9662](https://github.com/encode/django-rest-framework/pull/9662)
 * Add `django-pyoidc` as a third party authentication library in [#9667](https://github.com/encode/django-rest-framework/pull/9667)
 
-## New Contributors
+#### New Contributors
 
 * [`@maerteijn`](https://github.com/maerteijn) made their first contribution in [#9198](https://github.com/encode/django-rest-framework/pull/9198)
 * [`@FraCata00`](https://github.com/FraCata00) made their first contribution in [#9444](https://github.com/encode/django-rest-framework/pull/9444)

--- a/docs/community/release-notes.md
+++ b/docs/community/release-notes.md
@@ -40,9 +40,9 @@ You can determine your currently installed version using `pip show`:
 
 ### 3.16.1
 
-**Date**: 7th July 2025
+**Date**: 6th July 2025
 
-This release is considered a bugfix release.
+This release fixes a few bugs, clean-up some old code paths for unsupported Python versions and improve translations.
 
 #### Minor changes
 
@@ -50,9 +50,9 @@ This release is considered a bugfix release.
 
 #### Bug fixes
 
-* Fix `UniqueTogetherValidator` to handle fields w/ `source` attr in [#9688](https://github.com/encode/django-rest-framework/pull/9688)
-* Drop HTML line breaks on long headers in browsable API in [#9438](https://github.com/encode/django-rest-framework/pull/9438)
 * Fix regression in `unique_together` validation with `SerializerMethodField` in [#9712](https://github.com/encode/django-rest-framework/pull/9712)
+* Fix `UniqueTogetherValidator` to handle fields with `source` attribute in [#9688](https://github.com/encode/django-rest-framework/pull/9688)
+* Drop HTML line breaks on long headers in browsable API in [#9438](https://github.com/encode/django-rest-framework/pull/9438)
 
 #### Translations
 

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '3.16.0'
+__version__ = '3.16.1'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 3-Clause'
 __copyright__ = 'Copyright 2011-2023 Encode OSS Ltd'


### PR DESCRIPTION
## Description

As discussed in https://github.com/encode/django-rest-framework/discussions/9748

Checklist:

- [x] Create pull request for [release notes](https://github.com/encode/django-rest-framework/blob/master/docs/topics/release-notes.md)
- [ ] [N/A] Update supported versions:
    - [ ] `setup.py` `python_requires` list
    - [ ] `setup.py` Python & Django version trove classifiers
    - [ ] `README` Python & Django versions
    - [ ] `docs` Python & Django versions
- [x] Update the translations
- [x] Ensure the pull request increments the version to `3.16.1` in [`restframework/__init__.py`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/__init__.py).
- [x] Ensure documentation validates
    - Build and serve docs `mkdocs serve`
    - Validate links `pylinkvalidate.py -P http://127.0.0.1:8000`
- [x] Confirm that release is finalized and ready to go.
- [x] Ensure that release date is included in pull request.
- [ ] Merge the release pull request.
- [ ] Push the package to PyPI with `./setup.py publish`.
- [ ] Tag the release, with `git tag -a 3.16.1 -m 'version 3.16.1'; git push --tags`.
- [ ] Create the release in GitHub
- [ ] Deploy the documentation with `mkdocs gh-deploy`.
- [ ] Make a release announcement on Mastodon.
- [ ] [N/A] Close the milestone on GitHub
