### PR TITLE
add clarity in requirements section for version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Some reasons you might want to use REST framework:
 * Python 3.10+
 * Django 4.2, 5.0, 5.1, 5.2
 
-We **highly recommend** and only officially support the latest patch release of
+We **highly recommend** and only officially support the latest patch release (for example, 3.12.x or 5.2.x) of
 each Python and Django series.
 
 # Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,8 +90,11 @@ REST framework requires the following:
 * Django (4.2, 5.0, 5.1, 5.2)
 * Python (3.10, 3.11, 3.12, 3.13, 3.14)
 
-We **highly recommend** and only officially support the latest patch release of
-each Python and Django series.
+**Note:** Python **3.14** requires Django **5.2 or newer**.  
+For more details, see [Django version support](https://docs.djangoproject.com/en/5.2/faq/install/#what-python-version-can-i-use-with-django).
+
+
+We **highly recommend** and only officially support the latest patch release (for example, 3.12.x or 5.2.x) of each supported Python and Django series.
 
 The following packages are optional:
 


### PR DESCRIPTION

Right now, [requirements section](https://www.django-rest-framework.org/#requirements) has very general statement about supporting` "latest patch release,"` but for a new user, it’s not immediately clear which major versions (like Django 5.2 or Python 3.13) are officially supported. This can be confusing and makes setup more difficult than it needs to be.

adding to that, Python 3.14 is only supported with Django 5.2 for now , see [here](https://code.djangoproject.com/ticket/35844) , highlighting it will remove confusion for  developers working on forward compatibility. 

This PR improves clarity in requirements section.

update doc screen shot:
<img width="1922" height="1057" alt="drf-req" src="https://github.com/user-attachments/assets/2c092661-1fdf-4a55-b390-1c55c1e7e910" />

