### PR TITLE
Replace `cc_delim_re usage` with `split_header_value` for Django 6.1+ compatibility

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -189,6 +189,19 @@ else:
         }
 
 
+if django.VERSION >= (6, 1):
+    # `split_header_value` was added in Django 6.2 (backported to 6.1b1+),
+    # replacing the `cc_delim_re` regular expression.
+    # https://github.com/django/django/commit/526b1b414d8e215bf627b5722df12a09346dbf6b
+    from django.utils.http import split_header_value
+else:
+
+    def split_header_value(value, sep=","):
+        for part in value.split(sep):
+            if stripped := part.strip():
+                yield stripped
+
+
 # `separators` argument to `json.dumps()` differs between 2.x and 3.x
 # See: https://bugs.python.org/issue22767
 SHORT_SEPARATORS = (',', ':')

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -7,12 +7,13 @@ from django.core.exceptions import PermissionDenied
 from django.db import connections, models
 from django.http import Http404
 from django.http.response import HttpResponseBase
-from django.utils.cache import cc_delim_re, patch_vary_headers
+from django.utils.cache import patch_vary_headers
 from django.utils.encoding import smart_str
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
 from rest_framework import exceptions, status
+from rest_framework.compat import split_header_value
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.schemas import DefaultSchema
@@ -444,7 +445,7 @@ class APIView(View):
         # Add new vary headers to the response instead of overwriting.
         vary_headers = self.headers.pop('Vary', None)
         if vary_headers is not None:
-            patch_vary_headers(response, cc_delim_re.split(vary_headers))
+            patch_vary_headers(response, list(split_header_value(vary_headers)))
 
         for key, value in self.headers.items():
             response[key] = value

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,6 +3,7 @@ import unittest
 
 from django import VERSION as DJANGO_VERSION
 from django.test import TestCase
+from django.views.decorators.vary import vary_on_headers
 
 from rest_framework import status
 from rest_framework.decorators import api_view
@@ -82,6 +83,42 @@ class ClassBasedViewIntegrationTests(TestCase):
         }
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert sanitise_json_error(response.data) == expected
+
+
+@api_view(['GET'])
+@vary_on_headers('X-Some-Header,X-Other-Header')
+def vary_headers_with_default_view(request):
+    return Response({'method': 'GET'})
+
+
+class CustomVaryHeadersView(APIView):
+    def get(self, request, *args, **kwargs):
+        # These will be merged with the Vary header in the response.
+        self.headers["Vary"] = "  X-Some-Header, X-Other-Header  , Cookie  "
+        return Response(
+            {'method': 'GET'},
+            headers={'Vary': 'X-Foo-Header,X-Bar-Header'},
+        )
+
+
+class VaryHeaderTests(TestCase):
+    def test_default_vary_headers_merge_not_overwrite(self):
+        response = vary_headers_with_default_view(factory.get('/'))
+        vary = response['Vary'].split(', ')
+        # "Accept" added, as JSON and Browsable renderers are enabled by default.
+        assert sorted(vary) == ['Accept', 'X-Other-Header', 'X-Some-Header']
+
+    def test_custom_vary_headers_merge_not_overwrite(self):
+        view = CustomVaryHeadersView.as_view()
+        response = view(factory.get('/'))
+        vary = response['Vary'].split(', ')
+        assert sorted(vary) == [
+            'Cookie',
+            'X-Bar-Header',
+            'X-Foo-Header',
+            'X-Other-Header',
+            'X-Some-Header',
+        ]
 
 
 class FunctionBasedViewIntegrationTests(TestCase):


### PR DESCRIPTION
## Description

`cc_delim_re` is removed in Django ~~6.2+~~ 6.1b1+ (ref: https://github.com/django/django/pull/21438)


DRF breaks with the above change in Django, as seen in Wagtail's CI: https://github.com/wagtail/wagtail/actions/runs/27202033860/job/80308185523


Not sure if this is the best way to go about it, just thought I'd send a patch if this might help. Cheers!