### PR TITLE
Add section about avoiding N+1 queries in generic views

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -102,6 +102,39 @@ For example:
 
 ---
 
+### Avoiding N+1 Queries
+
+When listing objects (e.g. using `ListAPIView` or `ModelViewSet`), serializers may trigger an N+1 query pattern if related objects are accessed individually for each item.
+
+To prevent this, optimize the queryset in `get_queryset()` or by setting the `queryset` class attribute using [`select_related()`](https://docs.djangoproject.com/en/stable/ref/models/querysets/#select-related) and [`prefetch_related()`](https://docs.djangoproject.com/en/stable/ref/models/querysets/#prefetch-related), depending on the type of relationship.
+
+**For ForeignKey and OneToOneField**:
+
+Use `select_related()` to fetch related objects in the same query:
+
+    def get_queryset(self):
+        return Order.objects.select_related("customer", "billing_address")
+
+**For reverse and many-to-many relationships**:
+
+Use `prefetch_related()` to efficiently load collections of related objects:
+
+    def get_queryset(self):
+        return Book.objects.prefetch_related("categories", "reviews__user")
+
+**Combining both**:
+
+    def get_queryset(self):
+        return (
+            Order.objects
+            .select_related("customer")
+            .prefetch_related("items__product")
+        )
+
+These optimizations reduce repeated database access and improve list view performance.
+
+---
+
 #### `get_object(self)`
 
 Returns an object instance that should be used for detail views.  Defaults to using the `lookup_field` parameter to filter the base queryset.


### PR DESCRIPTION
I noticed that DRF mentions N+1 problems briefly in a note under get_queryset(), but it doesn’t give any proper explanation or examples.

I added a new section about performance and N+1 queries. It explains why the issue happens and how to use `select_related` and `prefetch_related` in `get_queryset()` for generic views and viewsets. I also included short examples.

The goal is to make it clearer for new people and avoid confusion.

<img width="1914" height="966" alt="drf-doc-3" src="https://github.com/user-attachments/assets/1f088e3b-1386-4434-a66d-f13c7f1109a8" />

