### PR TITLE
Fix #8839: Use USERNAME_FIELD instead of hardcoded 'username' in AuthTokenSerializer

### DIFF
--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -20,13 +20,25 @@ class AuthTokenSerializer(serializers.Serializer):
         read_only=True
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        User = get_user_model()
+        username_field = User.USERNAME_FIELD
+        if username_field != 'username':
+            self.fields[username_field] = self.fields.pop('username')
+            self.fields[username_field].label = _(username_field.capitalize())
+
     def validate(self, attrs):
-        username = attrs.get('username')
+        User = get_user_model()
+        username_field = User.USERNAME_FIELD
+        username = attrs.get(username_field)
         password = attrs.get('password')
 
         if username and password:
-            user = authenticate(request=self.context.get('request'),
-                                username=username, password=password)
+            user = authenticate(
+                request=self.context.get('request'),
+                **{username_field: username, 'password': password}
+            )
 
             # The authenticate call simply returns None for is_active=False
             # users. (Assuming the default ModelBackend authentication
@@ -35,7 +47,7 @@ class AuthTokenSerializer(serializers.Serializer):
                 msg = _('Unable to log in with provided credentials.')
                 raise serializers.ValidationError(msg, code='authorization')
         else:
-            msg = _('Must include "username" and "password".')
+            msg = _(f'Must include "{username_field}" and "password".')
             raise serializers.ValidationError(msg, code='authorization')
 
         attrs['user'] = user

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -24,9 +24,17 @@ class AuthTokenSerializer(serializers.Serializer):
         super().__init__(*args, **kwargs)
         User = get_user_model()
         username_field = User.USERNAME_FIELD
-        if username_field != 'username':
-            self.fields[username_field] = self.fields.pop('username')
-            self.fields[username_field].label = _(username_field.capitalize())
+        if username_field != 'username' and 'username' in self.fields:
+            # Rebuild the fields mapping to preserve the original position
+            # of the login field when renaming it.
+            original_items = list(self.fields.items())
+            new_fields = self.fields.__class__(self)
+            for name, field in original_items:
+                if name == 'username':
+                    name = username_field
+                    field.label = _(username_field.capitalize())
+                new_fields[name] = field
+            self.fields = new_fields
 
     def validate(self, attrs):
         User = get_user_model()


### PR DESCRIPTION
## Summary

Fixes #8839 — `AuthTokenSerializer` hardcoded `username` field, breaking token auth for projects using custom `USERNAME_FIELD` (e.g. email, phone).

## Changes

In `rest_framework/authtoken/serializers.py`:
- Added `__init__` that dynamically renames the field based on `get_user_model().USERNAME_FIELD`
- Updated `validate()` to authenticate using the correct field name
- Error messages now reference the actual field name

## Before/After

```python
# Before: only works with username
POST /api-token-auth/ {"username": "john", "password": "..."}

# After: works with any USERNAME_FIELD
POST /api-token-auth/ {"email": "john@example.com", "password": "..."}
```

## Context

This issue has been open since **January 2023 (3 years)**. Resolved with assistance from [OwlMind](https://owlmind.dev) — an autonomous AI coding agent.