### PR TITLE
Drop support for Django 4.2, Django 5.0 and Django 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Some reasons you might want to use REST framework:
 # Requirements
 
 * Python 3.10+
-* Django 4.2, 5.0, 5.1, 5.2, 6.0
+* Django 5.0, 5.1, 5.2, 6.0
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Some reasons you might want to use REST framework:
 # Requirements
 
 * Python 3.10+
-* Django 5.0, 5.1, 5.2, 6.0
+* Django 5.2, 6.0
 
 We **highly recommend** and only officially support the latest patch release of
 each Python and Django series.

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -330,7 +330,7 @@ Corresponds to `django.db.models.fields.DateTimeField`.
 
 * `format` - A string representing the output format. If not specified, this defaults to the same value as the `DATETIME_FORMAT` settings key, which will be `'iso-8601'` unless set. Setting to a format string indicates that `to_representation` return values should be coerced to string output. Format strings are described below. Setting this value to `None` indicates that Python `datetime` objects should be returned by `to_representation`. In this case the datetime encoding will be determined by the renderer.
 * `input_formats` - A list of strings representing the input formats which may be used to parse the date.  If not specified, the `DATETIME_INPUT_FORMATS` setting will be used, which defaults to `['iso-8601']`.
-* `default_timezone` - A `tzinfo` subclass (`zoneinfo` or `pytz`) representing the timezone. If not specified and the `USE_TZ` setting is enabled, this defaults to the [current timezone][django-current-timezone]. If `USE_TZ` is disabled, then datetime objects will be naive.
+* `default_timezone` - A `tzinfo` subclass (`zoneinfo`) representing the timezone. If not specified and the `USE_TZ` setting is enabled, this defaults to the [current timezone][django-current-timezone]. If `USE_TZ` is disabled, then datetime objects will be naive.
 
 #### `DateTimeField` format strings.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ Some reasons you might want to use REST framework:
 
 REST framework requires the following:
 
-* Django (5.0, 5.1, 5.2, 6.0)
+* Django (5.2, 6.0)
 * Python (3.10, 3.11, 3.12, 3.13, 3.14)
 
 We **highly recommend** and only officially support the latest patch release of

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ Some reasons you might want to use REST framework:
 
 REST framework requires the following:
 
-* Django (4.2, 5.0, 5.1, 5.2, 6.0)
+* Django (5.0, 5.1, 5.2, 6.0)
 * Python (3.10, 3.11, 3.12, 3.13, 3.14)
 
 We **highly recommend** and only officially support the latest patch release of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
@@ -31,7 +30,7 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP",
 ]
 dynamic = [ "version" ]
-dependencies = [ "django>=4.2" ]
+dependencies = [ "django>=5.0" ]
 urls.Changelog = "https://www.django-rest-framework.org/community/release-notes/"
 urls.Funding = "https://fund.django-rest-framework.org/topics/funding/"
 urls.Homepage = "https://www.django-rest-framework.org"
@@ -51,8 +50,6 @@ test = [
   "pytest-cov==7.*",
   "pytest-django>=4.5.2,<5",
 
-  # Remove when dropping support for Django<5.0
-  "pytz",
 ]
 docs = [
   # MkDocs to build our documentation.
@@ -74,7 +71,6 @@ optional = [
   "requests",
   "uritemplate",
 ]
-django42 = [ "django>=4.2,<5.0" ]
 django50 = [ "django>=5.0,<5.1" ]
 django51 = [ "django>=5.1,<5.2" ]
 django52 = [ "django>=5.2,<6.0" ]
@@ -101,7 +97,7 @@ skip = [ ".tox" ]
 atomic = true
 multi_line_output = 5
 extra_standard_library = [ "types" ]
-known_third_party = [ "pytest", "_pytest", "django", "pytz", "uritemplate" ]
+known_third_party = [ "pytest", "_pytest", "django", "uritemplate" ]
 known_first_party = [ "rest_framework", "tests" ]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 5.0",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
@@ -30,7 +28,7 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP",
 ]
 dynamic = [ "version" ]
-dependencies = [ "django>=5.0" ]
+dependencies = [ "django>=5.2" ]
 urls.Changelog = "https://www.django-rest-framework.org/community/release-notes/"
 urls.Funding = "https://fund.django-rest-framework.org/topics/funding/"
 urls.Homepage = "https://www.django-rest-framework.org"
