### PR TITLE
fix(validators): guard UniqueConstraint validators against queryset instance in ListSerializer (fixes #9484)

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -8,7 +8,7 @@ object creation, and makes it possible to switch between using the implicit
 """
 from django.core.exceptions import FieldError
 from django.db import DataError
-from django.db.models import Exists
+from django.db.models import Exists, QuerySet
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
@@ -43,6 +43,26 @@ def qs_filter(queryset, **kwargs):
         return queryset.none()
 
 
+def _is_single_instance(instance):
+    """
+    Return True if `instance` is a saved model instance (i.e. not None,
+    not a QuerySet, not a list/tuple), and has a `.pk` attribute.
+
+    When a serializer is used with many=True and a queryset is passed as
+    `instance` (e.g. for ListSerializer bulk-create), the child serializer
+    inherits that queryset as its `.instance`. Calling `.pk` on a QuerySet
+    raises AttributeError, crashing the UniqueConstraint validators.
+
+    This helper guards against that case so validators can treat a queryset
+    or list `instance` as a create operation rather than an update.
+    """
+    if instance is None:
+        return False
+    if isinstance(instance, (QuerySet, list, tuple)):
+        return False
+    return hasattr(instance, 'pk')
+
+
 class UniqueValidator:
     """
     Validator that corresponds to `unique=True` on a model field.
@@ -68,8 +88,12 @@ class UniqueValidator:
         """
         If an instance is being updated, then do not include
         that instance itself as a uniqueness conflict.
+
+        When `instance` is a QuerySet or list (e.g. when the serializer is
+        used inside a ListSerializer with many=True), treat this as a create
+        operation and do not attempt to exclude by pk.
         """
-        if instance is not None:
+        if _is_single_instance(instance):
             return queryset.exclude(pk=instance.pk)
         return queryset
 
@@ -149,7 +173,7 @@ class UniqueTogetherValidator:
 
         # If this is an update, then any unprovided field should
         # have it's value set based on the existing instance attribute.
-        if serializer.instance is not None:
+        if _is_single_instance(serializer.instance):
             for source in sources:
                 if source not in attrs:
                     attrs[source] = getattr(serializer.instance, source)
@@ -165,8 +189,12 @@ class UniqueTogetherValidator:
         """
         If an instance is being updated, then do not include
         that instance itself as a uniqueness conflict.
+
+        When `instance` is a QuerySet or list (e.g. when the serializer is
+        used inside a ListSerializer with many=True), treat this as a create
+        operation and do not attempt to exclude by pk.
         """
-        if instance is not None:
+        if _is_single_instance(instance):
             return queryset.exclude(pk=instance.pk)
         return queryset
 
@@ -180,7 +208,7 @@ class UniqueTogetherValidator:
             serializer.fields[field_name].source for field_name in self.fields
         ]
         # Ignore validation if any field is None
-        if serializer.instance is None:
+        if not _is_single_instance(serializer.instance):
             checked_values = [attrs[field_name] for field_name in checked_names]
         else:
             # Ignore validation if all field values are unchanged
@@ -272,8 +300,12 @@ class BaseUniqueForValidator:
         """
         If an instance is being updated, then do not include
         that instance itself as a uniqueness conflict.
+
+        When `instance` is a QuerySet or list (e.g. when the serializer is
+        used inside a ListSerializer with many=True), treat this as a create
+        operation and do not attempt to exclude by pk.
         """
-        if instance is not None:
+        if _is_single_instance(instance):
             return queryset.exclude(pk=instance.pk)
         return queryset
 


### PR DESCRIPTION
## Problem

Fixes #9484 — **`AttributeError: 'BaseQuerySet' object has no attribute 'pk'`** when using `ModelSerializer` with `many=True` on a model that has a `UniqueConstraint`.

### Root Cause

When `many=True` is passed to a `ModelSerializer`, `many_init` creates a `ListSerializer` wrapping the child serializer. The `instance` kwarg (a `QuerySet`) is forwarded to both the `ListSerializer` and the `child` serializer. When the child's `UniqueTogetherValidator` (or `UniqueValidator`) runs during validation, it calls:

```python
def exclude_current_instance(self, attrs, queryset, instance):
    if instance is not None:
        return queryset.exclude(pk=instance.pk)  # 💥 QuerySet has no .pk
    return queryset
```

Because `instance` is the entire `QuerySet`, not a model instance, `.pk` raises `AttributeError`.

### Reproducer (from #9484)

```python
class Pet(models.Model):
    name = models.CharField(max_length=100)
    animal_type = models.CharField(max_length=100)
    can_fly = models.BooleanField(null=True)

    class Meta:
        constraints = [
            UniqueConstraint(fields=["name", "animal_type"], name="unique_pet")
        ]

class PetSerializer(serializers.ModelSerializer):
    class Meta:
        model = Pet
        fields = ('name', 'animal_type', 'can_fly')

class PetListSerializer(serializers.ListSerializer):
    child = PetSerializer()

    def create(self, validated_data):
        return Pet.objects.bulk_create([Pet(**item) for item in validated_data])

new_data = [
    {"name": "Polly", "animal_type": "Parrot", "can_fly": True},
    {"name": "Penguin", "animal_type": "Bird", "can_fly": False},
]
serializer = PetListSerializer(Pet.objects.all(), data=new_data, many=True)
serializer.is_valid(raise_exception=True)  # AttributeError: 'BaseQuerySet' object has no attribute 'pk'
```

## Fix

Introduces a small private helper `_is_single_instance(instance)` that returns `True` only if `instance` is a non-None, non-QuerySet, non-list object that has a `.pk` attribute. Both `UniqueValidator.exclude_current_instance` and `UniqueTogetherValidator.exclude_current_instance` (and `BaseUniqueForValidator.exclude_current_instance`) now use this helper instead of `if instance is not None`.

This is minimal and fully backward-compatible:
- **Single-instance update**: unchanged — `instance.pk` still used to exclude the current object.
- **Bulk create (ListSerializer + queryset `instance`)**: validators no longer crash; treat each child item as a create.
- **`None` instance (plain create)**: unchanged.

The fix also corrects `UniqueTogetherValidator.filter_queryset` and `__call__` which had the same latent bug of reading from `serializer.instance` without guarding against a queryset type.

## Checklist

- [x] Minimal, targeted fix (one helper, three call sites updated)
- [x] Backward compatible — no API changes
- [x] Fixes crash in `UniqueValidator`, `UniqueTogetherValidator`, and `BaseUniqueForValidator`
- [x] Covers the `filter_queryset` path in `UniqueTogetherValidator` (latent bug: `getattr(serializer.instance, source)` would also crash if instance is a queryset)
