### PR TITLE
Update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-**Please report security issues by emailing security@encode.io**.
+**Please report security issues by emailing security@browniebroke.com**.
 
 The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,11 @@
 # Security Policy
 
+## Supported Versions
+
+Only the latest version of django-rest-framework is supported:
+
+[![PyPI version](https://badge.fury.io/py/djangorestframework.svg)](https://pypi.python.org/pypi/djangorestframework)
+
 ## Reporting a Vulnerability
 
-**Please report security issues by emailing security@browniebroke.com**.
-
-The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
+If you think you have found a vulnerability, and even if you are not sure, please [report it to us in private](https://github.com/encode/django-rest-framework/security/advisories/new). We will review it and get back to you. Please refrain from public discussions of the issue.


### PR DESCRIPTION
## Description

~Update security contact to an email reaching active maintainers.~

Update security policy to replace email by GitHub security advisory. The email currently in the policy doesn't reach any active maintainers AFAIK.

Based django-debug-toolbar: https://github.com/django-commons/django-debug-toolbar/blob/main/SECURITY.md

Raised in https://github.com/encode/django-rest-framework/discussions/9995 