### PR TITLE
Fix duplicate validation errors for GenericIPAddressField with protocol

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -208,7 +208,11 @@ def get_field_kwargs(field_name, model_field):
         if isinstance(model_field, models.GenericIPAddressField):
             validator_kwarg = [
                 validator for validator in validator_kwarg
-                if validator is not validators.validate_ipv46_address
+                if validator not in (
+                    validators.validate_ipv46_address,
+                    validators.validate_ipv4_address,
+                    validators.validate_ipv6_address,
+                )
             ]
         # Our decimal validation is handled in the field code, not validator code.
         if isinstance(model_field, models.DecimalField):

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -204,15 +204,17 @@ def get_field_kwargs(field_name, model_field):
                 if validator is not validators.validate_slug
             ]
 
-        # IPAddressField do not need to include the 'validate_ipv46_address' argument,
+        # IPAddressField does not need to include the IP address validators,
+        # as it adds its own based on the 'protocol' argument.
         if isinstance(model_field, models.GenericIPAddressField):
+            kwargs['protocol'] = model_field.protocol
             validator_kwarg = [
                 validator for validator in validator_kwarg
-                if validator not in (
+                if validator not in {
                     validators.validate_ipv46_address,
                     validators.validate_ipv4_address,
                     validators.validate_ipv6_address,
-                )
+                }
             ]
         # Our decimal validation is handled in the field code, not validator code.
         if isinstance(model_field, models.DecimalField):

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -210,11 +210,11 @@ def get_field_kwargs(field_name, model_field):
             kwargs['protocol'] = model_field.protocol
             validator_kwarg = [
                 validator for validator in validator_kwarg
-                if validator not in {
+                if validator not in (
                     validators.validate_ipv46_address,
                     validators.validate_ipv4_address,
                     validators.validate_ipv6_address,
-                }
+                )
             ]
         # Our decimal validation is handled in the field code, not validator code.
         if isinstance(model_field, models.DecimalField):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -439,6 +439,42 @@ class TestGenericIPAddressFieldValidation(TestCase):
                          'Unexpected number of validation errors: '
                          '{}'.format(s.errors))
 
+    def test_ip_address_validation_with_protocol_ipv4(self):
+        class IPAddressFieldModel(models.Model):
+            address = models.GenericIPAddressField(protocol='IPv4')
+
+            class Meta:
+                app_label = 'test_model_serializer'
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = IPAddressFieldModel
+                fields = '__all__'
+
+        s = TestSerializer(data={'address': 'not an ip address'})
+        self.assertFalse(s.is_valid())
+        self.assertEqual(1, len(s.errors['address']),
+                         'Unexpected number of validation errors: '
+                         '{}'.format(s.errors))
+
+    def test_ip_address_validation_with_protocol_ipv6(self):
+        class IPAddressFieldModel(models.Model):
+            address = models.GenericIPAddressField(protocol='IPv6')
+
+            class Meta:
+                app_label = 'test_model_serializer'
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = IPAddressFieldModel
+                fields = '__all__'
+
+        s = TestSerializer(data={'address': 'not an ip address'})
+        self.assertFalse(s.is_valid())
+        self.assertEqual(1, len(s.errors['address']),
+                         'Unexpected number of validation errors: '
+                         '{}'.format(s.errors))
+
 
 @pytest.mark.skipif('not postgres_fields')
 class TestPosgresFieldsMapping(TestCase):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -435,9 +435,8 @@ class TestGenericIPAddressFieldValidation(TestCase):
 
         s = TestSerializer(data={'address': 'not an ip address'})
         self.assertFalse(s.is_valid())
-        self.assertEqual(1, len(s.errors['address']),
-                         'Unexpected number of validation errors: '
-                         '{}'.format(s.errors))
+        self.assertEqual(s.errors['address'],
+                         ['Enter a valid IPv4 or IPv6 address.'])
 
     def test_ip_address_validation_with_protocol_ipv4(self):
         class IPv4AddressFieldModel(models.Model):
@@ -457,16 +456,14 @@ class TestGenericIPAddressFieldValidation(TestCase):
 
         s = TestSerializer(data={'address': 'not an ip address'})
         self.assertFalse(s.is_valid())
-        self.assertEqual(1, len(s.errors['address']),
-                         'Unexpected number of validation errors: '
-                         '{}'.format(s.errors))
+        self.assertEqual(s.errors['address'],
+                         ['Enter a valid IPv4 address.'])
 
         # An IPv6 address is not valid for an IPv4-only field.
         s = TestSerializer(data={'address': '2001:db8::1'})
         self.assertFalse(s.is_valid())
-        self.assertEqual(1, len(s.errors['address']),
-                         'Unexpected number of validation errors: '
-                         '{}'.format(s.errors))
+        self.assertEqual(s.errors['address'],
+                         ['Enter a valid IPv4 address.'])
 
         s = TestSerializer(data={'address': '192.0.2.1'})
         self.assertTrue(s.is_valid(), s.errors)
@@ -489,16 +486,14 @@ class TestGenericIPAddressFieldValidation(TestCase):
 
         s = TestSerializer(data={'address': 'not an ip address'})
         self.assertFalse(s.is_valid())
-        self.assertEqual(1, len(s.errors['address']),
-                         'Unexpected number of validation errors: '
-                         '{}'.format(s.errors))
+        self.assertEqual(s.errors['address'],
+                         ['Enter a valid IPv6 address.'])
 
         # An IPv4 address is not valid for an IPv6-only field.
         s = TestSerializer(data={'address': '192.0.2.1'})
         self.assertFalse(s.is_valid())