@@ -71,8 +69,6 @@ optional = [
   "requests",
   "uritemplate",
 ]
-django50 = [ "django>=5.0,<5.1" ]
-django51 = [ "django>=5.1,<5.2" ]
 django52 = [ "django>=5.2,<6.0" ]
 django60 = [ "django>=6.0,<6.1" ]
 djangomain = [ "django @ https://github.com/django/django/archive/main.tar.gz" ]

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -2,6 +2,7 @@
 The `compat` module provides support for backwards compatibility with older
 versions of Django/Python, and compatibility wrappers around optional packages.
 """
+import django
 from django.views.generic import View
 
 

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -137,10 +137,6 @@ else:
         return False
 
 
-def get_referenced_base_fields_from_q(q):
-    return q.referenced_base_fields
-
-
 if django.VERSION >= (6, 1):
     # `split_header_value` was added in Django 6.2 (backported to 6.1b1+),
     # replacing the `cc_delim_re` regular expression.

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -2,10 +2,6 @@
 The `compat` module provides support for backwards compatibility with older
 versions of Django/Python, and compatibility wrappers around optional packages.
 """
-import django
-from django.db import models
-from django.db.models.constants import LOOKUP_SEP
-from django.db.models.sql.query import Node
 from django.views.generic import View
 
 
@@ -141,52 +137,8 @@ else:
         return False
 
 
-if django.VERSION >= (5, 1):
-    # Django 5.1+: use the stock ip_address_validators function
-    # Note: Before Django 5.1, ip_address_validators returns a tuple containing
-    #       1) the list of validators and 2) the error message. Starting from
-    #       Django 5.1 ip_address_validators only returns the list of validators
-    from django.core.validators import ip_address_validators
-
-    def get_referenced_base_fields_from_q(q):
-        return q.referenced_base_fields
-
-else:
-    # Django <= 5.1: create a compatibility shim for ip_address_validators
-    from django.core.validators import \
-        ip_address_validators as _ip_address_validators
-
-    def ip_address_validators(protocol, unpack_ipv4):
-        return _ip_address_validators(protocol, unpack_ipv4)[0]
-
-    # Django < 5.1: create a compatibility shim for Q.referenced_base_fields
-    # https://github.com/django/django/blob/5.1a1/django/db/models/query_utils.py#L179
-    def _get_paths_from_expression(expr):
-        if isinstance(expr, models.F):
-            yield expr.name
-        elif hasattr(expr, 'flatten'):
-            for child in expr.flatten():
-                if isinstance(child, models.F):
-                    yield child.name
-                elif isinstance(child, models.Q):
-                    yield from _get_children_from_q(child)
-
-    def _get_children_from_q(q):
-        for child in q.children:
-            if isinstance(child, Node):
-                yield from _get_children_from_q(child)
-            elif isinstance(child, tuple):
-                lhs, rhs = child
-                yield lhs
-                if hasattr(rhs, 'resolve_expression'):
-                    yield from _get_paths_from_expression(rhs)
-            elif hasattr(child, 'resolve_expression'):
-                yield from _get_paths_from_expression(child)
-
-    def get_referenced_base_fields_from_q(q):
-        return {
-            child.split(LOOKUP_SEP, 1)[0] for child in _get_children_from_q(q)
-        }
+def get_referenced_base_fields_from_q(q):
+    return q.referenced_base_fields
 
 
 if django.VERSION >= (6, 1):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1172,15 +1172,12 @@ class DateTimeField(Field):
                     return value.astimezone(field_timezone)
                 except OverflowError:
                     self.fail('overflow')
-            try:
-                dt = timezone.make_aware(value, field_timezone)
-                # When the resulting datetime is a ZoneInfo instance, it won't necessarily
-                # throw given an invalid datetime, so we need to specifically check.
-                if not valid_datetime(dt):
-                    self.fail('make_aware', timezone=field_timezone)
-                return dt
-            except Exception as e:
-                raise e
+            dt = timezone.make_aware(value, field_timezone)
+            # When the resulting datetime is a ZoneInfo instance, it won't necessarily
+            # throw given an invalid datetime, so we need to specifically check.
+            if not valid_datetime(dt):
+                self.fail('make_aware', timezone=field_timezone)
+            return dt
         elif (field_timezone is None) and timezone.is_aware(value):
             return timezone.make_naive(value, datetime.timezone.utc)
         return value

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -16,7 +16,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import (
     EmailValidator, MaxLengthValidator, MaxValueValidator, MinLengthValidator,
     MinValueValidator, ProhibitNullCharactersValidator, RegexValidator,
-    URLValidator
+    URLValidator, ip_address_validators
 )
 from django.forms import FilePathField as DjangoFilePathField
 from django.forms import ImageField as DjangoImageField
