### PR TITLE
Add syntax highlighting to code examples in tutorial

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -16,14 +16,18 @@ The tutorial is fairly in-depth, so you should probably get a cookie and a cup o
 
 Before we do anything else we'll create a new virtual environment, using [venv]. This will make sure our package configuration is kept nicely isolated from any other projects we're working on.
 
-    python3 -m venv env
-    source env/bin/activate
+```bash
+python3 -m venv env
+source env/bin/activate
+```
 
 Now that we're inside a virtual environment, we can install our package requirements.
 
-    pip install django
-    pip install djangorestframework
-    pip install pygments  # We'll be using this for the code highlighting
+```bash
+pip install django
+pip install djangorestframework
+pip install pygments  # We'll be using this for the code highlighting
+```
 
 **Note:** To exit the virtual environment at any time, just type `deactivate`.  For more information see the [venv documentation][venv].
 
@@ -32,21 +36,27 @@ Now that we're inside a virtual environment, we can install our package requirem
 Okay, we're ready to get coding.
 To get started, let's create a new project to work with.
 
-    cd ~
-    django-admin startproject tutorial
-    cd tutorial
+```bash
+cd ~
+django-admin startproject tutorial
+cd tutorial
+```
 
 Once that's done we can create an app that we'll use to create a simple Web API.
 
-    python manage.py startapp snippets
+```bash
+python manage.py startapp snippets
+```
 
 We'll need to add our new `snippets` app and the `rest_framework` app to `INSTALLED_APPS`. Let's edit the `tutorial/settings.py` file:
 
-    INSTALLED_APPS = [
-        ...
-        'rest_framework',
-        'snippets',
-    ]
+```text
+INSTALLED_APPS = [
+    ...
+    'rest_framework',
+    'snippets',
+]
+```
 
 Okay, we're ready to roll.
 
@@ -54,64 +64,72 @@ Okay, we're ready to roll.
 
 For the purposes of this tutorial we're going to start by creating a simple `Snippet` model that is used to store code snippets.  Go ahead and edit the `snippets/models.py` file.  Note: Good programming practices include comments.  Although you will find them in our repository version of this tutorial code, we have omitted them here to focus on the code itself.
 
-    from django.db import models
-    from pygments.lexers import get_all_lexers
-    from pygments.styles import get_all_styles
+```python
+from django.db import models
+from pygments.lexers import get_all_lexers
+from pygments.styles import get_all_styles
 
-    LEXERS = [item for item in get_all_lexers() if item[1]]
-    LANGUAGE_CHOICES = sorted([(item[1][0], item[0]) for item in LEXERS])
-    STYLE_CHOICES = sorted([(item, item) for item in get_all_styles()])
+LEXERS = [item for item in get_all_lexers() if item[1]]
+LANGUAGE_CHOICES = sorted([(item[1][0], item[0]) for item in LEXERS])
+STYLE_CHOICES = sorted([(item, item) for item in get_all_styles()])
 
 
-    class Snippet(models.Model):
-        created = models.DateTimeField(auto_now_add=True)
-        title = models.CharField(max_length=100, blank=True, default='')
-        code = models.TextField()
-        linenos = models.BooleanField(default=False)
-        language = models.CharField(choices=LANGUAGE_CHOICES, default='python', max_length=100)
-        style = models.CharField(choices=STYLE_CHOICES, default='friendly', max_length=100)
+class Snippet(models.Model):
+    created = models.DateTimeField(auto_now_add=True)
+    title = models.CharField(max_length=100, blank=True, default="")
+    code = models.TextField()
+    linenos = models.BooleanField(default=False)
+    language = models.CharField(
+        choices=LANGUAGE_CHOICES, default="python", max_length=100
+    )
+    style = models.CharField(choices=STYLE_CHOICES, default="friendly", max_length=100)
 
-        class Meta:
-            ordering = ['created']
+    class Meta:
+        ordering = ["created"]
+```
 
 We'll also need to create an initial migration for our snippet model, and sync the database for the first time.
 
-    python manage.py makemigrations snippets
-    python manage.py migrate snippets
+```bash
+python manage.py makemigrations snippets
+python manage.py migrate snippets
+```
 
 ## Creating a Serializer class
 
 The first thing we need to get started on our Web API is to provide a way of serializing and deserializing the snippet instances into representations such as `json`.  We can do this by declaring serializers that work very similar to Django's forms.  Create a file in the `snippets` directory named `serializers.py` and add the following.
 
-    from rest_framework import serializers
-    from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
+```python
+from rest_framework import serializers
+from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
 
 
-    class SnippetSerializer(serializers.Serializer):
-        id = serializers.IntegerField(read_only=True)
-        title = serializers.CharField(required=False, allow_blank=True, max_length=100)
-        code = serializers.CharField(style={'base_template': 'textarea.html'})
-        linenos = serializers.BooleanField(required=False)
-        language = serializers.ChoiceField(choices=LANGUAGE_CHOICES, default='python')
-        style = serializers.ChoiceField(choices=STYLE_CHOICES, default='friendly')
+class SnippetSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    title = serializers.CharField(required=False, allow_blank=True, max_length=100)
+    code = serializers.CharField(style={"base_template": "textarea.html"})
+    linenos = serializers.BooleanField(required=False)
+    language = serializers.ChoiceField(choices=LANGUAGE_CHOICES, default="python")
+    style = serializers.ChoiceField(choices=STYLE_CHOICES, default="friendly")
 
-        def create(self, validated_data):
-            """
-            Create and return a new `Snippet` instance, given the validated data.
-            """
-            return Snippet.objects.create(**validated_data)
+    def create(self, validated_data):
+        """
+        Create and return a new `Snippet` instance, given the validated data.
+        """
+        return Snippet.objects.create(**validated_data)
 
-        def update(self, instance, validated_data):
-            """
-            Update and return an existing `Snippet` instance, given the validated data.
-            """
-            instance.title = validated_data.get('title', instance.title)
-            instance.code = validated_data.get('code', instance.code)
-            instance.linenos = validated_data.get('linenos', instance.linenos)
-            instance.language = validated_data.get('language', instance.language)
-            instance.style = validated_data.get('style', instance.style)
-            instance.save()
-            return instance
+    def update(self, instance, validated_data):
+        """
+        Update and return an existing `Snippet` instance, given the validated data.
+        """
+        instance.title = validated_data.get("title", instance.title)
+        instance.code = validated_data.get("code", instance.code)
+        instance.linenos = validated_data.get("linenos", instance.linenos)
+        instance.language = validated_data.get("language", instance.language)
+        instance.style = validated_data.get("style", instance.style)
+        instance.save()
+        return instance
+```
 
 The first part of the serializer class defines the fields that get serialized/deserialized.  The `create()` and `update()` methods define how fully fledged instances are created or modified when calling `serializer.save()`
 
@@ -125,57 +143,71 @@ We can actually also save ourselves some time by using the `ModelSerializer` cla
 
 Before we go any further we'll familiarize ourselves with using our new Serializer class.  Let's drop into the Django shell.
 
-    python manage.py shell
+```bash
+python manage.py shell
+```
 
 Okay, once we've got a few imports out of the way, let's create a couple of code snippets to work with.
 
-    from snippets.models import Snippet
-    from snippets.serializers import SnippetSerializer
-    from rest_framework.renderers import JSONRenderer
-    from rest_framework.parsers import JSONParser
+```pycon
+>>> from snippets.models import Snippet
+>>> from snippets.serializers import SnippetSerializer
+>>> from rest_framework.renderers import JSONRenderer
+>>> from rest_framework.parsers import JSONParser
 
-    snippet = Snippet(code='foo = "bar"\n')
-    snippet.save()
+>>> snippet = Snippet(code='foo = "bar"\n')
+>>> snippet.save()
 
-    snippet = Snippet(code='print("hello, world")\n')
-    snippet.save()
+>>> snippet = Snippet(code='print("hello, world")\n')
+>>> snippet.save()
+```
 
 We've now got a few snippet instances to play with.  Let's take a look at serializing one of those instances.
 
