### PR TITLE
Remove outdated reference to `AllowPUTAsCreateMixin` in the documentation

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -374,8 +374,6 @@ Allowing `PUT` as create operations is problematic, as it necessarily exposes in
 
 Both styles "`PUT` as 404" and "`PUT` as create" can be valid in different circumstances, but from version 3.0 onwards we now use 404 behavior as the default, due to it being simpler and more obvious.
 
-If you need to generic PUT-as-create behavior you may want to include something like [this `AllowPUTAsCreateMixin` class](https://gist.github.com/tomchristie/a2ace4577eff2c603b1b) as a mixin to your views.
-
 ---
 
 # Third party packages


### PR DESCRIPTION
### Description
Remove outdated reference to the `AllowPUTAsCreateMixin` class in the documentation (`docs/api-guide/generic-views.md`).  

The linked Gist [here](https://gist.github.com/tomchristie/a2ace4577eff2c603b1b) currently returns a 404 and is no longer available.  

Since PUT-as-create is no longer the default behavior in DRF (as of version 3.0), the reference to AllowPUTAsCreateMixin is outdated and potentially confusing. Removing it makes the documentation clearer.