### PR TITLE
Fix disclosure of GET-protected data in case of validation error with `AdminRenderer`

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -779,8 +779,20 @@ class AdminRenderer(BrowsableAPIRenderer):
             self.error_title = {'POST': 'Create', 'PUT': 'Edit'}.get(request.method, 'Errors')
 
             with override_method(view, request, 'GET') as request:
-                response = view.get(request, *view.args, **view.kwargs)
-            data = response.data
+                # Only simulate the GET request if the current user is
+                # actually permitted to perform it. Otherwise, we could leak
+                # data that GET permissions are meant to protect.
+                try:
+                    view.check_permissions(request)
+                except exceptions.APIException:
+                    # The user isn't permitted to perform the GET request, so
+                    # we must not expose the data it would return. Render only
+                    # the error data instead of the detail/list representation.
+                    if not isinstance(data, dict):
+                        data = {api_settings.NON_FIELD_ERRORS_KEY: data}
+                else:
+                    response = view.get(request, *view.args, **view.kwargs)
+                    data = response.data
 
         template = loader.get_template(self.template)
         context = self.get_context(data, accepted_media_type, renderer_context)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import permissions, serializers, status
 from rest_framework.decorators import action
+from rest_framework.permissions import BasePermission
 from rest_framework.renderers import (
     AdminRenderer, BaseRenderer, BrowsableAPIRenderer, HTMLFormRenderer,
     JSONRenderer, StaticHTMLRenderer
@@ -966,3 +967,100 @@ class AdminRendererTests(TestCase):
         self.assertEqual(results[1]['url'], '/example')
         self.assertEqual(results[2]['url'], None)
         self.assertNotIn('url', results[3])
+
+    def test_invalid_post_request_shows_validation_error(self):
+        factory = APIRequestFactory()
+
+        class DummySerializer(serializers.Serializer):
+            name = serializers.CharField()
+
+            def validate_name(self, value):
+                raise serializers.ValidationError("any-post-is-invalid")
+
+        class DummyView(APIView):
+            renderer_classes = (AdminRenderer,)
+            serializer_class = DummySerializer
+
+            def get(self, request):
+                return Response({'content': 'page-content-on-get'})
+
+            def post(self, request):
+                serializer = DummySerializer(data=request.data)
+                serializer.is_valid(raise_exception=True)
+                return Response(serializer.data)
+
+        view = DummyView.as_view()
+        request = factory.post('/', {'name': 'anything'})
+        response = view(request)
+        response.render()
+
+        # Render normal page
+        self.assertContains(response, 'page-content-on-get', status_code=400)
+        # The validation error is surfaced through the bound error form
+        self.assertContains(response, 'any-post-is-invalid', status_code=400)
+
+    def test_invalid_post_request_missing_get_permissions(self):
+        factory = APIRequestFactory()
+
+        class PostOnlyPermission(BasePermission):
+            def has_permission(self, request, view):
+                return request.method == "POST"
+
+        class DummyView(APIView):
+            renderer_classes = (AdminRenderer,)
+            permission_classes = (PostOnlyPermission,)
+
+            def get(self, request):
+                return Response({'content': 'super-duper-secret'})
+
+            def post(self, request):
+                raise serializers.ValidationError("any-post-is-invalid")
+
+        view = DummyView.as_view()
+        request = factory.post('/')
+        response = view(request)
+        response.render()
+
+        # We should not leak private data
+        self.assertNotContains(response, 'super-duper-secret', status_code=400)
+
+        # We should show the validation error instead
+        self.assertContains(response, 'any-post-is-invalid', status_code=400)
+
+    def test_invalid_post_request_missing_get_permissions_with_serializer(self):
+        factory = APIRequestFactory()
+
+        class PostOnlyPermission(BasePermission):
+            def has_permission(self, request, view):
+                return request.method == "POST"
+
+        class DummySerializer(serializers.Serializer):
+            name = serializers.CharField()
+
+            def validate_name(self, value):
+                raise serializers.ValidationError("any-post-is-invalid")
+
+        class DummyView(APIView):
+            renderer_classes = (AdminRenderer,)
+            permission_classes = (PostOnlyPermission,)
+            serializer_class = DummySerializer
+
+            def get(self, request):
+                return Response({'content': 'super-duper-secret'})
+
+            def post(self, request):
+                serializer = DummySerializer(data=request.data)
+                serializer.is_valid(raise_exception=True)
+                return Response(serializer.data)
+
+        view = DummyView.as_view()
+        request = factory.post('/', {'name': 'anything'})
+        response = view(request)
+        response.render()
+
+        # Even with a serializer (and its bound error form), the denied GET
+        # representation must not leak.
+        self.assertNotContains(response, 'super-duper-secret', status_code=400)
+
+        # We should still show the validation error.
+        self.assertContains(response, 'any-post-is-invalid', status_code=400)


### PR DESCRIPTION
## Description

Backport from main branch

(cherry picked from commit 9e82afc98acfe6fc28c9bf78147f0c5b3f222cb5)
