### PR TITLE
Refactor token generation to use secrets module

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -1,5 +1,4 @@
-import binascii
-import os
+import secrets
 
 from django.conf import settings
 from django.db import models
@@ -34,7 +33,7 @@ class Token(models.Model):
 
     @classmethod
     def generate_key(cls):
-        return binascii.hexlify(os.urandom(20)).decode()
+        return secrets.token_hex(20)
 
     def __str__(self):
         return self.key


### PR DESCRIPTION
## Summary

Replace `binascii.hexlify(os.urandom(20)).decode()` with `secrets.token_hex(20)` in `Token.generate_key()` method.

## Rationale

The `secrets` module is the recommended approach for cryptographic token generation in Python 3.6+. This change maintains the same 40-character hex output format and passes all existing tests.

## Changes

- Updated imports: `binascii`, `os` → `secrets`
- Simplified token generation logic
- No breaking changes or test modifications required