### PR TITLE
Replace pre-commit with prek to fix CI deprecation warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v6.3.0
-        with:
-          python-version: "3.10"
-
-      - uses: pre-commit/action@v3.0.1
+      - uses: j178/prek-action@v2.0.6
 
   tests:
     name: Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Description

The [pre-commit job](https://github.com/encode/django-rest-framework/actions/runs/30157350659/job/89677280297) has a deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

pre-commit/action is not planning on updating:

* https://github.com/pre-commit/action/issues/241
* https://github.com/pre-commit/action/pull/242
* https://github.com/pre-commit/action/pull/244