### PR TITLE
Fix list serializer on unique constraint validator

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -856,6 +856,17 @@ Here's an example of how you might choose to implement multiple updates:
         class Meta:
             list_serializer_class = BookListSerializer
 
+If the child serializer includes uniqueness validators (`UniqueValidator`, `UniqueTogetherValidator`, or the `UniqueForDateValidator` family), they need to know which object each item in the list is updating, so that the object itself is not reported as a uniqueness conflict. By default the child serializer's `.instance` is the whole queryset or list that was passed to the list serializer, so these validators will raise a `RuntimeError` during a multiple update. To support this, override `run_child_validation()` on your `ListSerializer` subclass to set the child's `.instance` for each item before validation:
+
+    class BookListSerializer(serializers.ListSerializer):
+        def run_child_validation(self, data):
+            # `.instance` is `None` for items that do not exist yet.
+            self.child.instance = self.instance.filter(pk=data.get('id')).first()
+            return super().run_child_validation(data)
+
+        def update(self, instance, validated_data):
+            ...
+
 ### Customizing ListSerializer initialization
 
 When a serializer with `many=True` is instantiated, we need to determine which arguments and keyword arguments should be passed to the `.__init__()` method for both the child `Serializer` class, and for the parent `ListSerializer` class.

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -860,8 +860,14 @@ If the child serializer includes uniqueness validators (`UniqueValidator`, `Uniq
 
     class BookListSerializer(serializers.ListSerializer):
         def run_child_validation(self, data):
-            # `.instance` is `None` for items that do not exist yet.
-            self.child.instance = self.instance.filter(pk=data.get('id')).first()
+            # `.instance` stays `None` for items that do not exist yet, and
+            # for malformed items, which child validation will then reject
+            # as usual.
+            self.child.instance = None
+            try:
+                self.child.instance = self.instance.filter(pk=data['id']).first()
+            except (TypeError, KeyError, ValueError):
+                pass
             self.child.initial_data = data
             return super().run_child_validation(data)
 

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -856,7 +856,7 @@ Here's an example of how you might choose to implement multiple updates:
         class Meta:
             list_serializer_class = BookListSerializer
 
-If the child serializer includes uniqueness validators (`UniqueValidator`, `UniqueTogetherValidator`, or the `UniqueForDateValidator` family), they need to know which object each item in the list is updating, so that the object itself is not reported as a uniqueness conflict. By default the child serializer's `.instance` is the whole queryset or list that was passed to the list serializer, so these validators will raise a `RuntimeError` during a multiple update. To support this, override `run_child_validation()` on your `ListSerializer` subclass to set the child's `.instance` for each item before validation:
+If the child serializer includes uniqueness validators (`UniqueValidator`, `UniqueTogetherValidator`, or the `UniqueForDateValidator` family), they need to know which object each item in the list is updating, so that the object itself is not reported as a uniqueness conflict. By default the child serializer's `.instance` is the whole queryset or list that was passed to the list serializer, so these validators will raise a `RuntimeError` during a multiple update. To support this, override `run_child_validation()` on your `ListSerializer` subclass to set the child's `.instance` for each item before validation. For example, if `self.instance` is a queryset:
 
     class BookListSerializer(serializers.ListSerializer):
         def run_child_validation(self, data):

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -856,12 +856,13 @@ Here's an example of how you might choose to implement multiple updates:
         class Meta:
             list_serializer_class = BookListSerializer
 
-If the child serializer includes uniqueness validators (`UniqueValidator`, `UniqueTogetherValidator`, or the `UniqueForDateValidator` family), they need to know which object each item in the list is updating, so that the object itself is not reported as a uniqueness conflict. By default the child serializer's `.instance` is the whole queryset or list that was passed to the list serializer, so these validators will raise a `RuntimeError` during a multiple update. To support this, override `run_child_validation()` on your `ListSerializer` subclass to set the child's `.instance` for each item before validation. For example, if `self.instance` is a queryset:
+If the child serializer includes uniqueness validators (`UniqueValidator`, `UniqueTogetherValidator`, or the `UniqueForDateValidator` family), they need to know which object each item in the list is updating, so that the object itself is not reported as a uniqueness conflict. By default the child serializer's `.instance` is the whole queryset or list that was passed to the list serializer, so these validators will raise a `RuntimeError` during a multiple update. To support this, override `run_child_validation()` on your `ListSerializer` subclass to set the child's `.instance` and `.initial_data` for each item before validation. For example, if `self.instance` is a queryset:
 
     class BookListSerializer(serializers.ListSerializer):
         def run_child_validation(self, data):
             # `.instance` is `None` for items that do not exist yet.
             self.child.instance = self.instance.filter(pk=data.get('id')).first()
+            self.child.initial_data = data
             return super().run_child_validation(data)
 
         def update(self, instance, validated_data):

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -856,7 +856,13 @@ Here's an example of how you might choose to implement multiple updates:
         class Meta:
             list_serializer_class = BookListSerializer
 
-If the child serializer includes uniqueness validators (`UniqueValidator`, `UniqueTogetherValidator`, or the `UniqueForDateValidator` family), they need to know which object each item in the list is updating, so that the object itself is not reported as a uniqueness conflict. By default the child serializer's `.instance` is the whole queryset or list that was passed to the list serializer, so these validators will raise a `RuntimeError` during a multiple update. To support this, override `run_child_validation()` on your `ListSerializer` subclass to set the child's `.instance` and `.initial_data` for each item before validation. For example, if `self.instance` is a queryset:
+If the child serializer includes uniqueness validators (`UniqueValidator`, `UniqueTogetherValidator`, or the
+`UniqueForDateValidator` family), they need to know which object each item in the list is updating, so
+that the object itself is not reported as a uniqueness conflict. By default the child serializer's
+`.instance` is the whole queryset or list that was passed to the list serializer, so these validators will
+raise a `RuntimeError` during a multiple update. To support this, override `run_child_validation()` on
+your `ListSerializer` subclass to set the child's `.instance` and `.initial_data` for each item before
+validation. For example, if `self.instance` is a queryset:
 
     class BookListSerializer(serializers.ListSerializer):
         def run_child_validation(self, data):

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -43,6 +43,29 @@ def qs_filter(queryset, **kwargs):
         return queryset.none()
 
 
+def _check_single_instance(serializer, instance, validator):
+    """
+    Uniqueness validators need a single model instance in order to exclude
+    the object being updated from the uniqueness check.
+
+    When a serializer is used with `many=True` and a queryset or list is
+    passed as the `instance`, the child serializer's `instance` will be that
+    queryset or list, unless `ListSerializer.run_child_validation()` has been
+    overridden to set `child.instance` for each item. Raise a clear error in
+    that case rather than an `AttributeError` when accessing `instance.pk`.
+    """
+    if (
+        instance is not None and
+        getattr(serializer.parent, 'many', False) and
+        not hasattr(instance, 'pk')
+    ):
+        raise RuntimeError(
+            '`%s` cannot determine the current instance during a multiple '
+            'update. Override `ListSerializer.run_child_validation()` to set '
+            '`child.instance` before validation.' % validator.__class__.__name__
+        )
+
+
 class UniqueValidator:
     """
     Validator that corresponds to `unique=True` on a model field.
@@ -78,7 +101,9 @@ class UniqueValidator:
         # same as the serializer field name if `source=<>` is set.
         field_name = serializer_field.source_attrs[-1]
         # Determine the existing instance, if this is an update operation.
-        instance = getattr(serializer_field.parent, 'instance', None)
+        serializer = serializer_field.parent
+        instance = getattr(serializer, 'instance', None)
+        _check_single_instance(serializer, instance, self)
 
         queryset = self.queryset
         queryset = self.filter_queryset(value, queryset, field_name)
@@ -172,18 +197,7 @@ class UniqueTogetherValidator:
         return queryset
 
     def __call__(self, attrs, serializer):
-        if (
-            serializer.instance is not None and
-            getattr(serializer.parent, 'many', False) and
-            not hasattr(serializer.instance, 'pk')
-        ):
-            raise RuntimeError(
-                '`UniqueTogetherValidator` cannot determine the current '
-                'instance during a multiple update. Override '
-                '`ListSerializer.run_child_validation()` to set '
-                '`child.instance` before validation.'
-            )
-
+        _check_single_instance(serializer, serializer.instance, self)
         self.enforce_required_fields(attrs, serializer)
         queryset = self.queryset
         queryset = self.filter_queryset(attrs, queryset, serializer)
@@ -301,6 +315,7 @@ class BaseUniqueForValidator:
         field_name = serializer.fields[self.field].source_attrs[-1]
         date_field_name = serializer.fields[self.date_field].source_attrs[-1]
 
+        _check_single_instance(serializer, serializer.instance, self)
         self.enforce_required_fields(attrs)
         queryset = self.queryset
         queryset = self.filter_queryset(attrs, queryset, field_name, date_field_name)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -183,6 +183,7 @@ class TestUniquenessValidation(TestCase):
         class ListUpdateSerializer(serializers.ListSerializer):
             def run_child_validation(self, data):
                 self.child.instance = self.instance.get(pk=data['id'])
+                self.child.initial_data = data
                 return super().run_child_validation(data)
 
             def update(self, instance, validated_data):
@@ -365,6 +366,7 @@ class TestUniquenessTogetherValidation(TestCase):
         class ListUpdateSerializer(serializers.ListSerializer):
             def run_child_validation(self, data):
                 self.child.instance = self.instance.get(pk=data['id'])
+                self.child.initial_data = data
                 return super().run_child_validation(data)
 
             def update(self, instance, validated_data):
@@ -386,6 +388,47 @@ class TestUniquenessTogetherValidation(TestCase):
             many=True,
         )
         assert serializer.is_valid(), serializer.errors
+
+    def test_many_partial_update_with_child_instance(self):
+        """
+        During a partial multiple update, unprovided field values are read
+        from the instance set by `run_child_validation()`.
+        """
+        class ListUpdateSerializer(serializers.ListSerializer):
+            def run_child_validation(self, data):
+                self.child.instance = self.instance.get(pk=data['id'])
+                self.child.initial_data = data
+                return super().run_child_validation(data)
+
+            def update(self, instance, validated_data):
+                return instance
+
+        class Serializer(UniquenessTogetherSerializer):
+            id = serializers.IntegerField()
+
+            class Meta(UniquenessTogetherSerializer.Meta):
+                list_serializer_class = ListUpdateSerializer
+
+        # An unchanged value is not a conflict with the instance itself.
+        serializer = Serializer(
+            instance=UniquenessTogetherModel.objects.all(),
+            data=[{'id': self.instance.pk, 'position': self.instance.position}],
+            many=True,
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+
+        # A value that collides with a different instance is rejected.
+        serializer = Serializer(
+            instance=UniquenessTogetherModel.objects.all(),
+            data=[{'id': self.instance.pk, 'position': 2}],
+            many=True,
+            partial=True,
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            0: {'non_field_errors': ['The fields race_name, position must make a unique set.']},
+        }
 
     def test_unique_together_is_required(self):
         """
@@ -1075,6 +1118,7 @@ class TestUniquenessForDateValidation(TestCase):
         class ListUpdateSerializer(serializers.ListSerializer):
             def run_child_validation(self, data):
                 self.child.instance = self.instance.get(pk=data['id'])
+                self.child.initial_data = data
                 return super().run_child_validation(data)
 
             def update(self, instance, validated_data):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -137,6 +137,85 @@ class TestUniquenessValidation(TestCase):
         serializer = UniquenessIntegerSerializer(data={'integer': 'abc'})
         assert serializer.is_valid()
 
+    def test_many_create_validates_uniqueness(self):
+        serializer = UniquenessSerializer(
+            data=[{'username': 'existing'}, {'username': 'other'}],
+            many=True,
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            0: {'username': ['uniqueness model with this username already exists.']},
+        }
+
+    def test_many_update_requires_child_instance(self):
+        serializer = UniquenessSerializer(
+            instance=UniquenessModel.objects.all(),
+            data=[{'username': 'existing'}],
+            many=True,
+        )
+        message = (
+            '`UniqueValidator` cannot determine the current instance during '
+            'a multiple update. Override '
+            '`ListSerializer.run_child_validation()` to set `child.instance` '
+            'before validation.'
+        )
+        with pytest.raises(RuntimeError, match=re.escape(message)):
+            serializer.is_valid()
+
+    def test_many_update_with_list_instance_requires_child_instance(self):
+        instances = [self.instance]
+        serializer = UniquenessSerializer(
+            instance=instances,
+            data=[{'username': 'existing'}],
+            many=True,
+        )
+        with pytest.raises(RuntimeError, match='`UniqueValidator` cannot determine'):
+            serializer.is_valid()
+
+    def test_many_update_with_child_instance(self):
+        """
+        Overriding `run_child_validation()` to set `child.instance` allows
+        uniqueness validation to exclude the instance being updated.
+        """
+        existing = self.instance
+        other = UniquenessModel.objects.create(username='other')
+
+        class ListUpdateSerializer(serializers.ListSerializer):
+            def run_child_validation(self, data):
+                self.child.instance = self.instance.get(pk=data['id'])
+                return super().run_child_validation(data)
+
+            def update(self, instance, validated_data):
+                return instance
+
+        class Serializer(UniquenessSerializer):
+            id = serializers.IntegerField()
+
+            class Meta(UniquenessSerializer.Meta):
+                list_serializer_class = ListUpdateSerializer
+
+        # Unchanged values are not a conflict with the instance itself.
+        serializer = Serializer(
+            instance=UniquenessModel.objects.all(),
+            data=[
+                {'id': existing.pk, 'username': 'existing'},
+                {'id': other.pk, 'username': 'renamed'},
+            ],
+            many=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+
+        # A value that conflicts with a different instance is rejected.
+        serializer = Serializer(
+            instance=UniquenessModel.objects.all(),
+            data=[{'id': other.pk, 'username': 'existing'}],
+            many=True,
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            0: {'username': ['uniqueness model with this username already exists.']},
+        }
+
 
 # Tests for `UniqueTogetherValidator`
 # -----------------------------------
@@ -277,6 +356,36 @@ class TestUniquenessTogetherValidation(TestCase):
 
         with pytest.raises(RuntimeError, match=re.escape(message)):
             serializer.is_valid()
+
+    def test_many_update_with_child_instance(self):
+        """
+        Overriding `run_child_validation()` to set `child.instance` allows
+        unique together validation to exclude the instance being updated.
+        """
+        class ListUpdateSerializer(serializers.ListSerializer):
+            def run_child_validation(self, data):
+                self.child.instance = self.instance.get(pk=data['id'])
+                return super().run_child_validation(data)
+
+            def update(self, instance, validated_data):
+                return instance
+
+        class Serializer(UniquenessTogetherSerializer):
+            id = serializers.IntegerField()
+
+            class Meta(UniquenessTogetherSerializer.Meta):
+                list_serializer_class = ListUpdateSerializer
+
+        serializer = Serializer(
+            instance=UniquenessTogetherModel.objects.all(),
+            data=[{
+                'id': self.instance.pk,
+                'race_name': self.instance.race_name,
+                'position': self.instance.position,
+            }],
+            many=True,
+        )
+        assert serializer.is_valid(), serializer.errors
 
     def test_unique_together_is_required(self):
         """
@@ -946,6 +1055,43 @@ class TestUniquenessForDateValidation(TestCase):
             'slug': 'existing',
             'published': datetime.date(2000, 1, 1)
         }
+
+    def test_many_update_requires_child_instance(self):
+        serializer = UniqueForDateSerializer(
+            instance=UniqueForDateModel.objects.all(),
+            data=[{'slug': 'existing', 'published': '2000-01-01'}],
+            many=True,
+        )
+        message = (
+            '`UniqueForDateValidator` cannot determine the current instance '
+            'during a multiple update. Override '
+            '`ListSerializer.run_child_validation()` to set `child.instance` '
+            'before validation.'
+        )
+        with pytest.raises(RuntimeError, match=re.escape(message)):
+            serializer.is_valid()
+
+    def test_many_update_with_child_instance(self):
+        class ListUpdateSerializer(serializers.ListSerializer):
+            def run_child_validation(self, data):
+                self.child.instance = self.instance.get(pk=data['id'])
+                return super().run_child_validation(data)
+
+            def update(self, instance, validated_data):
+                return instance
+
+        class Serializer(UniqueForDateSerializer):
+            id = serializers.IntegerField()
+
+            class Meta(UniqueForDateSerializer.Meta):
+                list_serializer_class = ListUpdateSerializer
+
+        serializer = Serializer(
+            instance=UniqueForDateModel.objects.all(),
+            data=[{'id': self.instance.pk, 'slug': 'existing', 'published': '2000-01-01'}],
+            many=True,
+        )
+        assert serializer.is_valid(), serializer.errors
 
 # Tests for `UniqueForMonthValidator`
 # ----------------------------------


### PR DESCRIPTION
Fixes #9484

## Problem

Since 3.15 (#7438), uniqueness validators run for serializers built from models
using `UniqueConstraint`. When a serializer is used with `many=True` and a
queryset (or list) is passed as `instance` — i.e. a multiple update — these
validators crash with a confusing error:

    AttributeError: 'QuerySet' object has no attribute 'pk'

The root cause: `many_init()` forwards the whole queryset/list to the child
serializer as its `.instance`, and the validators' `exclude_current_instance()`
then calls `instance.pk` on it while trying to exclude the object being updated
from the uniqueness check.

`UniqueTogetherValidator` already raised a descriptive `RuntimeError` for this
case, but `UniqueValidator` and the `UniqueForDateValidator` family still hit
the raw `AttributeError`.

## Changes

- **`rest_framework/validators.py`**: extracted the existing check from
  `UniqueTogetherValidator.__call__` into a shared `_check_single_instance()`
  helper, and applied it to `UniqueValidator` and `BaseUniqueForValidator`
  (covering `UniqueForDate/Month/YearValidator`) as well. All uniqueness
  validators now raise the same clear `RuntimeError` explaining that
  `ListSerializer.run_child_validation()` must be overridden to set
  `child.instance` per item, instead of an opaque `AttributeError`.

- **`docs/api-guide/serializers.md`**: documented the limitation in the
  "multiple updates" section, with an example `run_child_validation()`
  override (for a queryset `instance`) that resolves each item's instance
  by `pk` so unchanged values are not reported as conflicts with themselves.

- **`tests/test_validators.py`**: added tests for all three validator families
  verifying that (a) `many=True` create still validates uniqueness normally,
  (b) a multiple update with a queryset or list `instance` raises the
  descriptive `RuntimeError`, and (c) with the documented
  `run_child_validation()` override, bulk updates validate correctly —
  an item keeping its own value passes, while a value colliding with a
  *different* instance is rejected.

## Notes

- No behavior change for `many=True` create, or for single-instance updates.
- Per the discussion in #9484, validation is not silently skipped and no
  automatic per-item O(N) lookup is introduced; the unsupported case now
  fails loudly with actionable guidance, and the supported path is documented.
