### PR TITLE
Fix invalid SPDX license expression in `__init__.py`

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -10,7 +10,7 @@ ______ _____ _____ _____    __
 __title__ = 'Django REST framework'
 __version__ = '3.16.1'
 __author__ = 'Tom Christie'
-__license__ = 'BSD 3-Clause'
+__license__ = 'BSD-3-Clause'
 __copyright__ = 'Copyright 2011-2023 Encode OSS Ltd'
 
 # Version synonym


### PR DESCRIPTION
## Description

According to https://packaging.python.org/en/latest/specifications/license-expression/ expressions with spaces are not allowed (see example with `# spaces are not allowed`).

This should fix problems when parsing the license information with a library that expects a valid SPDX expression (e.g.: https://pypi.org/project/license-expression/).