@@ -30,13 +30,7 @@ from django.utils.formats import localize_input, sanitize_separators
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.translation import gettext_lazy as _
 
-try:
-    import pytz
-except ImportError:
-    pytz = None
-
 from rest_framework import DJANGO_DURATION_FORMAT, ISO_8601
-from rest_framework.compat import ip_address_validators
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.utils import html, humanize_datetime, json, representation
@@ -1186,8 +1180,6 @@ class DateTimeField(Field):
                     self.fail('make_aware', timezone=field_timezone)
                 return dt
             except Exception as e:
-                if pytz and isinstance(e, pytz.exceptions.InvalidTimeError):
-                    self.fail('make_aware', timezone=field_timezone)
                 raise e
         elif (field_timezone is None) and timezone.is_aware(value):
             return timezone.make_naive(value, datetime.timezone.utc)

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -26,9 +26,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework.compat import (
-    get_referenced_base_fields_from_q, postgres_fields
-)
+from rest_framework.compat import postgres_fields
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.fields import get_error_detail
 from rest_framework.settings import api_settings
@@ -1466,7 +1464,7 @@ class ModelSerializer(Serializer):
                     if constraint.condition is None:
                         condition_fields = []
                     else:
-                        condition_fields = list(get_referenced_base_fields_from_q(constraint.condition))
+                        condition_fields = list(constraint.condition.referenced_base_fields)
                     yield (constraint.fields, model._default_manager, condition_fields, constraint.condition)
 
     def get_uniqueness_extra_kwargs(self, field_names, declared_fields, extra_kwargs):

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -1,7 +1,6 @@
 """
 Provides an APIView class that is the base of all views in REST framework.
 """
-from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db import connections, models
@@ -143,8 +142,7 @@ class APIView(View):
 
         # Exempt all DRF views from Django's LoginRequiredMiddleware. Users should set
         # DEFAULT_PERMISSION_CLASSES to 'rest_framework.permissions.IsAuthenticated' instead
-        if DJANGO_VERSION >= (5, 1):
-            view.login_required = False
+        view.login_required = False
 
         # Note: session based authentication is explicitly CSRF validated,
         # all other authentication is CSRF exempt.

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -19,7 +19,6 @@ automatically.
 from functools import update_wrapper
 from inspect import getmembers
 
-from django import VERSION as DJANGO_VERSION
 from django.urls import NoReverseMatch
 from django.utils.decorators import classonlymethod
 from django.views.decorators.csrf import csrf_exempt
@@ -140,8 +139,7 @@ class ViewSetMixin:
 
         # Exempt from Django's LoginRequiredMiddleware. Users should set
         # DEFAULT_PERMISSION_CLASSES to 'rest_framework.permissions.IsAuthenticated' instead
-        if DJANGO_VERSION >= (5, 1):
-            view.login_required = False
+        view.login_required = False
 
         return csrf_exempt(view)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,9 +9,7 @@ from enum import auto
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-import django
 import pytest
-import pytz
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import IntegerChoices, TextChoices
 from django.http import QueryDict
