### PR TITLE
Avoid whole project installation in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
   jobs:
     install:
       - pip install --upgrade pip
-      - pip install -e . --group docs
+      - pip install --group docs
 
 # Build documentation with Mkdocs
 mkdocs:


### PR DESCRIPTION
I suppose we don't need install project in the readthedocs server, just docs dependencies were fine i guess.