-    serializer = SnippetSerializer(snippet)
-    serializer.data
-    # {'id': 2, 'title': '', 'code': 'print("hello, world")\n', 'linenos': False, 'language': 'python', 'style': 'friendly'}
+```pycon
+>>> serializer = SnippetSerializer(snippet)
+>>> serializer.data
+{'id': 2, 'title': '', 'code': 'print("hello, world")\n', 'linenos': False, 'language': 'python', 'style': 'friendly'}
+```
 
 At this point we've translated the model instance into Python native datatypes.  To finalize the serialization process we render the data into `json`.
 
-    content = JSONRenderer().render(serializer.data)
-    content
-    # b'{"id":2,"title":"","code":"print(\\"hello, world\\")\\n","linenos":false,"language":"python","style":"friendly"}'
+```pycon
+>>> content = JSONRenderer().render(serializer.data)
+>>> content
+b'{"id":2,"title":"","code":"print(\\"hello, world\\")\\n","linenos":false,"language":"python","style":"friendly"}'
+```
 
 Deserialization is similar.  First we parse a stream into Python native datatypes...
 
-    import io
+```pycon
+>>> import io
 
-    stream = io.BytesIO(content)
-    data = JSONParser().parse(stream)
+>>> stream = io.BytesIO(content)
+>>> data = JSONParser().parse(stream)
+```
 
 ...then we restore those native datatypes into a fully populated object instance.
 
-    serializer = SnippetSerializer(data=data)
-    serializer.is_valid()
-    # True
-    serializer.validated_data
-    # {'title': '', 'code': 'print("hello, world")', 'linenos': False, 'language': 'python', 'style': 'friendly'}
-    serializer.save()
-    # <Snippet: Snippet object>
+```pycon
+>>> serializer = SnippetSerializer(data=data)
+>>> serializer.is_valid()
+True
+>>> serializer.validated_data
+{'title': '', 'code': 'print("hello, world")', 'linenos': False, 'language': 'python', 'style': 'friendly'}
+>>> serializer.save()
+<Snippet: Snippet object>
+```
 
 Notice how similar the API is to working with forms.  The similarity should become even more apparent when we start writing views that use our serializer.
 
 We can also serialize querysets instead of model instances.  To do so we simply add a `many=True` flag to the serializer arguments.
 
-    serializer = SnippetSerializer(Snippet.objects.all(), many=True)
-    serializer.data
-    # [{'id': 1, 'title': '', 'code': 'foo = "bar"\n', 'linenos': False, 'language': 'python', 'style': 'friendly'}, {'id': 2, 'title': '', 'code': 'print("hello, world")\n', 'linenos': False, 'language': 'python', 'style': 'friendly'}, {'id': 3, 'title': '', 'code': 'print("hello, world")', 'linenos': False, 'language': 'python', 'style': 'friendly'}]
+```pycon
+>>> serializer = SnippetSerializer(Snippet.objects.all(), many=True)
+>>> serializer.data
+[{'id': 1, 'title': '', 'code': 'foo = "bar"\n', 'linenos': False, 'language': 'python', 'style': 'friendly'}, {'id': 2, 'title': '', 'code': 'print("hello, world")\n', 'linenos': False, 'language': 'python', 'style': 'friendly'}, {'id': 3, 'title': '', 'code': 'print("hello, world")', 'linenos': False, 'language': 'python', 'style': 'friendly'}]
+```
 
 ## Using ModelSerializers
 
@@ -186,23 +218,28 @@ In the same way that Django provides both `Form` classes and `ModelForm` classes
 Let's look at refactoring our serializer using the `ModelSerializer` class.
 Open the file `snippets/serializers.py` again, and replace the `SnippetSerializer` class with the following.
 
-    class SnippetSerializer(serializers.ModelSerializer):
-        class Meta:
-            model = Snippet
-            fields = ['id', 'title', 'code', 'linenos', 'language', 'style']
+```python
+class SnippetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Snippet
+        fields = ["id", "title", "code", "linenos", "language", "style"]
+```
 
 One nice property that serializers have is that you can inspect all the fields in a serializer instance, by printing its representation. Open the Django shell with `python manage.py shell`, then try the following:
 
-    from snippets.serializers import SnippetSerializer
-    serializer = SnippetSerializer()
-    print(repr(serializer))
-    # SnippetSerializer():
-    #    id = IntegerField(label='ID', read_only=True)
-    #    title = CharField(allow_blank=True, max_length=100, required=False)
-    #    code = CharField(style={'base_template': 'textarea.html'})
-    #    linenos = BooleanField(required=False)
-    #    language = ChoiceField(choices=[('Clipper', 'FoxPro'), ('Cucumber', 'Gherkin'), ('RobotFramework', 'RobotFramework'), ('abap', 'ABAP'), ('ada', 'Ada')...
-    #    style = ChoiceField(choices=[('autumn', 'autumn'), ('borland', 'borland'), ('bw', 'bw'), ('colorful', 'colorful')...
+```pycon
+>>> from snippets.serializers import SnippetSerializer
+
+>>> serializer = SnippetSerializer()
+>>> print(repr(serializer))
+SnippetSerializer():
+    id = IntegerField(label='ID', read_only=True)
+    title = CharField(allow_blank=True, max_length=100, required=False)
+    code = CharField(style={'base_template': 'textarea.html'})
+    linenos = BooleanField(required=False)
+    language = ChoiceField(choices=[('Clipper', 'FoxPro'), ('Cucumber', 'Gherkin'), ('RobotFramework', 'RobotFramework'), ('abap', 'ABAP'), ('ada', 'Ada')...
+    style = ChoiceField(choices=[('autumn', 'autumn'), ('borland', 'borland'), ('bw', 'bw'), ('colorful', 'colorful')...
+```
 
 It's important to remember that `ModelSerializer` classes don't do anything particularly magical, they are simply a shortcut for creating serializer classes:
 
@@ -216,79 +253,89 @@ For the moment we won't use any of REST framework's other features, we'll just w
 
 Edit the `snippets/views.py` file, and add the following.
 
-    from django.http import HttpResponse, JsonResponse
-    from django.views.decorators.csrf import csrf_exempt
-    from rest_framework.parsers import JSONParser
-    from snippets.models import Snippet
-    from snippets.serializers import SnippetSerializer
+```python
+from django.http import HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.parsers import JSONParser
+from snippets.models import Snippet
+from snippets.serializers import SnippetSerializer
+```
 
 The root of our API is going to be a view that supports listing all the existing snippets, or creating a new snippet.
 
-    @csrf_exempt
-    def snippet_list(request):
-        """
-        List all code snippets, or create a new snippet.
-        """
-        if request.method == 'GET':
-            snippets = Snippet.objects.all()
-            serializer = SnippetSerializer(snippets, many=True)
-            return JsonResponse(serializer.data, safe=False)
+```python
+@csrf_exempt
+def snippet_list(request):
+    """
+    List all code snippets, or create a new snippet.
+    """
+    if request.method == "GET":
+        snippets = Snippet.objects.all()
+        serializer = SnippetSerializer(snippets, many=True)
+        return JsonResponse(serializer.data, safe=False)
 
-        elif request.method == 'POST':
-            data = JSONParser().parse(request)
-            serializer = SnippetSerializer(data=data)
-            if serializer.is_valid():
-                serializer.save()
-                return JsonResponse(serializer.data, status=201)
-            return JsonResponse(serializer.errors, status=400)
+    elif request.method == "POST":
+        data = JSONParser().parse(request)
+        serializer = SnippetSerializer(data=data)
+        if serializer.is_valid():
+            serializer.save()
+            return JsonResponse(serializer.data, status=201)
+        return JsonResponse(serializer.errors, status=400)
+```
 
 Note that because we want to be able to POST to this view from clients that won't have a CSRF token we need to mark the view as `csrf_exempt`.  This isn't something that you'd normally want to do, and REST framework views actually use more sensible behavior than this, but it'll do for our purposes right now.
 
 We'll also need a view which corresponds to an individual snippet, and can be used to retrieve, update or delete the snippet.
 
