### PR TITLE
Fix typo in quote attribution

### DIFF
--- a/docs/api-guide/requests.md
+++ b/docs/api-guide/requests.md
@@ -5,7 +5,7 @@ source:
 
 > If you're doing REST-based web service stuff ... you should ignore request.POST.
 >
-> &mdash; Malcom Tredinnick, [Django developers group][cite]
+> &mdash; Malcolm Tredinnick, [Django developers group][cite]
 
 REST framework's `Request` class extends the standard `HttpRequest`, adding support for REST framework's flexible request parsing and request authentication.
 


### PR DESCRIPTION
Just started off with the docs and noticed the spelling was off in the beginning so I just changed "Malcom" to "Malcolm"
