### PR TITLE
Add drf-auth-kit to Third Party Authentication Packages

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -367,6 +367,10 @@ The following example will authenticate any incoming request as the user given b
 
 The following third-party packages are also available.
 
+## DRF Auth Kit
+
+[DRF Auth Kit][drf-auth-kit] library provides a modern REST authentication solution with JWT cookies, social login, multi-factor authentication, and comprehensive user management. The package offers full type safety, automatic OpenAPI schema generation with DRF Spectacular. It supports multiple authentication types (JWT, DRF Token, or Custom) and includes built-in internationalization for 50+ languages.
+
 ## django-rest-knox
 
 [Django-rest-knox][django-rest-knox] library provides models and views to handle token-based authentication in a more secure and extensible way than the built-in TokenAuthentication scheme - with Single Page Applications and Mobile clients in mind. It provides per-client tokens, and views to generate them when provided some other authentication (usually basic authentication), to delete the token (providing a server enforced logout) and to delete all tokens (logs out all clients that a user is logged into).
@@ -498,3 +502,4 @@ More information can be found in the [Documentation](https://django-pyoidc.readt
 [django-rest-durin]: https://github.com/eshaan7/django-rest-durin
 [login-required-middleware]: https://docs.djangoproject.com/en/stable/ref/middleware/#django.contrib.auth.middleware.LoginRequiredMiddleware
 [django-pyoidc] : https://github.com/makinacorpus/django_pyoidc
+[drf-auth-kit]: https://github.com/huynguyengl99/drf-auth-kit

--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -55,6 +55,7 @@ To submit new content, [create a pull request][drf-create-pr].
 * [djangorestframework-digestauth][djangorestframework-digestauth] - Provides Digest Access Authentication support.
 * [django-oauth-toolkit][django-oauth-toolkit] - Provides OAuth 2.0 support.
 * [djangorestframework-simplejwt][djangorestframework-simplejwt] - Provides JSON Web Token Authentication support.
+* [DRF Auth Kit][drf-auth-kit] - Provides complete REST authentication with JWT cookies, social login, MFA, and user management. Features full type safety and automatic OpenAPI schema generation.
 * [hawkrest][hawkrest] - Provides Hawk HTTP Authorization.
 * [djangorestframework-httpsignature][djangorestframework-httpsignature] - Provides an easy to use HTTP Signature Authentication mechanism.
 * [djoser][djoser] - Provides a set of views to handle basic actions such as registration, login, logout, password reset and account activation.
@@ -180,6 +181,7 @@ To submit new content, [create a pull request][drf-create-pr].
 [permissions]: ../api-guide/permissions.md
 [third-party-packages]: #existing-third-party-packages
 [discussion-group]: https://groups.google.com/forum/#!forum/django-rest-framework
+[drf-auth-kit]: https://github.com/huynguyengl99/drf-auth-kit
 [djangorestframework-digestauth]: https://github.com/juanriaza/django-rest-framework-digestauth
 [django-oauth-toolkit]: https://github.com/evonove/django-oauth-toolkit
 [djangorestframework-jwt]: https://github.com/GetBlimp/django-rest-framework-jwt


### PR DESCRIPTION
This pull request adds [drf-auth-kit](https://github.com/huynguyengl99/drf-auth-kit) to Third Party Packages, under Authentication.

[drf-auth-kit](https://github.com/huynguyengl99/drf-auth-kit) supports and is tested with Python 3.10+, Django 5.0+, and Django REST Framework 3.0+.

[drf-auth-kit](https://github.com/huynguyengl99/drf-auth-kit) can be found on [PyPi](https://pypi.org/project/drf-auth-kit/).

[drf-auth-kit](https://github.com/huynguyengl99/drf-auth-kit) can be found on the [Django REST Framework grid](https://djangopackages.org/grids/g/django-rest-framework/) on Django Packages, and on its [package page](https://djangopackages.org/packages/p/drf-auth-kit/).