### PR TITLE
Docs: correct HTTP 401 status text to "Unauthorized"

### DIFF
--- a/docs/api-guide/exceptions.md
+++ b/docs/api-guide/exceptions.md
@@ -157,7 +157,7 @@ By default this exception results in a response with the HTTP status code "400 B
 
 Raised when an incoming request includes incorrect authentication.
 
-By default this exception results in a response with the HTTP status code "401 Unauthenticated", but it may also result in a "403 Forbidden" response, depending on the authentication scheme in use.  See the [authentication documentation][authentication] for more details.
+By default this exception results in a response with the HTTP status code "401 Unauthorized", but it may also result in a "403 Forbidden" response, depending on the authentication scheme in use.  See the [authentication documentation][authentication] for more details.
 
 ### NotAuthenticated
 
@@ -165,7 +165,7 @@ By default this exception results in a response with the HTTP status code "401 U
 
 Raised when an unauthenticated request fails the permission checks.
 
-By default this exception results in a response with the HTTP status code "401 Unauthenticated", but it may also result in a "403 Forbidden" response, depending on the authentication scheme in use.  See the [authentication documentation][authentication] for more details.
+By default this exception results in a response with the HTTP status code "401 Unauthorized", but it may also result in a "403 Forbidden" response, depending on the authentication scheme in use.  See the [authentication documentation][authentication] for more details.
 
 ### PermissionDenied
 


### PR DESCRIPTION

**Repo:** encode/django-rest-framework (⭐ 28000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
The `docs/api-guide/exceptions.md` file described HTTP status code 401 as "401 Unauthenticated" in the API reference entries for `AuthenticationFailed` and `NotAuthenticated`. This patch corrects both occurrences to "401 Unauthorized", matching the official IANA/RFC reason phrase.

## Why
RFC 7235 (and the IANA HTTP status code registry) defines the canonical reason phrase for 401 as "Unauthorized", not "Unauthenticated". DRF itself names the constant `HTTP_401_UNAUTHORIZED` in `rest_framework/status.py`, so the documentation was inconsistent both with the standard and with DRF's own code. Readers comparing the docs against the source or HTTP specs may be confused. No behavioral change; pure documentation fix.

## Testing
Documentation-only change — no code paths affected. Verified the surrounding context still reads correctly and that the "403 Forbidden" branch wording is unchanged. No build/test run required for a markdown edit.

## Risk
Low — two-word docs fix, no code changes.
