### PR TITLE
Fix broken documentation links and a typo

### DIFF
--- a/docs/community/third-party-packages.md
+++ b/docs/community/third-party-packages.md
@@ -137,7 +137,7 @@ To submit new content, [create a pull request][drf-create-pr].
 
 * [drf-sendables][drf-sendables] - User messages for Django REST Framework
 * [cookiecutter-django-rest][cookiecutter-django-rest] - A cookiecutter template that takes care of the setup and configuration so you can focus on making your REST apis awesome.
-* [djangorestrelationalhyperlink][djangorestrelationalhyperlink] - A hyperlinked serializer that can can be used to alter relationships via hyperlinks, but otherwise like a hyperlink model serializer.
+* [djangorestrelationalhyperlink][djangorestrelationalhyperlink] - A hyperlinked serializer that can be used to alter relationships via hyperlinks, but otherwise like a hyperlink model serializer.
 * [django-rest-framework-proxy][django-rest-framework-proxy] - Proxy to redirect incoming request to another API server.
 * [gaiarestframework][gaiarestframework] - Utils for django-rest-framework
 * [drf-extensions][drf-extensions] - A collection of custom extensions

--- a/docs/community/tutorials-and-resources.md
+++ b/docs/community/tutorials-and-resources.md
@@ -89,7 +89,7 @@ Want your Django REST Framework talk/tutorial/article to be added to our website
 
 [beginners-guide-to-the-django-rest-framework]: https://code.tutsplus.com/tutorials/beginners-guide-to-the-django-rest-framework--cms-19786
 [getting-started-with-django-rest-framework-and-angularjs]: https://blog.kevinastone.com/django-rest-framework-and-angular-js
-[end-to-end-web-app-with-django-rest-framework-angularjs]: https://mourafiq.com/2013/07/01/end-to-end-web-app-with-django-angular-1.html
+[end-to-end-web-app-with-django-rest-framework-angularjs]: https://web.archive.org/web/20220331111339/https://mourafiq.com/2013/07/01/end-to-end-web-app-with-django-angular-1.html
 [start-your-api-django-rest-framework-part-1]: https://www.youtube.com/watch?v=hqo2kk91WpE
 [permissions-authentication-django-rest-framework-part-2]: https://www.youtube.com/watch?v=R3xvUDUZxGU
 [viewsets-and-routers-django-rest-framework-part-3]: https://www.youtube.com/watch?v=2d6w4DGQ4OU
@@ -126,12 +126,12 @@ Want your Django REST Framework talk/tutorial/article to be added to our website
 [drf-image-upload-tutorial-with-angularjs]: https://www.youtube.com/watch?v=hMiNTCIY7dw&list=PLUe5s-xycYk_X0vDjYBmKuIya2a2myF8O
 [blog-api-with-drf]: https://www.youtube.com/watch?v=XMu0T6L2KRQ&list=PLEsfXFp6DpzTOcOVdZF-th7BS_GYGguAS
 [drf-an-intro]: https://realpython.com/blog/python/django-rest-framework-quick-start/
-[drf-tutorial]: https://tests4geeks.com/django-rest-framework-tutorial/
+[drf-tutorial]: https://web.archive.org/web/20190822013217/https://tests4geeks.com/django-rest-framework-tutorial/
 [building-a-restful-api-with-drf]: https://agiliq.com/blog/2014/12/building-a-restful-api-with-django-rest-framework/
 [submit-pr]: https://github.com/encode/django-rest-framework
 [anna-email]: mailto:anna@django-rest-framework.org
 [pycon-us-2017]: https://www.youtube.com/watch?v=Rk6MHZdust4
-[django-rest-react-valentinog]: https://www.valentinog.com/blog/tutorial-api-django-rest-react/
+[django-rest-react-valentinog]: https://web.archive.org/web/20180914054059/https://www.valentinog.com/blog/tutorial-api-django-rest-react/
 [doordash-implementing-rest-apis]: https://doordash.engineering/2013/10/07/implementing-rest-apis-with-embedded-privacy/
 [developing-restful-apis-with-django-rest-framework]: https://testdriven.io/courses/django-rest-framework/
 [django-con-2018]: https://youtu.be/pY-oje5b5Qk?si=AOU6tLi0IL1_pVzq

--- a/docs/topics/browser-enhancements.md
+++ b/docs/topics/browser-enhancements.md
@@ -86,4 +86,4 @@ as well as how to support content types other than form-encoded data.
 [ajax-form]: https://github.com/tomchristie/ajax-form
 [rails]: https://guides.rubyonrails.org/form_helpers.html#how-do-forms-with-put-or-delete-methods-work
 [html5]: https://www.w3.org/TR/html5-diff/#changes-2010-06-24
-[put_delete]: http://amundsen.com/examples/put-delete-forms/
+[put_delete]: https://web.archive.org/web/20230202091223/http://amundsen.com/examples/put-delete-forms/


### PR DESCRIPTION
<!-- *Note*: Before submitting a code change, please review our [contributing guidelines](https://www.django-rest-framework.org/community/contributing/#pull-requests). -->

## Description

Fix broken documentation links and a duplicated word in the docs:

- `docs/community/third-party-packages.md` - "can can be used" -> "can be used"
- `docs/community/tutorials-and-resources.md` - point three dead tutorial links at their Wayback Machine snapshots
- `docs/topics/browser-enhancements.md` - point the dead "Supporting PUT and DELETE with HTML FORMS" link at its Wayback Machine snapshot

## How to verify

```sh
git fetch https://github.com/olitreadwell/django-rest-framework.git fix/docs-links-and-typo
git checkout FETCH_HEAD
mkdocs build
```

The docs build succeeds and each replacement returns an archived snapshot whose page content matches the original topic.