### PR TITLE
Validation many to many

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -81,6 +81,23 @@ To run the tests, clone the repository, and then:
     # Run the tests
     ./runtests.py
 
+---
+
+**Note:**  
+If your tests require access to the database, do not forget to inherit from `django.test.TestCase`.  
+For example:
+
+    from django.test import TestCase
+
+    class MyDatabaseTest(TestCase):
+        def test_something(self):
+            # Your test code here
+            pass
+
+You can reuse existing models defined in `tests/models.py` for your tests.
+
+---
+
 ### Test options
 
 Run using a more concise output style.
@@ -98,6 +115,10 @@ Run the tests for a given test method.
 Shorter form to run the tests for a given test method.
 
     ./runtests.py test_this_method
+
+**Note:** If you do not want the output to be captured (for example, to see print statements directly), you can use the `-s` flag:
+
+    ./runtests.py -s
 
 Note: The test case and test method matching is fuzzy and will sometimes run other tests that contain a partial string match to the given  command line input.
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1090,6 +1090,14 @@ class ModelSerializer(Serializer):
         # Determine the fields that should be included on the serializer.
         fields = {}
 
+        # If it's a ManyToMany field, and the default is None, then raises an exception to prevent exceptions on .set()
+        for field_name in declared_fields.keys():
+            if field_name in info.relations and info.relations[field_name].to_many and declared_fields[field_name].default is None:
+                raise ValueError(
+                    f"The field '{field_name}' on serializer '{self.__class__.__name__}' is a ManyToMany field and cannot have a default value of None. "
+                    "Please set an appropriate default value, such as an empty list, or remove the default."
+                )
+
         for field_name in field_names:
             # If the field is explicitly declared on the class then use that.
             if field_name in declared_fields:


### PR DESCRIPTION
*Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Hi!
First of all, thank you for the library, it's very useful for my work!

While working on a project, I got a 500 error in production due to a configuration error on my part (copy-paste 🤦‍♂️): when using a `PrimaryKeySerializer` on a _ManyToMany_ field and setting `default=None` like this:

```python
class ManyToManyTarget(RESTFrameworkModel):
    name = models.CharField(max_length=100)


class ManyToManySource(RESTFrameworkModel):
    name = models.CharField(max_length=100)
    targets = models.ManyToManyField(ManyToManyTarget, related_name='sources')


class ManyToManySourceSerializer(serializers.ModelSerializer):
    targets = serializers.PrimaryKeyRelatedField(
        many=True,
        queryset=ManyToManyTarget.objects.all(),
        default=None  # <---- This
    )
```

It crashes at runtime with the following exception when no value is provided for `targets` field:

```
my_file.py:XXX: in some_func
    instance = serializer.save()
rest_framework\serializers.py:210: in save
    self.instance = self.create(validated_data)
rest_framework\serializers.py:1017: in create
    field.set(value)
venv\lib\site-packages\django\db\models\fields\related_descriptors.py:1328: in set
    objs = tuple(objs)
```

Now it seems simple and intuitive, but in production, with thousands of lines, dozens of serializers, and hundreds of fields, it took me a long time to figure out what the problem was.
To prevent errors in production, I added a new validation in the `get_fields()` method with a super descriptive message indicating a solution.
I couldn't find an earlier place to perform the validation, but this change allows the validation to run for other methods such as `create()` or `update()`. If you have a better place where the code block could be moved, please let me know and I'll fix it without any problems.

Finally, since this is my first time collaborating on the project, I added some help to the _contributing.md_ file to explain a few things, such as the `-s` parameter in pytests, which allows you to obtain the output during testing, or `django.test.TestCase` inheritance so you can use the Django DB. If you think it shouldn't be there, or you don't like the format, let me know and I can make the changes.

Thanks and best regards!
