### PR TITLE
Fix ViewInspector sharing view state across views (#6877)

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -3,6 +3,7 @@ inspectors.py   # Per-endpoint view introspection
 
 See schemas.__init__.py for package overview.
 """
+import copy
 import re
 from weakref import WeakKeyDictionary
 
@@ -48,9 +49,15 @@ class ViewInspector:
         return self
 
     def __set__(self, instance, other):
-        self.instance_schemas[instance] = other
         if other is not None:
+            # A single `ViewInspector` instance may be shared by multiple
+            # views, e.g. when `@action(schema=AutoSchema())` is used on a
+            # method defined in a mixin and reused across several ViewSets.
+            # Store an independent copy per view so that `other.view` isn't
+            # silently overwritten by whichever view is set last.
+            other = copy.copy(other)
             other.view = instance
+        self.instance_schemas[instance] = other
 
     @property
     def view(self):

--- a/tests/schemas/test_view_inspector.py
+++ b/tests/schemas/test_view_inspector.py
@@ -1,5 +1,7 @@
+import pytest
 from django.test import TestCase
 
+from rest_framework.compat import uritemplate
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.routers import DefaultRouter
@@ -15,6 +17,7 @@ class TestViewInspectorDescriptor(TestCase):
     `@action(schema=AutoSchema())` on a method defined in a mixin, must
     not leak the `view` it was last accessed with onto other views.
     """
+    @pytest.mark.skipif(uritemplate is None, reason='uritemplate not installed.')
     def test_schema_shared_via_mixin_action_is_not_shared_between_viewsets(self):
         shared_schema = AutoSchema()
 

--- a/tests/schemas/test_view_inspector.py
+++ b/tests/schemas/test_view_inspector.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.routers import DefaultRouter
+from rest_framework.schemas.openapi import AutoSchema, SchemaGenerator
+from rest_framework.serializers import Serializer
+from rest_framework.viewsets import GenericViewSet
+
+
+class TestViewInspectorDescriptor(TestCase):
+    """
+    Regression tests for #6877: a `ViewInspector` (e.g. `AutoSchema`)
+    instance shared across multiple views, such as one assigned via
+    `@action(schema=AutoSchema())` on a method defined in a mixin, must
+    not leak the `view` it was last accessed with onto other views.
+    """
+    def test_schema_shared_via_mixin_action_is_not_shared_between_viewsets(self):
+        shared_schema = AutoSchema()
+
+        class CancelViewSetMixin:
+            @action(methods=['post'], detail=True, schema=shared_schema)
+            def cancel(self, request, pk):
+                return Response()
+
+        class ASerializer(Serializer):
+            pass
+
+        class BSerializer(Serializer):
+            pass
+
+        class ViewSetA(CancelViewSetMixin, GenericViewSet):
+            serializer_class = ASerializer
+
+        class ViewSetB(CancelViewSetMixin, GenericViewSet):
+            serializer_class = BSerializer
+
+        router = DefaultRouter()
+        router.register(r'view-set-a', ViewSetA, basename='viewseta')
+        router.register(r'view-set-b', ViewSetB, basename='viewsetb')
+
+        generator = SchemaGenerator(title='Test', patterns=router.urls)
+        schema = generator.get_schema(request=None, public=True)
+
+        operation_id_a = schema['paths']['/view-set-a/{id}/cancel/']['post']['operationId']
+        operation_id_b = schema['paths']['/view-set-b/{id}/cancel/']['post']['operationId']
+
+        assert operation_id_a == 'cancelA'
+        assert operation_id_b == 'cancelB'


### PR DESCRIPTION
## Problem

Fixes #6877.

A single `ViewInspector` instance (e.g. an `AutoSchema` assigned via `@action(schema=AutoSchema())`) can end up attached to multiple views when the action is defined on a mixin that's reused across several `ViewSet`s, since the decorator only evaluates `AutoSchema()` once, at decoration time.

`ViewInspector.__set__` stored `view` as a plain mutable attribute directly on that shared instance, so each view that touched it during schema generation would overwrite `.view` for every other view sharing the same instance. The result: schema generation collapses onto whichever view happened to set it last, producing duplicate/incorrect `operationId`s, descriptions, and request/response schemas for the other views.

## Reproduction

```python
class CancelViewSetMixin:
    @action(methods=['post'], detail=True, schema=AutoSchema())
    def cancel(self, request, pk):
        return Response()

class ViewSetA(CancelViewSetMixin, GenericViewSet):
    serializer_class = ASerializer

class ViewSetB(CancelViewSetMixin, GenericViewSet):
    serializer_class = BSerializer
```

Before this fix, generating the schema for both viewsets produces the same `operationId` for both `cancel` actions (and DRF itself warns about the resulting duplicate operationId).

## Fix

`__set__` now makes a shallow `copy.copy()` of the schema instance before binding `.view` to it, so each view gets its own independent copy instead of mutating shared state.

## Testing

- Added `tests/schemas/test_view_inspector.py`, reproducing the exact mixin scenario from #6877 and asserting each view gets a distinct `operationId`.
- Full test suite passes (`./runtests.py`).
- `pre-commit` passes.