### PR TITLE
Condition of UniqueTogetherValidator can be read-only

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -189,7 +189,12 @@ class UniqueTogetherValidator:
             ]
 
         condition_sources = (serializer.fields[field_name].source for field_name in self.condition_fields)
-        condition_kwargs = {source: attrs[source] for source in condition_sources}
+        condition_kwargs = {
+            source: attrs[source]
+            if source in attrs
+            else getattr(serializer.instance, source)
+            for source in condition_sources
+        }
         if checked_values and None not in checked_values and qs_exists_with_condition(queryset, self.condition, condition_kwargs):
             field_names = ', '.join(self.fields)
             message = self.message.format(field_names=field_names)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -753,22 +753,30 @@ class TestUniqueConstraintValidation(TestCase):
         )
         assert serializer.is_valid()
 
-    def test_uniq_constraint_condition_read_only(self):
+    def test_uniq_constraint_condition_read_only_create(self):
         class UniqueConstraintReadOnlyFieldModelSerializer(serializers.ModelSerializer):
             class Meta:
                 model = UniqueConstraintReadOnlyFieldModel
                 read_only_fields = ("state",)
                 fields = ("position", "something", *read_only_fields)
-
         serializer = UniqueConstraintReadOnlyFieldModelSerializer(
             data={"position": 1, "something": 1}
         )
         assert serializer.is_valid()
-        UniqueConstraintReadOnlyFieldModel.objects.create(position=1, something=1)
+
+    def test_uniq_constraint_condition_read_only_partial(self):
+        class UniqueConstraintReadOnlyFieldModelSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = UniqueConstraintReadOnlyFieldModel
+                read_only_fields = ("state",)
+                fields = ("position", "something", *read_only_fields)
+        instance = UniqueConstraintReadOnlyFieldModel.objects.create(position=1, something=1)
         serializer = UniqueConstraintReadOnlyFieldModelSerializer(
-            data={"position": 1, "something": 1}
+            instance=instance,
+            data={"position": 1, "something": 1},
+            partial=True
         )
-        assert not serializer.is_valid()
+        assert serializer.is_valid()
 
 
 # Tests for `UniqueForDateValidator`


### PR DESCRIPTION
## Description
We can't always expect to find the value of the unique condition in the serializer if the field is read-only.

The proposed solution is to fallback on instance's value.