### PR TITLE
Document that `read_only_fields` ignores explicitly declared fields

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -559,6 +559,8 @@ This option should be a list or tuple of field names, and is declared as follows
 
 Model fields which have `editable=False` set, and `AutoField` fields will be set to read-only by default, and do not need to be added to the `read_only_fields` option.
 
+Please keep in mind that, if the field has already been explicitly declared on the serializer class, then the `read_only_fields` option will be ignored. Set `read_only=True` on the field itself instead.
+
 !!! note
     There is a special-case where a read-only field is part of a `unique_together` constraint at the model level. In this case the field is required by the serializer class in order to validate the constraint, but should also not be editable by the user.
 
@@ -591,7 +593,7 @@ This option is a dictionary, mapping field names to a dictionary of keyword argu
             user.save()
             return user
 
-Please keep in mind that, if the field has already been explicitly declared on the serializer class, then the `extra_kwargs` option will be ignored.
+Please keep in mind that, if the field has already been explicitly declared on the serializer class, then the `extra_kwargs` option will be ignored. The same is true of `read_only_fields`, which is implemented using `extra_kwargs`.
 
 ### Relational fields
 

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -559,7 +559,7 @@ This option should be a list or tuple of field names, and is declared as follows
 
 Model fields which have `editable=False` set, and `AutoField` fields will be set to read-only by default, and do not need to be added to the `read_only_fields` option.
 
-Please keep in mind that, if the field has already been explicitly declared on the serializer class, then the `read_only_fields` option will be ignored. Set `read_only=True` on the field itself instead.
+Please keep in mind that, if a field has already been explicitly declared on the serializer class (or a parent class), then the `read_only_fields` option will not apply to that field. Set `read_only=True` on the field itself instead.
 
 !!! note
     There is a special-case where a read-only field is part of a `unique_together` constraint at the model level. In this case the field is required by the serializer class in order to validate the constraint, but should also not be editable by the user.


### PR DESCRIPTION
## Description

refs #3460

`read_only_fields` is implemented by merging into `Meta.extra_kwargs`, and explicitly declared fields skip that path. The extra_kwargs docs already mention the ignore behavior; the `read_only_fields` section did not.

This adds the same warning next to `read_only_fields`, and a one-line cross-reference under extra_kwargs.

Maintainers previously asked for this note rather than changing the API:

> We could take a **Note** to the serialiser docs below the Additional keyword arguments section saying that both these attributes are superseded by an explicit declaration.

https://github.com/encode/django-rest-framework/issues/3460#issuecomment-346766014

I also commented on the issue:

https://github.com/encode/django-rest-framework/issues/3460#issuecomment-5468151790