-        self.assertEqual(1, len(s.errors['address']),
-                         'Unexpected number of validation errors: '
-                         '{}'.format(s.errors))
+        self.assertEqual(s.errors['address'],
+                         ['Enter a valid IPv6 address.'])
 
         s = TestSerializer(data={'address': '2001:db8::1'})
         self.assertTrue(s.is_valid(), s.errors)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -440,40 +440,68 @@ class TestGenericIPAddressFieldValidation(TestCase):
                          '{}'.format(s.errors))
 
     def test_ip_address_validation_with_protocol_ipv4(self):
-        class IPAddressFieldModel(models.Model):
+        class IPv4AddressFieldModel(models.Model):
             address = models.GenericIPAddressField(protocol='IPv4')
 
-            class Meta:
-                app_label = 'test_model_serializer'
-
         class TestSerializer(serializers.ModelSerializer):
             class Meta:
-                model = IPAddressFieldModel
+                model = IPv4AddressFieldModel
                 fields = '__all__'
+
+        expected = dedent("""
+            TestSerializer():
+                id = IntegerField(label='ID', read_only=True)
+                address = IPAddressField(protocol='IPv4')
+        """)
+        self.assertEqual(repr(TestSerializer()), expected)
 
         s = TestSerializer(data={'address': 'not an ip address'})
         self.assertFalse(s.is_valid())
         self.assertEqual(1, len(s.errors['address']),
                          'Unexpected number of validation errors: '
                          '{}'.format(s.errors))
+
+        # An IPv6 address is not valid for an IPv4-only field.
+        s = TestSerializer(data={'address': '2001:db8::1'})
+        self.assertFalse(s.is_valid())
+        self.assertEqual(1, len(s.errors['address']),
+                         'Unexpected number of validation errors: '
+                         '{}'.format(s.errors))
+
+        s = TestSerializer(data={'address': '192.0.2.1'})
+        self.assertTrue(s.is_valid(), s.errors)
 
     def test_ip_address_validation_with_protocol_ipv6(self):
-        class IPAddressFieldModel(models.Model):
+        class IPv6AddressFieldModel(models.Model):
             address = models.GenericIPAddressField(protocol='IPv6')
-
-            class Meta:
-                app_label = 'test_model_serializer'
 
         class TestSerializer(serializers.ModelSerializer):
             class Meta:
-                model = IPAddressFieldModel
+                model = IPv6AddressFieldModel
                 fields = '__all__'
+
+        expected = dedent("""
+            TestSerializer():
+                id = IntegerField(label='ID', read_only=True)
+                address = IPAddressField(protocol='IPv6')
+        """)
+        self.assertEqual(repr(TestSerializer()), expected)
 
         s = TestSerializer(data={'address': 'not an ip address'})
         self.assertFalse(s.is_valid())
         self.assertEqual(1, len(s.errors['address']),
                          'Unexpected number of validation errors: '
                          '{}'.format(s.errors))
+
+        # An IPv4 address is not valid for an IPv6-only field.
+        s = TestSerializer(data={'address': '192.0.2.1'})
+        self.assertFalse(s.is_valid())
+        self.assertEqual(1, len(s.errors['address']),
+                         'Unexpected number of validation errors: '
+                         '{}'.format(s.errors))
+
+        s = TestSerializer(data={'address': '2001:db8::1'})
+        self.assertTrue(s.is_valid(), s.errors)
 
 
 @pytest.mark.skipif('not postgres_fields')

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -16,7 +16,8 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import (
-    MaxValueValidator, MinLengthValidator, MinValueValidator
+    MaxLengthValidator, MaxValueValidator, MinLengthValidator,
+    MinValueValidator
 )
 from django.db import models
 from django.db.models.signals import m2m_changed
@@ -437,6 +438,28 @@ class TestGenericIPAddressFieldValidation(TestCase):
         self.assertFalse(s.is_valid())
         self.assertEqual(s.errors['address'],
                          ['Enter a valid IPv4 or IPv6 address.'])
+
+    def test_ip_address_validation_with_custom_validator(self):
+        class IPAddressFieldModel(models.Model):
+            address = models.GenericIPAddressField(
+                # MaxLengthValidator is an unhashable type
+                validators=[MaxLengthValidator(15)],
+            )
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = IPAddressFieldModel
+                fields = '__all__'
+
+        s = TestSerializer(data={'address': 'not an ip address'})
+        self.assertFalse(s.is_valid())
+        self.assertEqual(
+            s.errors['address'],
+            [
+                'Ensure this value has at most 15 characters (it has 17).',
+                'Enter a valid IPv4 or IPv6 address.',
+            ],
+        )
 
     def test_ip_address_validation_with_protocol_ipv4(self):
         class IPv4AddressFieldModel(models.Model):


### PR DESCRIPTION
## Description

Adding follow up fixes on top of:

- https://github.com/encode/django-rest-framework/pull/9982

Since we can't push them and the contributor has become unresponsive...

When a Django model uses `GenericIPAddressField(protocol='IPv4')` or `GenericIPAddressField(protocol='IPv6')`, the serializer generates **duplicate validation errors** for invalid input:

```python
{'address': [
    ErrorDetail(string='Enter a valid IPv4 address.', code='invalid'),
    ErrorDetail(string='Enter a valid IPv4 or IPv6 address.', code='invalid'),
]}
```

After this fix, only the relevant error message is returned, depending on the accepted protocols by the field.

Fixes #9645
Closes #9647
Closes #9982 
