### PR TITLE
Fix ListSerializer.get_initial to return consistent initial list structure

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -608,14 +608,17 @@ class ListSerializer(BaseSerializer):
         super().__init__(*args, **kwargs)
         self.child.bind(field_name='', parent=self)
 
-   def get_initial(self):
-    if hasattr(self, 'initial_data'):
-        # If data is given, we should just return the raw input structure,
-        # but ensure it's represented in a consistent list format.
-        if isinstance(self.initial_data, list):
-            return [self.child.get_initial() for _ in self.initial_data]
+    def get_initial(self):
+        """
+        Return a list of initial values, one for each item in `initial_data`,
+        or an empty list if no input data was provided.
+        """
+        if hasattr(self, 'initial_data'):
+            if isinstance(self.initial_data, list):
+                return [self.child.get_initial() for _ in self.initial_data]
+            return []
         return []
-    return []
+
 
 
     def get_value(self, dictionary):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -597,7 +597,7 @@ class ListSerializer(BaseSerializer):
         'max_length': _('Ensure this field has no more than {max_length} elements.'),
         'min_length': _('Ensure this field has at least {min_length} elements.')
     }
-
+    
     def __init__(self, *args, **kwargs):
         self.child = kwargs.pop('child', copy.deepcopy(self.child))
         self.allow_empty = kwargs.pop('allow_empty', True)
@@ -618,9 +618,7 @@ class ListSerializer(BaseSerializer):
                 return [self.child.get_initial() for _ in self.initial_data]
             return []
         return []
-
-
-
+        
     def get_value(self, dictionary):
         """
         Given the input dictionary, return the field value.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -608,10 +608,15 @@ class ListSerializer(BaseSerializer):
         super().__init__(*args, **kwargs)
         self.child.bind(field_name='', parent=self)
 
-    def get_initial(self):
-        if hasattr(self, 'initial_data'):
-            return self.to_representation(self.initial_data)
+   def get_initial(self):
+    if hasattr(self, 'initial_data'):
+        # If data is given, we should just return the raw input structure,
+        # but ensure it's represented in a consistent list format.
+        if isinstance(self.initial_data, list):
+            return [self.child.get_initial() for _ in self.initial_data]
         return []
+    return []
+
 
     def get_value(self, dictionary):
         """


### PR DESCRIPTION
This change updates `ListSerializer.get_initial()` to return an initial
list structure when `initial_data` is provided. The previous behavior
did not correctly handle list initialization and could result in
inconsistent initial states when rendering form-like serializers.

The updated implementation ensures:
- When `initial_data` is a list, an initial list structure is returned
- When no initial_data is provided, an empty list is returned
- No unintended conversion via `to_representation()`

This aligns ListSerializer behavior with Serializer.get_initial and
prevents incorrect input→output transformations.
