### PR TITLE
Delay CoreAPI deprecation until DRF 3.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ max_supported_python = "3.14"
 [tool.pytest.ini_options]
 addopts = "--tb=short --strict-markers -ra"
 testpaths = [ "tests" ]
-filterwarnings = [ "ignore:CoreAPI compatibility is deprecated*:rest_framework.RemovedInDRF317Warning" ]
+filterwarnings = [ "ignore:CoreAPI compatibility is deprecated*:rest_framework.RemovedInDRF318Warning" ]
 
 [tool.coverage.run]
 # NOTE: source is ignored with pytest-cov (but uses the same).

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -24,5 +24,5 @@ ISO_8601 = 'iso-8601'
 DJANGO_DURATION_FORMAT = 'django'
 
 
-class RemovedInDRF317Warning(PendingDeprecationWarning):
+class RemovedInDRF318Warning(DeprecationWarning):
     pass

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -14,7 +14,7 @@ from django.utils.encoding import force_str
 from django.utils.text import smart_split, unescape_string_literal
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework import RemovedInDRF317Warning
+from rest_framework import RemovedInDRF318Warning
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.fields import CharField
 from rest_framework.settings import api_settings
@@ -51,7 +51,7 @@ class BaseFilterBackend:
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return []
 
@@ -189,7 +189,7 @@ class SearchFilter(BaseFilterBackend):
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
@@ -351,7 +351,7 @@ class OrderingFilter(BaseFilterBackend):
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -15,7 +15,7 @@ from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework import RemovedInDRF317Warning
+from rest_framework import RemovedInDRF318Warning
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
@@ -154,7 +154,7 @@ class BasePagination:
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         return []
 
     def get_schema_operation_parameters(self, view):
@@ -316,7 +316,7 @@ class PageNumberPagination(BasePagination):
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(
@@ -533,7 +533,7 @@ class LimitOffsetPagination(BasePagination):
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         return [
             coreapi.Field(
@@ -936,7 +936,7 @@ class CursorPagination(BasePagination):
     def get_schema_fields(self, view):
         assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
         fields = [
             coreapi.Field(

--- a/rest_framework/schemas/coreapi.py
+++ b/rest_framework/schemas/coreapi.py
@@ -5,7 +5,7 @@ from urllib import parse
 from django.db import models
 from django.utils.encoding import force_str
 
-from rest_framework import RemovedInDRF317Warning, exceptions, serializers
+from rest_framework import RemovedInDRF318Warning, exceptions, serializers
 from rest_framework.compat import coreapi, coreschema, uritemplate
 from rest_framework.settings import api_settings
 
@@ -119,7 +119,7 @@ class SchemaGenerator(BaseSchemaGenerator):
     def __init__(self, title=None, url=None, description=None, patterns=None, urlconf=None, version=None):
         assert coreapi, '`coreapi` must be installed for schema support.'
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
         assert coreschema, '`coreschema` must be installed for schema support.'
 
         super().__init__(title, url, description, patterns, urlconf)
@@ -354,7 +354,7 @@ class AutoSchema(ViewInspector):
         """
         super().__init__()
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
 
         if manual_fields is None:
             manual_fields = []
@@ -598,7 +598,7 @@ class ManualSchema(ViewInspector):
         """
         super().__init__()
         if coreapi is not None:
-            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+            warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
 
         assert all(isinstance(f, coreapi.Field) for f in fields), "`fields` must be a list of coreapi.Field instances"
         self._fields = fields
@@ -622,5 +622,5 @@ class ManualSchema(ViewInspector):
 def is_enabled():
     """Is CoreAPI Mode enabled?"""
     if coreapi is not None:
-        warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.17', RemovedInDRF317Warning)
+        warnings.warn('CoreAPI compatibility is deprecated and will be removed in DRF 3.18', RemovedInDRF318Warning)
     return issubclass(api_settings.DEFAULT_SCHEMA_CLASS, AutoSchema)

--- a/tests/schemas/test_coreapi.py
+++ b/tests/schemas/test_coreapi.py
@@ -7,7 +7,7 @@ from django.test import TestCase, override_settings
 from django.urls import include, path
 
 from rest_framework import (
-    RemovedInDRF317Warning, filters, generics, pagination, permissions,
+    RemovedInDRF318Warning, filters, generics, pagination, permissions,
     serializers
 )
 from rest_framework.compat import coreapi, coreschema
@@ -1445,42 +1445,42 @@ def test_schema_handles_exception():
 
 @pytest.mark.skipif(not coreapi, reason='coreapi is not installed')
 def test_coreapi_deprecation():
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         SchemaGenerator()
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         AutoSchema()
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         ManualSchema({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         deprecated_filter = OrderingFilter()
         deprecated_filter.get_schema_fields({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         deprecated_filter = BaseFilterBackend()
         deprecated_filter.get_schema_fields({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         deprecated_filter = SearchFilter()
         deprecated_filter.get_schema_fields({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         paginator = BasePagination()
         paginator.get_schema_fields({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         paginator = PageNumberPagination()
         paginator.get_schema_fields({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         paginator = LimitOffsetPagination()
         paginator.get_schema_fields({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         paginator = CursorPagination()
         paginator.get_schema_fields({})
 
-    with pytest.warns(RemovedInDRF317Warning):
+    with pytest.warns(RemovedInDRF318Warning):
         is_enabled()


### PR DESCRIPTION
## Description

As per [this comment](https://github.com/encode/django-rest-framework/pull/9583#issuecomment-3463233163). We're going to cut DRF 3.17 tomorrow and we're realistically won't have time to remove it by then, so delaying the deprecation.
