### PR TITLE
Clarify that only `required=True` conflicts with default in field docs

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -63,7 +63,7 @@ For example:
 
 When serializing the instance, default will be used if the object attribute or dictionary key is not present in the instance.
 
-Note that setting a `default` value implies that the field is not required. Including both the `default` and `required` keyword arguments is invalid and will raise an error.
+Note that setting a `default` value implies that the field is not required. Combining `default` with `required=True` is invalid and will raise an error. An explicit `required=False` alongside `default` is allowed, but redundant.
 
 ### `allow_null`
 


### PR DESCRIPTION
The fields docs say that "including both the `default` and `required` keyword arguments is invalid and will raise an error". The assertion in `Field.__init__` is `assert not (required and default is not empty)`, so only `required=True` combined with a default raises. An explicit `required=False` passes silently. Reword the note to match the implemented behavior.
