### PR TITLE
improved docs/api-guide/filtering.md for better understanding

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -235,7 +235,7 @@ For example:
 
     search_fields = ['=username', '=email']
 
-By default, the search parameter is named `'search'`, but this may be overridden with the `SEARCH_PARAM` setting.
+By default, the search parameter is named `'search'`, but this may be overridden with the `SEARCH_PARAM` setting in the `REST_FRAMEWORK` configuration.
 
 To dynamically change search fields based on request content, it's possible to subclass the `SearchFilter` and override the `get_search_fields()` function. For example, the following subclass will only search on `title` if the query parameter `title_only` is in the request:
 
@@ -257,7 +257,7 @@ The `OrderingFilter` class supports simple query parameter controlled ordering o
 
 ![Ordering Filter](../img/ordering-filter.png)
 
-By default, the query parameter is named `'ordering'`, but this may be overridden with the `ORDERING_PARAM` setting.
+By default, the query parameter is named `'ordering'`, but this may be overridden with the `ORDERING_PARAM` setting in the `REST_FRAMEWORK` configuration.
 
 For example, to order users by username:
 


### PR DESCRIPTION
I found it difficult locating where to override the SEARCH_PARAM setting when reading the docs:

> By default, the search parameter is named 'search', but this may be overridden with the SEARCH_PARAM setting.

In order to help other users who might have this challenge, I added a clause to show that this setting can be overridden in the REST_FRAMEWORK settings. Same with ORDERING_PARAM.