-    @csrf_exempt
-    def snippet_detail(request, pk):
-        """
-        Retrieve, update or delete a code snippet.
-        """
-        try:
-            snippet = Snippet.objects.get(pk=pk)
-        except Snippet.DoesNotExist:
-            return HttpResponse(status=404)
+```python
+@csrf_exempt
+def snippet_detail(request, pk):
+    """
+    Retrieve, update or delete a code snippet.
+    """
+    try:
+        snippet = Snippet.objects.get(pk=pk)
+    except Snippet.DoesNotExist:
+        return HttpResponse(status=404)
 
-        if request.method == 'GET':
-            serializer = SnippetSerializer(snippet)
+    if request.method == "GET":
+        serializer = SnippetSerializer(snippet)
+        return JsonResponse(serializer.data)
+
+    elif request.method == "PUT":
+        data = JSONParser().parse(request)
+        serializer = SnippetSerializer(snippet, data=data)
+        if serializer.is_valid():
+            serializer.save()
             return JsonResponse(serializer.data)
+        return JsonResponse(serializer.errors, status=400)
 
-        elif request.method == 'PUT':
-            data = JSONParser().parse(request)
-            serializer = SnippetSerializer(snippet, data=data)
-            if serializer.is_valid():
-                serializer.save()
-                return JsonResponse(serializer.data)
-            return JsonResponse(serializer.errors, status=400)
-
-        elif request.method == 'DELETE':
-            snippet.delete()
-            return HttpResponse(status=204)
+    elif request.method == "DELETE":
+        snippet.delete()
+        return HttpResponse(status=204)
+```
 
 Finally we need to wire these views up.  Create the `snippets/urls.py` file:
 
-    from django.urls import path
-    from snippets import views
+```python
+from django.urls import path
+from snippets import views
 
-    urlpatterns = [
-        path('snippets/', views.snippet_list),
-        path('snippets/<int:pk>/', views.snippet_detail),
-    ]
+urlpatterns = [
+    path("snippets/", views.snippet_list),
+    path("snippets/<int:pk>/", views.snippet_detail),
+]
+```
 
 We also need to wire up the root urlconf, in the `tutorial/urls.py` file, to include our snippet app's URLs.
 
-    from django.urls import path, include
+```python
+from django.urls import path, include
 
-    urlpatterns = [
-        path('', include('snippets.urls')),
-    ]
+urlpatterns = [
+    path("", include("snippets.urls")),
+]
+```
 
 It's worth noting that there are a couple of edge cases we're not dealing with properly at the moment.  If we send malformed `json`, or if a request is made with a method that the view doesn't handle, then we'll end up with a 500 "server error" response.  Still, this'll do for now.
 
@@ -298,18 +345,22 @@ Now we can start up a sample server that serves our snippets.
 
 Quit out of the shell...
 
-    quit()
+```pycon
+>>> quit()
+```
 
 ...and start up Django's development server.
 
-    python manage.py runserver
+```bash
+python manage.py runserver
 
-    Validating models...
+Validating models...
 
-    0 errors found
-    Django version 5.0, using settings 'tutorial.settings'
-    Starting Development server at http://127.0.0.1:8000/
-    Quit the server with CONTROL-C.
+0 errors found
+Django version 5.0, using settings 'tutorial.settings'
+Starting Development server at http://127.0.0.1:8000/
+Quit the server with CONTROL-C.
+```
 
 In another terminal window, we can test the server.
 
@@ -317,47 +368,26 @@ We can test our API using [curl][curl] or [httpie][httpie]. Httpie is a user fri
 
 You can install httpie using pip:
 
-    pip install httpie
+```bash
+pip install httpie
+```
 
 Finally, we can get a list of all of the snippets:
 
-    http GET http://127.0.0.1:8000/snippets/ --unsorted
+```bash
+http GET http://127.0.0.1:8000/snippets/ --unsorted
 
-    HTTP/1.1 200 OK
-    ...
-    [
-        {
-            "id": 1,
-            "title": "",
-            "code": "foo = \"bar\"\n",
-            "linenos": false,
-            "language": "python",
-            "style": "friendly"
-        },
-        {
-            "id": 2,
-            "title": "",
-            "code": "print(\"hello, world\")\n",
-            "linenos": false,
-            "language": "python",
-            "style": "friendly"
-        },
-        {
-            "id": 3,
-            "title": "",
-            "code": "print(\"hello, world\")",
-            "linenos": false,
-            "language": "python",
-            "style": "friendly"
-        }
-    ]
-
-Or we can get a particular snippet by referencing its id:
-
-    http GET http://127.0.0.1:8000/snippets/2/ --unsorted
-
-    HTTP/1.1 200 OK
-    ...
+HTTP/1.1 200 OK
+...
+[
+    {
+        "id": 1,
+        "title": "",
+        "code": "foo = \"bar\"\n",
+        "linenos": false,
+        "language": "python",
+        "style": "friendly"
+    },
     {
         "id": 2,
         "title": "",
@@ -365,7 +395,34 @@ Or we can get a particular snippet by referencing its id:
         "linenos": false,
         "language": "python",
         "style": "friendly"
+    },
+    {
+        "id": 3,
+        "title": "",
+        "code": "print(\"hello, world\")",
+        "linenos": false,
+        "language": "python",
+        "style": "friendly"
     }
+]
+```
+
+Or we can get a particular snippet by referencing its id:
+
+```bash
+http GET http://127.0.0.1:8000/snippets/2/ --unsorted
+
+HTTP/1.1 200 OK
+...
+{
+    "id": 2,
+    "title": "",
+    "code": "print(\"hello, world\")\n",
+    "linenos": false,
+    "language": "python",
+    "style": "friendly"
+}
+```
 
 Similarly, you can have the same json displayed by visiting these URLs in a web browser.
 

--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -7,14 +7,18 @@ Let's introduce a couple of essential building blocks.
 
 REST framework introduces a `Request` object that extends the regular `HttpRequest`, and provides more flexible request parsing.  The core functionality of the `Request` object is the `request.data` attribute, which is similar to `request.POST`, but more useful for working with Web APIs.
 
-    request.POST  # Only handles form data.  Only works for 'POST' method.
-    request.data  # Handles arbitrary data.  Works for 'POST', 'PUT' and 'PATCH' methods.
+```python
+request.POST  # Only handles form data.  Only works for 'POST' method.
+request.data  # Handles arbitrary data.  Works for 'POST', 'PUT' and 'PATCH' methods.
+```
 
 ## Response objects
 
 REST framework also introduces a `Response` object, which is a type of `TemplateResponse` that takes unrendered content and uses content negotiation to determine the correct content type to return to the client.
 
-    return Response(data)  # Renders to content type as requested by the client.
+```python
+return Response(data)  # Renders to content type as requested by the client.
+```
 
 ## Status codes
 
@@ -35,58 +39,62 @@ The wrappers also provide behavior such as returning `405 Method Not Allowed` re
 
 Okay, let's go ahead and start using these new components to refactor our views slightly.
 
-    from rest_framework import status
-    from rest_framework.decorators import api_view
-    from rest_framework.response import Response
-    from snippets.models import Snippet
-    from snippets.serializers import SnippetSerializer
+```python
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from snippets.models import Snippet
+from snippets.serializers import SnippetSerializer
 
 
-    @api_view(['GET', 'POST'])
-    def snippet_list(request):
-        """
-        List all code snippets, or create a new snippet.
-        """
-        if request.method == 'GET':
-            snippets = Snippet.objects.all()
-            serializer = SnippetSerializer(snippets, many=True)
-            return Response(serializer.data)
+@api_view(["GET", "POST"])
+def snippet_list(request):
+    """
+    List all code snippets, or create a new snippet.
+    """
+    if request.method == "GET":
+        snippets = Snippet.objects.all()
+        serializer = SnippetSerializer(snippets, many=True)
+        return Response(serializer.data)
 
-        elif request.method == 'POST':
-            serializer = SnippetSerializer(data=request.data)
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    elif request.method == "POST":
+        serializer = SnippetSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+```
 
 Our instance view is an improvement over the previous example.  It's a little more concise, and the code now feels very similar to if we were working with the Forms API.  We're also using named status codes, which makes the response meanings more obvious.
 
 Here is the view for an individual snippet, in the `views.py` module.
 
