### PR TITLE
Add django-lisan to third-party packages

### DIFF
--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -153,6 +153,7 @@ To submit new content, [create a pull request][drf-create-pr].
 * [drf-viewset-profiler][drf-viewset-profiler] - Lib to profile all methods from a viewset line by line.
 * [djangorestframework-features][djangorestframework-features] - Advanced schema generation and more based on named features.
 * [django-elasticsearch-dsl-drf][django-elasticsearch-dsl-drf] - Integrate Elasticsearch DSL with Django REST framework. Package provides views, serializers, filter backends, pagination and other handy add-ons.
+* [django-lisan](https://github.com/Nabute/django-lisan) - A lightweight translation and localization framework for Django REST Framework APIs. PyPI: [django-lisan](https://pypi.org/project/lisan)
 * [django-api-client][django-api-client] - DRF client that groups the Endpoint response, for use in CBVs and FBV as if you were working with Django's Native Models..
 * [fast-drf] - A model based library for making API development faster and easier.
 * [django-requestlogs] - Providing middleware and other helpers for audit logging for REST framework.


### PR DESCRIPTION
This PR adds [django-lisan](https://github.com/Nabute/django-lisan) to the Django REST Framework third-party packages page.

**Description**
A lightweight translation and localization utility for Django REST Framework APIs. It helps serve API responses in multiple languages with minimal configuration.

**Links**
- GitHub: https://github.com/Nabute/django-lisan
- PyPI: https://pypi.org/project/lisan

**Compatibility**
- Python: 3.9+
- Django: 3.2, 4.2, 5.0
- DRF: 3.14+

**Notes**
- Added to the "Misc" section in alphabetical order.
- Follows existing Markdown style for package entries.
