### PR TITLE
Adjust CI matrix to reflect upstream Django support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
        {py39}-{django42}
-       {py310}-{django42,django51,django52,djangomain}
-       {py311}-{django42,django51,django52,djangomain}
+       {py310}-{django42,django51,django52}
+       {py311}-{django42,django51,django52}
        {py312}-{django42,django51,django52,djangomain}
        {py313}-{django51,django52,djangomain}
        base
@@ -44,12 +44,6 @@ commands = mkdocs build
 deps =
        -rrequirements/requirements-testing.txt
        -rrequirements/requirements-documentation.txt
-
-[testenv:py310-djangomain]
-ignore_outcome = true
-
-[testenv:py311-djangomain]
-ignore_outcome = true
 
 [testenv:py312-djangomain]
 ignore_outcome = true


### PR DESCRIPTION
## Description

Looking at the [supported Python versions from the Django docs](https://docs.djangoproject.com/en/dev/faq/install/), the `main` branch (which will be the upcoming v6.0) only supports Python 3.12 and 3.13.

Our CI runs the tests against it but all the way to Python 3.10, ignoring the failures. We shouldn't even bother running tests on Python 3.10/3.11 + Django main, as we can't even install. 