-    @api_view(['GET', 'PUT', 'DELETE'])
-    def snippet_detail(request, pk):
-        """
-        Retrieve, update or delete a code snippet.
-        """
-        try:
-            snippet = Snippet.objects.get(pk=pk)
-        except Snippet.DoesNotExist:
-            return Response(status=status.HTTP_404_NOT_FOUND)
+```python
+@api_view(["GET", "PUT", "DELETE"])
+def snippet_detail(request, pk):
+    """
+    Retrieve, update or delete a code snippet.
+    """
+    try:
+        snippet = Snippet.objects.get(pk=pk)
+    except Snippet.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
 
-        if request.method == 'GET':
-            serializer = SnippetSerializer(snippet)
+    if request.method == "GET":
+        serializer = SnippetSerializer(snippet)
+        return Response(serializer.data)
+
+    elif request.method == "PUT":
+        serializer = SnippetSerializer(snippet, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
             return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        elif request.method == 'PUT':
-            serializer = SnippetSerializer(snippet, data=request.data)
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data)
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        elif request.method == 'DELETE':
-            snippet.delete()
-            return Response(status=status.HTTP_204_NO_CONTENT)
+    elif request.method == "DELETE":
+        snippet.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+```
 
 This should all feel very familiar - it is not a lot different from working with regular Django views.
 
@@ -94,28 +102,27 @@ Notice that we're no longer explicitly tying our requests or responses to a give
 
 ## Adding optional format suffixes to our URLs
 
-To take advantage of the fact that our responses are no longer hardwired to a single content type let's add support for format suffixes to our API endpoints.  Using format suffixes gives us URLs that explicitly refer to a given format, and means our API will be able to handle URLs such as [http://example.com/api/items/4.json][json-url].
+To take advantage of the fact that our responses are no longer hardwired to a single content type let's add support for format suffixes to our API endpoints.  Using format suffixes gives us URLs that explicitly refer to a given format, and means our API will be able to handle URLs such as [<http://example.com/api/items/4.json>][json-url].
 
 Start by adding a `format` keyword argument to both of the views, like so.
-
-    def snippet_list(request, format=None):
-
+`def snippet_list(request, format=None):`
 and
-
-    def snippet_detail(request, pk, format=None):
+`def snippet_detail(request, pk, format=None):`
 
 Now update the `snippets/urls.py` file slightly, to append a set of `format_suffix_patterns` in addition to the existing URLs.
 
-    from django.urls import path
-    from rest_framework.urlpatterns import format_suffix_patterns
-    from snippets import views
+```python
+from django.urls import path
+from rest_framework.urlpatterns import format_suffix_patterns
+from snippets import views
 
-    urlpatterns = [
-        path('snippets/', views.snippet_list),
-        path('snippets/<int:pk>/', views.snippet_detail),
-    ]
+urlpatterns = [
+    path("snippets/", views.snippet_list),
+    path("snippets/<int:pk>/", views.snippet_detail),
+]
 
-    urlpatterns = format_suffix_patterns(urlpatterns)
+urlpatterns = format_suffix_patterns(urlpatterns)
+```
 
 We don't necessarily need to add these extra url patterns in, but it gives us a simple, clean way of referring to a specific format.
 
