### PR TITLE
Support violation_error_code and violation_error_message from UniqueConstraint in UniqueTogetherValidator

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1427,20 +1427,33 @@ class ModelSerializer(Serializer):
 
     def get_unique_together_constraints(self, model):
         """
-        Returns iterator of (fields, queryset, condition_fields, condition),
+        Returns iterator of (fields, queryset, condition_fields, condition, message, code),
         each entry describes an unique together constraint on `fields` in `queryset`
-        with respect of constraint's `condition`.
+        with respect of constraint's `condition`, optional custom `violation_error_message` and `violation_error_code`.
         """
         for parent_class in [model] + list(model._meta.parents):
             for unique_together in parent_class._meta.unique_together:
-                yield unique_together, model._default_manager, [], None
+                yield unique_together, model._default_manager, [], None, None, None
             for constraint in parent_class._meta.constraints:
                 if isinstance(constraint, models.UniqueConstraint) and len(constraint.fields) > 1:
                     if constraint.condition is None:
                         condition_fields = []
                     else:
                         condition_fields = list(get_referenced_base_fields_from_q(constraint.condition))
-                    yield (constraint.fields, model._default_manager, condition_fields, constraint.condition)
+
+                    violation_error_message = constraint.get_violation_error_message()
+                    default_error_message = constraint.default_violation_error_message % {"name": constraint.name}
+                    if violation_error_message == default_error_message:
+                        violation_error_message = None
+
+                    yield (
+                        constraint.fields,
+                        model._default_manager,
+                        condition_fields,
+                        constraint.condition,
+                        violation_error_message,
+                        getattr(constraint, "violation_error_code", None)
+                    )
 
     def get_uniqueness_extra_kwargs(self, field_names, declared_fields, extra_kwargs):
         """
@@ -1473,7 +1486,7 @@ class ModelSerializer(Serializer):
 
         # Include each of the `unique_together` and `UniqueConstraint` field names,
         # so long as all the field names are included on the serializer.
-        for unique_together_list, queryset, condition_fields, condition in self.get_unique_together_constraints(model):
+        for unique_together_list, queryset, condition_fields, condition, *__ in self.get_unique_together_constraints(model):
             unique_together_list_and_condition_fields = set(unique_together_list) | set(condition_fields)
             if model_fields_names.issuperset(unique_together_list_and_condition_fields):
                 unique_constraint_names |= unique_together_list_and_condition_fields
@@ -1598,7 +1611,7 @@ class ModelSerializer(Serializer):
         # Note that we make sure to check `unique_together` both on the
         # base model class, but also on any parent classes.
         validators = []
-        for unique_together, queryset, condition_fields, condition in self.get_unique_together_constraints(self.Meta.model):
+        for unique_together, queryset, condition_fields, condition, message, code in self.get_unique_together_constraints(self.Meta.model):
             # Skip if serializer does not map to all unique together sources
             unique_together_and_condition_fields = set(unique_together) | set(condition_fields)
             if not set(source_map).issuperset(unique_together_and_condition_fields):
@@ -1626,6 +1639,8 @@ class ModelSerializer(Serializer):
                 fields=field_names,
                 condition_fields=tuple(source_map[f][0] for f in condition_fields),
                 condition=condition,
+                message=message,
+                code=code,
             )
             validators.append(validator)
         return validators

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -111,13 +111,15 @@ class UniqueTogetherValidator:
     message = _('The fields {field_names} must make a unique set.')
     missing_message = _('This field is required.')
     requires_context = True
+    code = 'unique'
 
-    def __init__(self, queryset, fields, message=None, condition_fields=None, condition=None):
+    def __init__(self, queryset, fields, message=None, condition_fields=None, condition=None, code=None):
         self.queryset = queryset
         self.fields = fields
         self.message = message or self.message
         self.condition_fields = [] if condition_fields is None else condition_fields
         self.condition = condition
+        self.code = code or self.code
 
     def enforce_required_fields(self, attrs, serializer):
         """
@@ -198,7 +200,7 @@ class UniqueTogetherValidator:
         if checked_values and None not in checked_values and qs_exists_with_condition(queryset, self.condition, condition_kwargs):
             field_names = ', '.join(self.fields)
             message = self.message.format(field_names=field_names)