@@ -1713,7 +1711,7 @@ class TestDefaultTZDateTimeField(TestCase):
 
     def assertUTC(self, tzinfo):
         """
-        Check UTC for datetime.timezone, ZoneInfo, and pytz tzinfo instances.
+        Check UTC for datetime.timezone, ZoneInfo.
         """
         assert (
             tzinfo is utc or
@@ -1749,34 +1747,6 @@ class TestCustomTimezoneForDateTimeField(TestCase):
         rendered_date_in_timezone = dt.astimezone(self.kolkata).strftime(self.date_format)
 
         assert rendered_date == rendered_date_in_timezone
-
-
-@pytest.mark.skipif(
-    condition=django.VERSION >= (5,),
-    reason="Django 5.0 has removed pytz; this test should eventually be able to get removed.",
-)
-class TestPytzNaiveDayLightSavingTimeTimeZoneDateTimeField(FieldValues):
-    """
-    Invalid values for `DateTimeField` with datetime in DST shift (non-existing or ambiguous) and timezone with DST.
-    Timezone America/New_York has DST shift from 2017-03-12T02:00:00 to 2017-03-12T03:00:00 and
-     from 2017-11-05T02:00:00 to 2017-11-05T01:00:00 in 2017.
-    """
-    valid_inputs = {}
-    invalid_inputs = {
-        '2017-03-12T02:30:00': ['Invalid datetime for the timezone "America/New_York".'],
-        '2017-11-05T01:30:00': ['Invalid datetime for the timezone "America/New_York".']
-    }
-    outputs = {}
-
-    class MockTimezone(pytz.BaseTzInfo):
-        @staticmethod
-        def localize(value, is_dst):
-            raise pytz.InvalidTimeError()
-
-        def __str__(self):
-            return 'America/New_York'
-
-    field = serializers.DateTimeField(default_timezone=MockTimezone())
 
 
 @patch('rest_framework.utils.timezone.datetime_ambiguous', return_value=True)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,3 @@
-import unittest
-
-import django
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.test import override_settings
@@ -113,7 +110,6 @@ class TestMiddleware(APITestCase):
         assert response.status_code == 200
 
 
-@unittest.skipUnless(django.VERSION >= (5, 1), 'Only for Django 5.1+')
 @override_settings(
     ROOT_URLCONF='tests.test_middleware',
     MIDDLEWARE=(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,5 @@
 import copy
-import unittest
 
-from django import VERSION as DJANGO_VERSION
 from django.test import TestCase
 from django.views.decorators.vary import vary_on_headers
 
@@ -177,7 +175,6 @@ class TestCustomSettings(TestCase):
         assert response.data == {'error': 'SyntaxError'}
 
 
-@unittest.skipUnless(DJANGO_VERSION >= (5, 1), 'Only for Django 5.1+')
 class TestLoginRequiredMiddlewareCompat(TestCase):
     def test_class_based_view_opted_out(self):
         class_based_view = BasicView.as_view()

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1,8 +1,6 @@
-import unittest
 from functools import wraps
 
 import pytest
-from django import VERSION as DJANGO_VERSION
 from django.db import models
 from django.test import TestCase, override_settings
 from django.urls import include, path
@@ -198,7 +196,6 @@ class InitializeViewSetsTestCase(TestCase):
         assert get.view.action == 'list_action'
         assert head.view.action == 'list_action'
 
-    @unittest.skipUnless(DJANGO_VERSION >= (5, 1), 'Only for Django 5.1+')
     def test_login_required_middleware_compat(self):
         view = ActionViewSet.as_view(actions={'get': 'list'})
         assert view.login_required is False

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-       {py310}-{django51,django52}
-       {py311}-{django51,django52}
-       {py312}-{django51,django52,django60,djangomain}
-       {py313}-{django51,django52,django60,djangomain}
+       {py310}-{django52}
+       {py311}-{django52}
+       {py312}-{django52,django60,djangomain}
+       {py313}-{django52,django60,djangomain}
        {py314}-{django52,django60,djangomain}
        base
        dist
@@ -20,8 +20,6 @@ pass_env =
 dependency_groups =
        test
        optional
-       django50: django50
-       django51: django51
        django52: django52
        django60: django60
        djangomain: djangomain

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-       {py310}-{django42,django51,django52}
-       {py311}-{django42,django51,django52}
-       {py312}-{django42,django51,django52,django60,djangomain}
+       {py310}-{django51,django52}
+       {py311}-{django51,django52}
+       {py312}-{django51,django52,django60,djangomain}
        {py313}-{django51,django52,django60,djangomain}
        {py314}-{django52,django60,djangomain}
        base
@@ -20,7 +20,6 @@ pass_env =
 dependency_groups =
        test
        optional
-       django42: django42
        django50: django50
        django51: django51
        django52: django52


### PR DESCRIPTION
*Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description
Django 4.2 will reach end of support on April 30, 2026.

I’m opening this PR early so we can have enough time to plan, communicate, and prepare for removing support.

source: https://endoflife.date/django
