### PR TITLE
Fix duplicate validation errors for GenericIPAddressField with protocol

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -208,7 +208,11 @@ def get_field_kwargs(field_name, model_field):
         if isinstance(model_field, models.GenericIPAddressField):
             validator_kwarg = [
                 validator for validator in validator_kwarg
-                if validator is not validators.validate_ipv46_address
+                if validator not in (
+                    validators.validate_ipv46_address,
+                    validators.validate_ipv4_address,
+                    validators.validate_ipv6_address,
+                )
             ]
         # Our decimal validation is handled in the field code, not validator code.
         if isinstance(model_field, models.DecimalField):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -439,6 +439,42 @@ class TestGenericIPAddressFieldValidation(TestCase):
                          'Unexpected number of validation errors: '
                          '{}'.format(s.errors))
 
+    def test_ip_address_validation_with_protocol_ipv4(self):
+        class IPAddressFieldModel(models.Model):
+            address = models.GenericIPAddressField(protocol='IPv4')
+
+            class Meta:
+                app_label = 'test_model_serializer'
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = IPAddressFieldModel
+                fields = '__all__'
+
+        s = TestSerializer(data={'address': 'not an ip address'})
+        self.assertFalse(s.is_valid())
+        self.assertEqual(1, len(s.errors['address']),
+                         'Unexpected number of validation errors: '
+                         '{}'.format(s.errors))
+
+    def test_ip_address_validation_with_protocol_ipv6(self):
+        class IPAddressFieldModel(models.Model):
+            address = models.GenericIPAddressField(protocol='IPv6')
+
+            class Meta:
+                app_label = 'test_model_serializer'
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = IPAddressFieldModel
+                fields = '__all__'
+
+        s = TestSerializer(data={'address': 'not an ip address'})
+        self.assertFalse(s.is_valid())
+        self.assertEqual(1, len(s.errors['address']),
+                         'Unexpected number of validation errors: '
+                         '{}'.format(s.errors))
+
 
 @pytest.mark.skipif('not postgres_fields')
 class TestPosgresFieldsMapping(TestCase):


### PR DESCRIPTION
## Summary

Fixes #9645
Closes #9647

When a Django model uses `GenericIPAddressField(protocol='IPv4')` or `GenericIPAddressField(protocol='IPv6')`, the serializer generates **duplicate validation errors** for invalid input:

```python
{'address': [
    ErrorDetail(string='Enter a valid IPv4 address.', code='invalid'),
    ErrorDetail(string='Enter a valid IPv4 or IPv6 address.', code='invalid'),
]}
```

## Root Cause

Django adds a protocol-specific validator (`validate_ipv4_address` or `validate_ipv6_address`) to the model field. DRF's `IPAddressField.__init__` also adds the same validator via `ip_address_validators()`. The existing code in `field_mapping.py` only removes `validate_ipv46_address`, leaving the protocol-specific validators in place, causing duplication.

## Fix

In `rest_framework/utils/field_mapping.py`, extend the validator filter to also remove `validate_ipv4_address` and `validate_ipv6_address`:

```python
if isinstance(model_field, models.GenericIPAddressField):
    validator_kwarg = [
        validator for validator in validator_kwarg
        if validator not in (
            validators.validate_ipv46_address,
            validators.validate_ipv4_address,
            validators.validate_ipv6_address,
        )
    ]
```

## Test Plan

Added two new test cases:
- `test_ip_address_validation_with_protocol_ipv4` — verifies only 1 error for invalid input with `protocol='IPv4'`
- `test_ip_address_validation_with_protocol_ipv6` — verifies only 1 error for invalid input with `protocol='IPv6'`

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)