@@ -125,68 +132,76 @@ Go ahead and test the API from the command line, as we did in [tutorial part 1][
 
 We can get a list of all of the snippets, as before.
 
-    http http://127.0.0.1:8000/snippets/
+```bash
+http http://127.0.0.1:8000/snippets/
 
-    HTTP/1.1 200 OK
-    ...
-    [
-      {
-        "id": 1,
-        "title": "",
-        "code": "foo = \"bar\"\n",
-        "linenos": false,
-        "language": "python",
-        "style": "friendly"
-      },
-      {
-        "id": 2,
-        "title": "",
-        "code": "print(\"hello, world\")\n",
-        "linenos": false,
-        "language": "python",
-        "style": "friendly"
-      }
-    ]
+HTTP/1.1 200 OK
+...
+[
+    {
+    "id": 1,
+    "title": "",
+    "code": "foo = \"bar\"\n",
+    "linenos": false,
+    "language": "python",
+    "style": "friendly"
+    },
+    {
+    "id": 2,
+    "title": "",
+    "code": "print(\"hello, world\")\n",
+    "linenos": false,
+    "language": "python",
+    "style": "friendly"
+    }
+]
+```
 
 We can control the format of the response that we get back, either by using the `Accept` header:
 
-    http http://127.0.0.1:8000/snippets/ Accept:application/json  # Request JSON
-    http http://127.0.0.1:8000/snippets/ Accept:text/html         # Request HTML
+```bash
+http http://127.0.0.1:8000/snippets/ Accept:application/json  # Request JSON
+http http://127.0.0.1:8000/snippets/ Accept:text/html         # Request HTML
+```
 
 Or by appending a format suffix:
 
-    http http://127.0.0.1:8000/snippets.json  # JSON suffix
-    http http://127.0.0.1:8000/snippets.api   # Browsable API suffix
+```bash
+http http://127.0.0.1:8000/snippets.json  # JSON suffix
+http http://127.0.0.1:8000/snippets.api   # Browsable API suffix
+```
 
 Similarly, we can control the format of the request that we send, using the `Content-Type` header.
 
-    # POST using form data
-    http --form POST http://127.0.0.1:8000/snippets/ code="print(123)"
+```bash
+# POST using form data
+http --form POST http://127.0.0.1:8000/snippets/ code="print(123)"
 
-    {
-      "id": 3,
-      "title": "",
-      "code": "print(123)",
-      "linenos": false,
-      "language": "python",
-      "style": "friendly"
-    }
+{
+    "id": 3,
+    "title": "",
+    "code": "print(123)",
+    "linenos": false,
+    "language": "python",
+    "style": "friendly"
+}
 
-    # POST using JSON
-    http --json POST http://127.0.0.1:8000/snippets/ code="print(456)"
+# POST using JSON
+http --json POST http://127.0.0.1:8000/snippets/ code="print(456)"
 
-    {
-        "id": 4,
-        "title": "",
-        "code": "print(456)",
-        "linenos": false,
-        "language": "python",
-        "style": "friendly"
-    }
+{
+    "id": 4,
+    "title": "",
+    "code": "print(456)",
+    "linenos": false,
+    "language": "python",
+    "style": "friendly"
+}
+```
 
 If you add a `--debug` switch to the `http` requests above, you will be able to see the request type in request headers.
 
-Now go and open the API in a web browser, by visiting [http://127.0.0.1:8000/snippets/][devserver].
+Now go and open the API in a web browser, by visiting [<http://127.0.0.1:8000/snippets/>][devserver].
 
 ### Browsability
 

--- a/docs/tutorial/3-class-based-views.md
+++ b/docs/tutorial/3-class-based-views.md
@@ -6,74 +6,82 @@ We can also write our API views using class-based views, rather than function ba
 
 We'll start by rewriting the root view as a class-based view.  All this involves is a little bit of refactoring of `views.py`.
 
-    from snippets.models import Snippet
-    from snippets.serializers import SnippetSerializer
-    from django.http import Http404
-    from rest_framework.views import APIView
-    from rest_framework.response import Response
-    from rest_framework import status
+```python
+from snippets.models import Snippet
+from snippets.serializers import SnippetSerializer
+from django.http import Http404
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
 
 
-    class SnippetList(APIView):
-        """
-        List all snippets, or create a new snippet.
-        """
-        def get(self, request, format=None):
-            snippets = Snippet.objects.all()
-            serializer = SnippetSerializer(snippets, many=True)
-            return Response(serializer.data)
+class SnippetList(APIView):
+    """
+    List all snippets, or create a new snippet.
+    """
 
-        def post(self, request, format=None):
-            serializer = SnippetSerializer(data=request.data)
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    def get(self, request, format=None):
+        snippets = Snippet.objects.all()
+        serializer = SnippetSerializer(snippets, many=True)
+        return Response(serializer.data)
+
+    def post(self, request, format=None):
+        serializer = SnippetSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+```
 
 So far, so good.  It looks pretty similar to the previous case, but we've got better separation between the different HTTP methods.  We'll also need to update the instance view in `views.py`.
 
-    class SnippetDetail(APIView):
-        """
-        Retrieve, update or delete a snippet instance.
-        """
-        def get_object(self, pk):
-            try:
-                return Snippet.objects.get(pk=pk)
-            except Snippet.DoesNotExist:
-                raise Http404
+```python
+class SnippetDetail(APIView):
+    """
+    Retrieve, update or delete a snippet instance.
+    """
 
-        def get(self, request, pk, format=None):
-            snippet = self.get_object(pk)
-            serializer = SnippetSerializer(snippet)
+    def get_object(self, pk):
+        try:
+            return Snippet.objects.get(pk=pk)
+        except Snippet.DoesNotExist:
+            raise Http404
+
+    def get(self, request, pk, format=None):
+        snippet = self.get_object(pk)
+        serializer = SnippetSerializer(snippet)
+        return Response(serializer.data)
+
+    def put(self, request, pk, format=None):
+        snippet = self.get_object(pk)
+        serializer = SnippetSerializer(snippet, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
             return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        def put(self, request, pk, format=None):
-            snippet = self.get_object(pk)
-            serializer = SnippetSerializer(snippet, data=request.data)
-            if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data)
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        def delete(self, request, pk, format=None):
-            snippet = self.get_object(pk)
-            snippet.delete()
-            return Response(status=status.HTTP_204_NO_CONTENT)
+    def delete(self, request, pk, format=None):
+        snippet = self.get_object(pk)
+        snippet.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+```
 
 That's looking good.  Again, it's still pretty similar to the function based view right now.
 
 We'll also need to refactor our `snippets/urls.py` slightly now that we're using class-based views.
 
-    from django.urls import path
-    from rest_framework.urlpatterns import format_suffix_patterns
-    from snippets import views
+```python
+from django.urls import path
+from rest_framework.urlpatterns import format_suffix_patterns
+from snippets import views
 
-    urlpatterns = [
-        path('snippets/', views.SnippetList.as_view()),
-        path('snippets/<int:pk>/', views.SnippetDetail.as_view()),
-    ]
+urlpatterns = [
+    path("snippets/", views.SnippetList.as_view()),
+    path("snippets/<int:pk>/", views.SnippetDetail.as_view()),
+]
 
-    urlpatterns = format_suffix_patterns(urlpatterns)
+urlpatterns = format_suffix_patterns(urlpatterns)
+```
 
 Okay, we're done.  If you run the development server everything should be working just as before.
 
@@ -85,42 +93,49 @@ The create/retrieve/update/delete operations that we've been using so far are go
 
 Let's take a look at how we can compose the views by using the mixin classes.  Here's our `views.py` module again.
 
-    from snippets.models import Snippet
-    from snippets.serializers import SnippetSerializer
-    from rest_framework import mixins
-    from rest_framework import generics
+```python
+from snippets.models import Snippet
+from snippets.serializers import SnippetSerializer
+from rest_framework import mixins
+from rest_framework import generics
 
-    class SnippetList(mixins.ListModelMixin,
-                      mixins.CreateModelMixin,
-                      generics.GenericAPIView):
-        queryset = Snippet.objects.all()
-        serializer_class = SnippetSerializer
 
-        def get(self, request, *args, **kwargs):
-            return self.list(request, *args, **kwargs)
+class SnippetList(
+    mixins.ListModelMixin, mixins.CreateModelMixin, generics.GenericAPIView
+):
+    queryset = Snippet.objects.all()
+    serializer_class = SnippetSerializer
 
-        def post(self, request, *args, **kwargs):
-            return self.create(request, *args, **kwargs)
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)
+```
 
 We'll take a moment to examine exactly what's happening here.  We're building our view using `GenericAPIView`, and adding in `ListModelMixin` and `CreateModelMixin`.
 
 The base class provides the core functionality, and the mixin classes provide the `.list()` and `.create()` actions.  We're then explicitly binding the `get` and `post` methods to the appropriate actions.  Simple enough stuff so far.
 
-    class SnippetDetail(mixins.RetrieveModelMixin,
-                        mixins.UpdateModelMixin,
-                        mixins.DestroyModelMixin,
-                        generics.GenericAPIView):
-        queryset = Snippet.objects.all()
-        serializer_class = SnippetSerializer
+```python
+class SnippetDetail(
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    generics.GenericAPIView,
+):
+    queryset = Snippet.objects.all()
+    serializer_class = SnippetSerializer
 
-        def get(self, request, *args, **kwargs):
-            return self.retrieve(request, *args, **kwargs)
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
 
-        def put(self, request, *args, **kwargs):
-            return self.update(request, *args, **kwargs)
+    def put(self, request, *args, **kwargs):
+        return self.update(request, *args, **kwargs)
 
-        def delete(self, request, *args, **kwargs):
-            return self.destroy(request, *args, **kwargs)
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)
+```
 
 Pretty similar.  Again we're using the `GenericAPIView` class to provide the core functionality, and adding in mixins to provide the `.retrieve()`, `.update()` and `.destroy()` actions.
 
@@ -128,19 +143,21 @@ Pretty similar.  Again we're using the `GenericAPIView` class to provide the cor
 
 Using the mixin classes we've rewritten the views to use slightly less code than before, but we can go one step further.  REST framework provides a set of already mixed-in generic views that we can use to trim down our `views.py` module even more.
 
-    from snippets.models import Snippet
-    from snippets.serializers import SnippetSerializer
-    from rest_framework import generics
+```python
+from snippets.models import Snippet
+from snippets.serializers import SnippetSerializer
+from rest_framework import generics
 
 
-    class SnippetList(generics.ListCreateAPIView):
-        queryset = Snippet.objects.all()
-        serializer_class = SnippetSerializer
+class SnippetList(generics.ListCreateAPIView):
+    queryset = Snippet.objects.all()
+    serializer_class = SnippetSerializer
 
 
-    class SnippetDetail(generics.RetrieveUpdateDestroyAPIView):
-        queryset = Snippet.objects.all()
-        serializer_class = SnippetSerializer
+class SnippetDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Snippet.objects.all()
+    serializer_class = SnippetSerializer
+```
 
 Wow, that's pretty concise.  We've gotten a huge amount for free, and our code looks like good, clean, idiomatic Django.
 

--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -14,81 +14,103 @@ First, let's add a couple of fields.  One of those fields will be used to repres
 
 Add the following two fields to the `Snippet` model in `models.py`.
 
-    owner = models.ForeignKey('auth.User', related_name='snippets', on_delete=models.CASCADE)
-    highlighted = models.TextField()
+```python
+owner = models.ForeignKey(
+    "auth.User", related_name="snippets", on_delete=models.CASCADE
+)
+highlighted = models.TextField()
+```
 
 We'd also need to make sure that when the model is saved, that we populate the highlighted field, using the `pygments` code highlighting library.
 
 We'll need some extra imports:
 
-    from pygments.lexers import get_lexer_by_name
-    from pygments.formatters.html import HtmlFormatter
-    from pygments import highlight
+```python
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters.html import HtmlFormatter
+from pygments import highlight
+```
 
 And now we can add a `.save()` method to our model class:
 
-    def save(self, *args, **kwargs):
-        """
-        Use the `pygments` library to create a highlighted HTML
-        representation of the code snippet.
-        """
-        lexer = get_lexer_by_name(self.language)
-        linenos = 'table' if self.linenos else False
-        options = {'title': self.title} if self.title else {}
-        formatter = HtmlFormatter(style=self.style, linenos=linenos,
-                                  full=True, **options)
-        self.highlighted = highlight(self.code, lexer, formatter)
-        super().save(*args, **kwargs)
+```python
+def save(self, *args, **kwargs):
+    """
+    Use the `pygments` library to create a highlighted HTML
+    representation of the code snippet.
+    """
+    lexer = get_lexer_by_name(self.language)
+    linenos = "table" if self.linenos else False
+    options = {"title": self.title} if self.title else {}
+    formatter = HtmlFormatter(style=self.style, linenos=linenos, full=True, **options)
+    self.highlighted = highlight(self.code, lexer, formatter)
+    super().save(*args, **kwargs)
+```
 
 When that's all done we'll need to update our database tables.
 Normally we'd create a database migration in order to do that, but for the purposes of this tutorial, let's just delete the database and start again.
 
-    rm -f db.sqlite3
-    rm -r snippets/migrations
-    python manage.py makemigrations snippets
-    python manage.py migrate
+```bash
+rm -f db.sqlite3
+rm -r snippets/migrations
+python manage.py makemigrations snippets
+python manage.py migrate
+```
 
 You might also want to create a few different users, to use for testing the API.  The quickest way to do this will be with the `createsuperuser` command.
 
-    python manage.py createsuperuser
+```bash
+python manage.py createsuperuser
+```
 
 ## Adding endpoints for our User models
 
 Now that we've got some users to work with, we'd better add representations of those users to our API.  Creating a new serializer is easy. In `serializers.py` add:
 
-    from django.contrib.auth.models import User
+```python
+from django.contrib.auth.models import User
 
-    class UserSerializer(serializers.ModelSerializer):
-        snippets = serializers.PrimaryKeyRelatedField(many=True, queryset=Snippet.objects.all())
 
-        class Meta:
-            model = User
-            fields = ['id', 'username', 'snippets']
+class UserSerializer(serializers.ModelSerializer):
+    snippets = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=Snippet.objects.all()
+    )
+
+    class Meta:
+        model = User
+        fields = ["id", "username", "snippets"]
+```
 
 Because `'snippets'` is a *reverse* relationship on the User model, it will not be included by default when using the `ModelSerializer` class, so we needed to add an explicit field for it.
 
 We'll also add a couple of views to `views.py`.  We'd like to just use read-only views for the user representations, so we'll use the `ListAPIView` and `RetrieveAPIView` generic class-based views.
 
-    from django.contrib.auth.models import User
+```python
+from django.contrib.auth.models import User
 
 
-    class UserList(generics.ListAPIView):
-        queryset = User.objects.all()
-        serializer_class = UserSerializer
+class UserList(generics.ListAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
 
 
-    class UserDetail(generics.RetrieveAPIView):
-        queryset = User.objects.all()
-        serializer_class = UserSerializer
+class UserDetail(generics.RetrieveAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+```
 
 Make sure to also import the `UserSerializer` class
 
-    from snippets.serializers import UserSerializer
+```python
+from snippets.serializers import UserSerializer
+```
 
 Finally we need to add those views into the API, by referencing them from the URL conf. Add the following to the patterns in `snippets/urls.py`.
 
-    path('users/', views.UserList.as_view()),
-    path('users/<int:pk>/', views.UserDetail.as_view()),
+```python
+path("users/", views.UserList.as_view()),
+path("users/<int:pk>/", views.UserDetail.as_view()),
+```
 
 ## Associating Snippets with Users
 
@@ -98,8 +120,10 @@ The way we deal with that is by overriding a `.perform_create()` method on our s
 
 On the `SnippetList` view class, add the following method:
 
-    def perform_create(self, serializer):
-        serializer.save(owner=self.request.user)
+```python
+def perform_create(self, serializer):
+    serializer.save(owner=self.request.user)
+```
 
 The `create()` method of our serializer will now be passed an additional `'owner'` field, along with the validated data from the request.
 
@@ -107,7 +131,9 @@ The `create()` method of our serializer will now be passed an additional `'owner
 
 Now that snippets are associated with the user that created them, let's update our `SnippetSerializer` to reflect that.  Add the following field to the serializer definition in `serializers.py`:
 
-    owner = serializers.ReadOnlyField(source='owner.username')
+```python
+owner = serializers.ReadOnlyField(source="owner.username")
+```
 
 **Note**: Make sure you also add `'owner',` to the list of fields in the inner `Meta` class.
 
@@ -123,11 +149,15 @@ REST framework includes a number of permission classes that we can use to restri
 
 First add the following import in the views module
 
-    from rest_framework import permissions
+```python
+from rest_framework import permissions
+```
 
 Then, add the following property to **both** the `SnippetList` and `SnippetDetail` view classes.
 
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+```python
+permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+```
 
 ## Adding login to the Browsable API
 
@@ -137,13 +167,17 @@ We can add a login view for use with the browsable API, by editing the URLconf i
 
 Add the following import at the top of the file:
 
-    from django.urls import path, include
+```python
+from django.urls import path, include
+```
 
 And, at the end of the file, add a pattern to include the login and logout views for the browsable API.
 
-    urlpatterns += [
-        path('api-auth/', include('rest_framework.urls')),
-    ]
+```python
+urlpatterns += [
+    path("api-auth/", include("rest_framework.urls")),
+]
+```
 
 The `'api-auth/'` part of pattern can actually be whatever URL you want to use.
 
@@ -159,31 +193,36 @@ To do that we're going to need to create a custom permission.
 
 In the snippets app, create a new file, `permissions.py`
 
-    from rest_framework import permissions
+```python
+from rest_framework import permissions
 
 
-    class IsOwnerOrReadOnly(permissions.BasePermission):
-        """
-        Custom permission to only allow owners of an object to edit it.
-        """
+class IsOwnerOrReadOnly(permissions.BasePermission):
+    """
+    Custom permission to only allow owners of an object to edit it.
+    """
 
-        def has_object_permission(self, request, view, obj):
-            # Read permissions are allowed to any request,
-            # so we'll always allow GET, HEAD or OPTIONS requests.
-            if request.method in permissions.SAFE_METHODS:
-                return True
+    def has_object_permission(self, request, view, obj):
+        # Read permissions are allowed to any request,
+        # so we'll always allow GET, HEAD or OPTIONS requests.
+        if request.method in permissions.SAFE_METHODS:
+            return True
 
-            # Write permissions are only allowed to the owner of the snippet.
-            return obj.owner == request.user
+        # Write permissions are only allowed to the owner of the snippet.
+        return obj.owner == request.user
+```
 
 Now we can add that custom permission to our snippet instance endpoint, by editing the `permission_classes` property on the `SnippetDetail` view class:
 
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly,
-                          IsOwnerOrReadOnly]
+```python
+permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
+```
 
 Make sure to also import the `IsOwnerOrReadOnly` class.
 
-    from snippets.permissions import IsOwnerOrReadOnly
+```python
+from snippets.permissions import IsOwnerOrReadOnly
+```
 
 Now, if you open a browser again, you find that the 'DELETE' and 'PUT' actions only appear on a snippet instance endpoint if you're logged in as the same user that created the code snippet.
 
@@ -197,25 +236,29 @@ If we're interacting with the API programmatically we need to explicitly provide
 
 If we try to create a snippet without authenticating, we'll get an error:
 
-    http POST http://127.0.0.1:8000/snippets/ code="print(123)"
+```bash
+http POST http://127.0.0.1:8000/snippets/ code="print(123)"
 
-    {
-        "detail": "Authentication credentials were not provided."
-    }
+{
+    "detail": "Authentication credentials were not provided."
+}
+```
 
 We can make a successful request by including the username and password of one of the users we created earlier.
 
-    http -a admin:password123 POST http://127.0.0.1:8000/snippets/ code="print(789)"
+```bash
+http -a admin:password123 POST http://127.0.0.1:8000/snippets/ code="print(789)"
 
-    {
-        "id": 1,
-        "owner": "admin",
-        "title": "foo",
-        "code": "print(789)",
-        "linenos": false,
-        "language": "python",
-        "style": "friendly"
-    }
+{
+    "id": 1,
+    "owner": "admin",
+    "title": "foo",
+    "code": "print(789)",
+    "linenos": false,
+    "language": "python",
+    "style": "friendly"
+}
+```
 
 ## Summary
 

--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -6,17 +6,21 @@ At the moment relationships within our API are represented by using primary keys
 
 Right now we have endpoints for 'snippets' and 'users', but we don't have a single entry point to our API.  To create one, we'll use a regular function-based view and the `@api_view` decorator we introduced earlier. In your `snippets/views.py` add:
 
-    from rest_framework.decorators import api_view
-    from rest_framework.response import Response
-    from rest_framework.reverse import reverse
+```python
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
 
 
-    @api_view(['GET'])
-    def api_root(request, format=None):
-        return Response({
-            'users': reverse('user-list', request=request, format=format),
-            'snippets': reverse('snippet-list', request=request, format=format)
-        })
+@api_view(["GET"])
+def api_root(request, format=None):
+    return Response(
+        {
+            "users": reverse("user-list", request=request, format=format),
+            "snippets": reverse("snippet-list", request=request, format=format),
+        }
+    )
+```
 
 Two things should be noticed here. First, we're using REST framework's `reverse` function in order to return fully-qualified URLs; second, URL patterns are identified by convenience names that we will declare later on in our `snippets/urls.py`.
 
@@ -30,24 +34,31 @@ The other thing we need to consider when creating the code highlight view is tha
 
 Instead of using a concrete generic view, we'll use the base class for representing instances, and create our own `.get()` method.  In your `snippets/views.py` add:
 
-    from rest_framework import renderers
+```python
+from rest_framework import renderers
 
-    class SnippetHighlight(generics.GenericAPIView):
-        queryset = Snippet.objects.all()
-        renderer_classes = [renderers.StaticHTMLRenderer]
 
-        def get(self, request, *args, **kwargs):
-            snippet = self.get_object()
-            return Response(snippet.highlighted)
+class SnippetHighlight(generics.GenericAPIView):
+    queryset = Snippet.objects.all()
+    renderer_classes = [renderers.StaticHTMLRenderer]
+
+    def get(self, request, *args, **kwargs):
+        snippet = self.get_object()
+        return Response(snippet.highlighted)
+```
 
 As usual we need to add the new views that we've created in to our URLconf.
 We'll add a url pattern for our new API root in `snippets/urls.py`:
 
-    path('', views.api_root),
+```python
+path("", views.api_root),
+```
 
 And then add a url pattern for the snippet highlights:
 
-    path('snippets/<int:pk>/highlight/', views.SnippetHighlight.as_view()),
+```python
+path("snippets/<int:pk>/highlight/", views.SnippetHighlight.as_view()),
+```
 
 ## Hyperlinking our API
 
@@ -73,22 +84,37 @@ The `HyperlinkedModelSerializer` has the following differences from `ModelSerial
 
 We can easily re-write our existing serializers to use hyperlinking. In your `snippets/serializers.py` add:
 
-    class SnippetSerializer(serializers.HyperlinkedModelSerializer):
-        owner = serializers.ReadOnlyField(source='owner.username')
-        highlight = serializers.HyperlinkedIdentityField(view_name='snippet-highlight', format='html')
+```python
+class SnippetSerializer(serializers.HyperlinkedModelSerializer):
+    owner = serializers.ReadOnlyField(source="owner.username")
+    highlight = serializers.HyperlinkedIdentityField(
+        view_name="snippet-highlight", format="html"
+    )
 
-        class Meta:
-            model = Snippet
-            fields = ['url', 'id', 'highlight', 'owner',
-                      'title', 'code', 'linenos', 'language', 'style']
+    class Meta:
+        model = Snippet
+        fields = [
+            "url",
+            "id",
+            "highlight",
+            "owner",
+            "title",
+            "code",
+            "linenos",
+            "language",
+            "style",
+        ]
 
 
-    class UserSerializer(serializers.HyperlinkedModelSerializer):
-        snippets = serializers.HyperlinkedRelatedField(many=True, view_name='snippet-detail', read_only=True)
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    snippets = serializers.HyperlinkedRelatedField(
+        many=True, view_name="snippet-detail", read_only=True
+    )
 
-        class Meta:
-            model = User
-            fields = ['url', 'id', 'username', 'snippets']
+    class Meta:
+        model = User
+        fields = ["url", "id", "username", "snippets"]
+```
 
 Notice that we've also added a new `'highlight'` field.  This field is of the same type as the `url` field, except that it points to the `'snippet-highlight'` url pattern, instead of the `'snippet-detail'` url pattern.
 
@@ -100,11 +126,15 @@ Because we've included format suffixed URLs such as `'.json'`, we also need to i
 
 When you are manually instantiating these serializers inside your views (e.g., in `SnippetDetail` or `SnippetList`), you **must** pass `context={'request': request}` so the serializer knows how to build absolute URLs. For example, instead of:
 
-    serializer = SnippetSerializer(snippet)
+```python
+serializer = SnippetSerializer(snippet)
+```
 
 You must write:
 
-    serializer = SnippetSerializer(snippet, context={'request': request})
+```python
+serializer = SnippetSerializer(snippet, context={"request": request})
+```
 
 If your view is a subclass of `GenericAPIView`, you may use the `get_serializer_context()` as a convenience method.
 
@@ -121,29 +151,29 @@ If we're going to have a hyperlinked API, we need to make sure we name our URL p
 
 After adding all those names into our URLconf, our final `snippets/urls.py` file should look like this:
 
-    from django.urls import path
-    from rest_framework.urlpatterns import format_suffix_patterns
-    from snippets import views
+```python
+from django.urls import path
+from rest_framework.urlpatterns import format_suffix_patterns
+from snippets import views
 
-    # API endpoints
-    urlpatterns = format_suffix_patterns([
-        path('', views.api_root),
-        path('snippets/',
-            views.SnippetList.as_view(),
-            name='snippet-list'),
-        path('snippets/<int:pk>/',
-            views.SnippetDetail.as_view(),
-            name='snippet-detail'),
-        path('snippets/<int:pk>/highlight/',
+# API endpoints
+urlpatterns = format_suffix_patterns(
+    [
+        path("", views.api_root),
+        path("snippets/", views.SnippetList.as_view(), name="snippet-list"),
+        path(
+            "snippets/<int:pk>/", views.SnippetDetail.as_view(), name="snippet-detail"
+        ),
+        path(
+            "snippets/<int:pk>/highlight/",
             views.SnippetHighlight.as_view(),
-            name='snippet-highlight'),
-        path('users/',
-            views.UserList.as_view(),
-            name='user-list'),
-        path('users/<int:pk>/',
-            views.UserDetail.as_view(),
-            name='user-detail')
-    ])
+            name="snippet-highlight",
+        ),
+        path("users/", views.UserList.as_view(), name="user-list"),
+        path("users/<int:pk>/", views.UserDetail.as_view(), name="user-detail"),
+    ]
+)
+```
 
 ## Adding pagination
 
@@ -151,10 +181,12 @@ The list views for users and code snippets could end up returning quite a lot of
 
 We can change the default list style to use pagination, by modifying our `tutorial/settings.py` file slightly. Add the following setting:
 
-    REST_FRAMEWORK = {
-        'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-        'PAGE_SIZE': 10
-    }
+```python
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
+}
+```
 
 Note that settings in REST framework are all namespaced into a single dictionary setting, named `REST_FRAMEWORK`, which helps keep them well separated from your other project settings.
 

--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -6,57 +6,65 @@ We're going to create a simple API to allow admin users to view and edit the use
 
 Create a new Django project named `tutorial`, then start a new app called `quickstart`.
 
-    # Create the project directory
-    mkdir tutorial
-    cd tutorial
+```bash
+# Create the project directory
+mkdir tutorial
+cd tutorial
 
-    # Create a virtual environment to isolate our package dependencies locally
-    python3 -m venv env
-    source env/bin/activate  # On Windows use `env\Scripts\activate`
+# Create a virtual environment to isolate our package dependencies locally
+python3 -m venv env
+source env/bin/activate  # On Windows use `env\Scripts\activate`
 
-    # Install Django and Django REST framework into the virtual environment
-    pip install djangorestframework
+# Install Django and Django REST framework into the virtual environment
+pip install djangorestframework
 
-    # Set up a new project with a single application
-    django-admin startproject tutorial .  # Note the trailing '.' character
-    cd tutorial
-    django-admin startapp quickstart
-    cd ..
+# Set up a new project with a single application
+django-admin startproject tutorial .  # Note the trailing '.' character
+cd tutorial
+django-admin startapp quickstart
+cd ..
+```
 
 The project layout should look like:
 
-    $ pwd
-    <some path>/tutorial
-    $ find .
-    .
-    ./tutorial
-    ./tutorial/asgi.py
-    ./tutorial/__init__.py
-    ./tutorial/quickstart
-    ./tutorial/quickstart/migrations
-    ./tutorial/quickstart/migrations/__init__.py
-    ./tutorial/quickstart/models.py
-    ./tutorial/quickstart/__init__.py
-    ./tutorial/quickstart/apps.py
-    ./tutorial/quickstart/admin.py
-    ./tutorial/quickstart/tests.py
-    ./tutorial/quickstart/views.py
-    ./tutorial/settings.py
-    ./tutorial/urls.py
-    ./tutorial/wsgi.py
-    ./env
-    ./env/...
-    ./manage.py
+```bash
+$ pwd
+<some path>/tutorial
+$ find .
+.
+./tutorial
+./tutorial/asgi.py
+./tutorial/__init__.py
+./tutorial/quickstart
+./tutorial/quickstart/migrations
+./tutorial/quickstart/migrations/__init__.py
+./tutorial/quickstart/models.py
+./tutorial/quickstart/__init__.py
+./tutorial/quickstart/apps.py
+./tutorial/quickstart/admin.py
+./tutorial/quickstart/tests.py
+./tutorial/quickstart/views.py
+./tutorial/settings.py
+./tutorial/urls.py
+./tutorial/wsgi.py
+./env
+./env/...
+./manage.py
+```
 
 It may look unusual that the application has been created within the project directory. Using the project's namespace avoids name clashes with external modules (a topic that goes outside the scope of the quickstart).
 
 Now sync your database for the first time:
 
-    python manage.py migrate
+```bash
+python manage.py migrate
+```
 
 We'll also create an initial user named `admin` with a password. We'll authenticate as that user later in our example.
 
-    python manage.py createsuperuser --username admin --email admin@example.com
+```bash
+python manage.py createsuperuser --username admin --email admin@example.com
+```
 
 Once you've set up a database and the initial user is created and ready to go, open up the app's directory and we'll get coding...
 
@@ -64,20 +72,22 @@ Once you've set up a database and the initial user is created and ready to go, o
 
 First up we're going to define some serializers. Let's create a new module named `tutorial/quickstart/serializers.py` that we'll use for our data representations.
 
-    from django.contrib.auth.models import Group, User
-    from rest_framework import serializers
+```python
+from django.contrib.auth.models import Group, User
+from rest_framework import serializers
 
 
-    class UserSerializer(serializers.HyperlinkedModelSerializer):
-        class Meta:
-            model = User
-            fields = ['url', 'username', 'email', 'groups']
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ["url", "username", "email", "groups"]
 
 
-    class GroupSerializer(serializers.HyperlinkedModelSerializer):
-        class Meta:
-            model = Group
-            fields = ['url', 'name']
+class GroupSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Group
+        fields = ["url", "name"]
+```
 
 Notice that we're using hyperlinked relations in this case with `HyperlinkedModelSerializer`.  You can also use primary key and various other relationships, but hyperlinking is good RESTful design.
 
@@ -85,28 +95,32 @@ Notice that we're using hyperlinked relations in this case with `HyperlinkedMode
 
 Right, we'd better write some views then.  Open `tutorial/quickstart/views.py` and get typing.
 
-    from django.contrib.auth.models import Group, User
-    from rest_framework import permissions, viewsets
+```python
+from django.contrib.auth.models import Group, User
+from rest_framework import permissions, viewsets
 
-    from tutorial.quickstart.serializers import GroupSerializer, UserSerializer
-
-
-    class UserViewSet(viewsets.ModelViewSet):
-        """
-        API endpoint that allows users to be viewed or edited.
-        """
-        queryset = User.objects.all().order_by('-date_joined')
-        serializer_class = UserSerializer
-        permission_classes = [permissions.IsAuthenticated]
+from tutorial.quickstart.serializers import GroupSerializer, UserSerializer
 
 
-    class GroupViewSet(viewsets.ModelViewSet):
-        """
-        API endpoint that allows groups to be viewed or edited.
-        """
-        queryset = Group.objects.all().order_by('name')
-        serializer_class = GroupSerializer
-        permission_classes = [permissions.IsAuthenticated]
+class UserViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+
+    queryset = User.objects.all().order_by("-date_joined")
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class GroupViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows groups to be viewed or edited.
+    """
+
+    queryset = Group.objects.all().order_by("name")
+    serializer_class = GroupSerializer
+    permission_classes = [permissions.IsAuthenticated]
+```
 
 Rather than write multiple views we're grouping together all the common behavior into classes called `ViewSets`.
 
@@ -116,21 +130,23 @@ We can easily break these down into individual views if we need to, but using vi
 
 Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
 
-    from django.urls import include, path
-    from rest_framework import routers
+```python
+from django.urls import include, path
+from rest_framework import routers
 
-    from tutorial.quickstart import views
+from tutorial.quickstart import views
 
-    router = routers.DefaultRouter()
-    router.register(r'users', views.UserViewSet)
-    router.register(r'groups', views.GroupViewSet)
+router = routers.DefaultRouter()
+router.register(r"users", views.UserViewSet)
+router.register(r"groups", views.GroupViewSet)
 
-    # Wire up our API using automatic URL routing.
-    # Additionally, we include login URLs for the browsable API.
-    urlpatterns = [
-        path('', include(router.urls)),
-        path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
-    ]
+# Wire up our API using automatic URL routing.
+# Additionally, we include login URLs for the browsable API.
+urlpatterns = [
+    path("", include(router.urls)),
+    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+]
+```
 
 Because we're using viewsets instead of views, we can automatically generate the URL conf for our API, by simply registering the viewsets with a router class.
 
@@ -139,21 +155,26 @@ Again, if we need more control over the API URLs we can simply drop down to usin
 Finally, we're including default login and logout views for use with the browsable API.  That's optional, but useful if your API requires authentication and you want to use the browsable API.
 
 ## Pagination
+
 Pagination allows you to control how many objects per page are returned. To enable it add the following lines to `tutorial/settings.py`
 
-    REST_FRAMEWORK = {
-        'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-        'PAGE_SIZE': 10
-    }
+```python
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
+}
+```
 
 ## Settings
 
 Add `'rest_framework'` to `INSTALLED_APPS`. The settings module will be in `tutorial/settings.py`
 
-    INSTALLED_APPS = [
-        ...
-        'rest_framework',
-    ]
+```text
+INSTALLED_APPS = [
+    ...
+    'rest_framework',
+]
+```
 
 Okay, we're done.
 
@@ -163,46 +184,51 @@ Okay, we're done.
 
 We're now ready to test the API we've built.  Let's fire up the server from the command line.
 
-    python manage.py runserver
+```bash
+python manage.py runserver
+```
 
 We can now access our API, both from the command-line, using tools like `curl`...
 
-    bash: curl -u admin -H 'Accept: application/json; indent=4' http://127.0.0.1:8000/users/
-    Enter host password for user 'admin':
-    {
-        "count": 1,
-        "next": null,
-        "previous": null,
-        "results": [
-            {
-                "url": "http://127.0.0.1:8000/users/1/",
-                "username": "admin",
-                "email": "admin@example.com",
-                "groups": []
-            }
-        ]
-    }
+```bash
+bash: curl -u admin -H 'Accept: application/json; indent=4' http://127.0.0.1:8000/users/
+Enter host password for user 'admin':
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "url": "http://127.0.0.1:8000/users/1/",
+            "username": "admin",
+            "email": "admin@example.com",
+            "groups": []
+        }
+    ]
+}
+```
 
 Or using the [httpie][httpie], command line tool...
 
-    bash: http -a admin http://127.0.0.1:8000/users/
-    http: password for admin@127.0.0.1:8000:: 
-    $HTTP/1.1 200 OK
-    ...
-    {
-        "count": 1,
-        "next": null,
-        "previous": null,
-        "results": [
-            {
-                "email": "admin@example.com",
-                "groups": [],
-                "url": "http://127.0.0.1:8000/users/1/",
-                "username": "admin"
-            }
-        ]
-    }
-
+```bash
+bash: http -a admin http://127.0.0.1:8000/users/
+http: password for admin@127.0.0.1:8000:: 
+$HTTP/1.1 200 OK
+...
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "email": "admin@example.com",
+            "groups": [],
+            "url": "http://127.0.0.1:8000/users/1/",
+            "username": "admin"
+        }
+    ]
+}
+```
 
 Or directly through the browser, by going to the URL `http://127.0.0.1:8000/users/`...
 


### PR DESCRIPTION
Added syntax highlighting to all the code examples in the source tutorial docs files for better readability.
Changes made to the following files:
reference: [docs/tutorial](https://github.com/encode/django-rest-framework/tree/main/docs/tutorial)
- `1-serialization.md`
- `2-requests-and-responses.md`
- `3-class-based-views.md`
- `4-authentication-and-permissions.md`
- `5-relationships-and-hyperlinked-apis.md`
- `6-viewsets-and-routers.md`
- `quickstart.md`
