### PR TITLE
Automate docs deployment

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,0 +1,29 @@
+name: mkdocs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - docs/**
+      - docs_theme/**
+      - requirements/requirements-documentation.txt
+      - mkdocs.yml
+      - .github/workflows/mkdocs-deploy.yml
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: github-pages
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: git fetch --no-tags --prune --depth=1 origin gh-pages
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install -r requirements/requirements-documentation.txt
+      - run: mkdocs gh-deploy


### PR DESCRIPTION
## Description

Automatcially deployes the docs to GH pages each time a push to master changes the content of the docs, theme, config or dependencies.

Repo with a minimal setup https://github.com/browniebroke/poc-mkdocks-gh-deploy-gh-actions 

Deployed https://browniebroke.github.io/poc-mkdocks-gh-deploy-gh-actions/ 

Right now, maintainers have to remember to run `mkdocs gh-deploy` manually.

