### PR TITLE
Update Django 6.1 dependency to stable release.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ optional = [
 ]
 django52 = [ "django>=5.2,<6.0" ]
 django60 = [ "django>=6.0,<6.1" ]
-django61 = [ "django>=6.1rc1,<6.2" ]
+django61 = [ "django>=6.1,<6.2" ]
 djangomain = [ "django @ https://github.com/django/django/archive/main.tar.gz" ]
 
 [tool.setuptools]


### PR DESCRIPTION
*Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests).

## Description

Django 6.1 is out 

https://www.djangoproject.com/weblog/2026/aug/05/django-61-released/