-            raise ValidationError(message, code='unique')
+            raise ValidationError(message, code=self.code)
 
     def __repr__(self):
         return '<{}({})>'.format(
@@ -217,6 +219,7 @@ class UniqueTogetherValidator:
                 and self.missing_message == other.missing_message
                 and self.queryset == other.queryset
                 and self.fields == other.fields
+                and self.code == other.code
                 )
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -616,6 +616,32 @@ class UniqueConstraintNullableModel(models.Model):
         ]
 
 
+class UniqueConstraintCustomMessageCodeModel(models.Model):
+    username = models.CharField(max_length=32)
+    company_id = models.IntegerField()
+    role = models.CharField(max_length=32)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=("username", "company_id"),
+                name="unique_username_company_custom_msg",
+                violation_error_message="Username must be unique within a company.",
+                violation_error_code="duplicate_username",
+            )
+            if django_version[0] >= 5
+            else models.UniqueConstraint(
+                fields=("username", "company_id"),
+                name="unique_username_company_custom_msg",
+                violation_error_message="Username must be unique within a company.",
+            ),
+            models.UniqueConstraint(
+                fields=("company_id", "role"),
+                name="unique_company_role_default_msg",
+            ),
+        ]
+
+
 class UniqueConstraintSerializer(serializers.ModelSerializer):
     class Meta:
         model = UniqueConstraintModel
@@ -626,6 +652,12 @@ class UniqueConstraintNullableSerializer(serializers.ModelSerializer):
     class Meta:
         model = UniqueConstraintNullableModel
         fields = ('title', 'age', 'tag')
+
+
+class UniqueConstraintCustomMessageCodeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = UniqueConstraintCustomMessageCodeModel
+        fields = ('username', 'company_id', 'role')
 
 
 class TestUniqueConstraintValidation(TestCase):
@@ -777,6 +809,31 @@ class TestUniqueConstraintValidation(TestCase):
             partial=True
         )
         assert serializer.is_valid()
+
+    def test_unique_constraint_custom_message_code(self):
+        UniqueConstraintCustomMessageCodeModel.objects.create(username="Alice", company_id=1, role="member")
+        expected_code = "duplicate_username" if django_version[0] >= 5 else UniqueTogetherValidator.code
+
+        serializer = UniqueConstraintCustomMessageCodeSerializer(data={
+            "username": "Alice",
+            "company_id": 1,
+            "role": "admin",
+        })
+        assert not serializer.is_valid()
+        assert serializer.errors == {"non_field_errors": ["Username must be unique within a company."]}
+        assert serializer.errors["non_field_errors"][0].code == expected_code
+
+    def test_unique_constraint_default_message_code(self):
+        UniqueConstraintCustomMessageCodeModel.objects.create(username="Alice", company_id=1, role="member")
+        serializer = UniqueConstraintCustomMessageCodeSerializer(data={
+            "username": "John",
+            "company_id": 1,
+            "role": "member",
+        })
+        expected_message = UniqueTogetherValidator.message.format(field_names=', '.join(("company_id", "role")))
+        assert not serializer.is_valid()
+        assert serializer.errors == {"non_field_errors": [expected_message]}
+        assert serializer.errors["non_field_errors"][0].code == UniqueTogetherValidator.code
 
 
 # Tests for `UniqueForDateValidator`


### PR DESCRIPTION
Added support for retrieving custom **violation_error_code** (_for django 5+_) and **violation_error_message** from Django model-level **UniqueConstraint** definitions and passing them to **UniqueTogetherValidator**.

refs #9714 and #9352

The update ensures that:
•	If **violation_error_message** or **violation_error_code** are explicitly defined on the model constraint, they are forwarded to the corresponding validator.
•	If the constraint uses the default message/code, they are not passed, allowing the validator to use its own defaults.

Additionally, tests have been added to cover both scenarios:
•	When a custom error message/code is used.
•	When defaults are applied.

_Note:_ The current structure of `get_unique_together_constraints()` may benefit from refactoring (e.g., returning a named structure for clarity and extensibility). This is outside the scope of this PR, but I may explore it in a future contribution.

