### PR TITLE
Raise clear error for unsupported unique-together list updates

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -171,6 +171,18 @@ class UniqueTogetherValidator:
         return queryset
 
     def __call__(self, attrs, serializer):
+        if (
+            serializer.instance is not None and
+            getattr(serializer.parent, 'many', False) and
+            not hasattr(serializer.instance, 'pk')
+        ):
+            raise RuntimeError(
+                '`UniqueTogetherValidator` cannot determine the current '
+                'instance during a multiple update. Override '
+                '`ListSerializer.run_child_validation()` to set '
+                '`child.instance` before validation.'
+            )
+
         self.enforce_required_fields(attrs, serializer)
         queryset = self.queryset
         queryset = self.filter_queryset(attrs, queryset, serializer)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -248,6 +248,36 @@ class TestUniquenessTogetherValidation(TestCase):
             'position': 1
         }
 
+    def test_many_update_requires_child_instance(self):
+        class ListUpdateSerializer(serializers.ListSerializer):
+            def update(self, instance, validated_data):
+                return instance
+
+        class Serializer(UniquenessTogetherSerializer):
+            id = serializers.IntegerField()
+
+            class Meta(UniquenessTogetherSerializer.Meta):
+                list_serializer_class = ListUpdateSerializer
+
+        serializer = Serializer(
+            instance=UniquenessTogetherModel.objects.all(),
+            data=[{
+                'id': self.instance.pk,
+                'race_name': self.instance.race_name,
+                'position': self.instance.position,
+            }],
+            many=True,
+        )
+        message = (
+            '`UniqueTogetherValidator` cannot determine the current instance '
+            'during a multiple update. Override '
+            '`ListSerializer.run_child_validation()` to set `child.instance` '
+            'before validation.'
+        )
+
+        with pytest.raises(RuntimeError, match=re.escape(message)):
+            serializer.is_valid()
+
     def test_unique_together_is_required(self):
         """
         In a unique together validation, all fields are required.


### PR DESCRIPTION



Fixes #6010

## Summary

This PR prevents an unclear `AttributeError` when using `many=True` with a queryset instance and a `ModelSerializer` that has an auto-generated `UniqueTogetherValidator`.

In this unsupported multiple-update validation path, the child serializer can receive the queryset as its `instance`. `UniqueTogetherValidator` then treats that value as a single model instance and attempts to access `.pk`, causing:

```text
AttributeError: 'QuerySet' object has no attribute 'pk'
````

## Changes

Instead of allowing the internal `AttributeError`, this PR raises a clear `RuntimeError` explaining that `UniqueTogetherValidator` cannot determine the current instance during a multiple update unless the custom `ListSerializer` assigns the correct child instance before validation.

This keeps the validator enabled and avoids changing update validation into create validation.

## Testing

Added regression coverage for the original crash scenario:

* model with a `unique_together` constraint
* `ModelSerializer` with a writable `id`
* custom `ListSerializer.update()`
* `many=True`
* `instance=<queryset>`
* `serializer.is_valid()`

Ran:

```bash
.\.venv\Scripts\python.exe -m pytest tests/test_validators.py -q -p no:cacheprovider
.\.venv\Scripts\python.exe -m pytest tests/test_serializer_lists.py -q -p no:cacheprovider
```

Result:

```text
56 passed
40 passed
```

## Notes

This does not change normal create validation, single-instance update validation, or custom list serializers that correctly assign `child.instance` before running child validation.


